### PR TITLE
Pr/add synchronize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13...3.17.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.13...3.18 FATAL_ERROR)
 project(gtensor
         VERSION 0.01
         LANGUAGES CXX

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -296,6 +296,11 @@ struct host_allocator
 
 #ifdef GTENSOR_DEVICE_HOST
 
+void device_synchronize()
+{
+  // no need to synchronize on host
+}
+
 template <typename T>
 struct host_allocator
 {

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -29,32 +29,33 @@ namespace backend
 
 #ifdef GTENSOR_DEVICE_CUDA
 
+void inline device_synchronize()
+{
+  gtGpuCheck(cudaStreamSynchronize(0));
+}
+
 template <typename T>
 void device_copy_hh(const T* src, T* dst, size_t count)
 {
   gtGpuCheck(cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyHostToHost));
-  gtGpuCheck(cudaDeviceSynchronize());
 }
 
 template <typename T>
 void device_copy_dd(const T* src, T* dst, size_t count)
 {
   gtGpuCheck(cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyDeviceToDevice));
-  gtGpuCheck(cudaDeviceSynchronize());
 }
 
 template <typename T>
 void device_copy_dh(const T* src, T* dst, size_t count)
 {
   gtGpuCheck(cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyDeviceToHost));
-  gtGpuCheck(cudaDeviceSynchronize());
 }
 
 template <typename T>
 void device_copy_hd(const T* src, T* dst, size_t count)
 {
   gtGpuCheck(cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyHostToDevice));
-  gtGpuCheck(cudaDeviceSynchronize());
 }
 
 template <typename T>
@@ -105,32 +106,33 @@ struct host_allocator
 
 #elif defined(GTENSOR_DEVICE_HIP)
 
+void inline device_synchronize()
+{
+  gtGpuCheck(hipStreamSynchronize(0));
+}
+
 template <typename T>
 void device_copy_hh(const T* src, T* dst, size_t count)
 {
   gtGpuCheck(hipMemcpy(dst, src, sizeof(T) * count, hipMemcpyHostToHost));
-  gtGpuCheck(hipDeviceSynchronize());
 }
 
 template <typename T>
 void device_copy_dd(const T* src, T* dst, size_t count)
 {
   gtGpuCheck(hipMemcpy(dst, src, sizeof(T) * count, hipMemcpyDeviceToDevice));
-  gtGpuCheck(hipDeviceSynchronize());
 }
 
 template <typename T>
 void device_copy_dh(const T* src, T* dst, size_t count)
 {
   gtGpuCheck(hipMemcpy(dst, src, sizeof(T) * count, hipMemcpyDeviceToHost));
-  gtGpuCheck(hipDeviceSynchronize());
 }
 
 template <typename T>
 void device_copy_hd(const T* src, T* dst, size_t count)
 {
   gtGpuCheck(hipMemcpy(dst, src, sizeof(T) * count, hipMemcpyHostToDevice));
-  gtGpuCheck(hipDeviceSynchronize());
 }
 
 template <typename T>
@@ -180,6 +182,11 @@ struct host_allocator
 };
 
 #elif defined(GTENSOR_DEVICE_SYCL)
+
+void inline device_synchronize()
+{
+  gt::backend::sycl::get_queue().wait();
+}
 
 // TODO: SYCL exception handler
 template <typename T>

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -544,6 +544,14 @@ eval(E&& e)
   return {std::forward<E>(e)};
 }
 
+// ======================================================================
+// synchronize
+
+void inline synchronize()
+{
+  gt::backend::device_synchronize();
+}
+
 } // namespace gt
 
 #endif

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -395,6 +395,26 @@ TEST(gtensor, device_move_assign)
   EXPECT_EQ(adata, bdata);
 }
 
+TEST(gtensor, synchronize)
+{
+  gt::gtensor_device<double, 2> a{{11., 12., 13.}, {21., 22., 23.}};
+  gt::gtensor_device<double, 2> b(a.shape());
+  gt::gtensor_device<double, 2> c(a.shape());
+
+  b = a;
+
+  // it's hard to force an async operation in pure gtensor, i.e. without using
+  // vendor specific API. Not necessary here since the stream (cuda/HIP) or
+  // queue will serialize multiple device copies, but at least we are
+  // exercising the function call.
+  gt::synchronize();
+
+  c = b;
+
+  EXPECT_EQ(c,
+            (gt::gtensor_device<double, 2>{{11., 12., 13.}, {21., 22., 23.}}));
+}
+
 #endif // GTENSOR_HAVE_DEVICE
 
 #if defined(GTENSOR_DEVICE_CUDA) || defined(GTENSOR_DEVICE_HIP)


### PR DESCRIPTION
Adds `gt::synchronize` device call, mapped to `cuda(hip)StreamSynchronize(0)` and `q.wait()` for SYCL. The eventual goal is to be able to write GPU vendor independent code using gtensor without having to do any vendor specific code hacks in client code, and synchronize is a pretty common requirement. In particular this is used in GENE.