### PR TITLE
hip: fix complex test for ROCm 3.5.0

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -178,9 +178,15 @@ jobs:
 
   build-hip:
     runs-on: ubuntu-latest
-    container: rocm/dev-ubuntu-18.04:3.3
+    #container: rocm/dev-ubuntu-18.04:3.3
+    container: rocm/dev-ubuntu-18.04:3.5
     env:
-      CMAKE_PREFIX_PATH: /opt/rocm/lib/cmake:/opt/rocm-3.5.0/lib/cmake
+      # NOTE: in 3.3 tag the repo only has 3.5, so anything not pre-installed
+      # will be in the 3.5.0 directory. Since only rocthrust/rocprim are
+      # missing and they have no further dependencies, this can be worked
+      # around by simply adding the second cmake dir.
+      #CMAKE_PREFIX_PATH: /opt/rocm/lib/cmake:/opt/rocm-3.5.0/lib/cmake
+      CMAKE_PREFIX_PATH: /opt/rocm/lib/cmake
       CXX: /opt/rocm/bin/hipcc
       HCC_AMDGPU_TARGET: gfx803
       GTEST_VERSION: 1.10.0

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -5,6 +5,7 @@
 #include "device_backend.h"
 #include "device_copy.h"
 
+#include "complex.h"
 #include "gfunction.h"
 #include "gtensor_view.h"
 #include "gview.h"

--- a/tests/test_complex.cxx
+++ b/tests/test_complex.cxx
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <gtensor/complex.h>
 #include <gtensor/gtensor.h>
 
 TEST(complex, complex_ops)


### PR DESCRIPTION
- std::complex works as long as the header is included after
  hip_runtime (imported via device_backend via device_runtime).
  For some reason this didn't come up in 3.3.0.
- switch ci back to 3.5.0 since it's so much faster (and tends
  to be more strict, so it should work for 3.3.0 as well).