### PR TITLE
fix for rocthrust 3.7

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -178,14 +178,9 @@ jobs:
 
   build-hip:
     runs-on: ubuntu-latest
-    #container: rocm/dev-ubuntu-18.04:3.3
-    container: rocm/dev-ubuntu-18.04:3.5
+    #container: rocm/dev-ubuntu-18.04:3.5
+    container: ubuntu:18.04
     env:
-      # NOTE: in 3.3 tag the repo only has 3.5, so anything not pre-installed
-      # will be in the 3.5.0 directory. Since only rocthrust/rocprim are
-      # missing and they have no further dependencies, this can be worked
-      # around by simply adding the second cmake dir.
-      #CMAKE_PREFIX_PATH: /opt/rocm/lib/cmake:/opt/rocm-3.5.0/lib/cmake
       CMAKE_PREFIX_PATH: /opt/rocm/lib/cmake
       CXX: /opt/rocm/bin/hipcc
       HCC_AMDGPU_TARGET: gfx803
@@ -194,12 +189,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: install packages
+    - name: install core packages
+      run: apt-get update -y && apt-get install -y wget git build-essential gnupg clang-9 sudo libnuma-dev
+    - name: setup ROCm repo
       run: |
-        apt-get update
-        apt-get upgrade -y
-        apt-get install -y --reinstall rocm-clang-ocl rocm-cmake rocm-dbgapi rocm-dev rocm-device-libs rocm-opencl rocm-opencl-dev rocm-utils hsa-amd-aqlprofile hsa-ext-rocr-dev hsa-rocr-dev hsakmt-roct hsakmt-roct-dev llvm-amdgpu hip-base hip-rocclr comgr
-        apt-get install -y wget git clang-9 rocthrust
+        wget -q -O - 'https://repo.radeon.com/rocm/rocm.gpg.key' | apt-key add -
+        echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
+        apt-get update -y
+    - name: install ROCm packages
+      run: apt-get install -y rocm-dev rocthrust rocprim
     - name: install cmake
       run: |
         wget -O cmake.sh 'https://github.com/Kitware/CMake/releases/download/v3.17.2/cmake-3.17.2-Linux-x86_64.sh'
@@ -248,7 +246,7 @@ jobs:
       run: apt-get update -y && apt-get install -y wget git build-essential gnupg clang-9
     - name: setup oneapi repos
       run: |
-        wget -O - 'https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB' | apt-key add -
+        wget -q -O - 'https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB' | apt-key add -
         echo "deb https://apt.repos.intel.com/oneapi all main" > /etc/apt/sources.list.d/oneAPI.list
         echo 'deb [trusted=yes arch=amd64] https://repositories.intel.com/graphics/ubuntu bionic-devel main' > /etc/apt/sources.list.d/intel-graphics.list
         apt-get update -y

--- a/include/gtensor/space.h
+++ b/include/gtensor/space.h
@@ -153,7 +153,7 @@ struct host
 
 #ifdef GTENSOR_USE_THRUST
 
-#if THRUST_VERSION <= 100903
+#if GTENSOR_DEVICE_CUDA && THRUST_VERSION <= 100903
 template <typename T>
 using device_allocator =
   caching_allocator<T, thrust::device_malloc_allocator<T>>;


### PR DESCRIPTION
rocthrust has an older verison, but uses the newer API.