### PR TITLE
Pr/sycl fixes

### DIFF
--- a/.github/workflows/sycl.yml
+++ b/.github/workflows/sycl.yml
@@ -8,10 +8,10 @@ jobs:
     #container: intel/oneapi-basekit:devel-ubuntu18.04
     container: ubuntu:18.04
     env:
-      CXX: /opt/intel/inteloneapi/compiler/latest/linux/bin/dpcpp
-      DPCPP_ROOT: /opt/intel/inteloneapi
-      INTEL_LICENSE_FILE: /opt/intel/inteloneapi/compiler/latest/licensing
-      LD_LIBRARY_PATH: /opt/intel/inteloneapi/compiler/latest/linux/lib:/opt/intel/inteloneapi/compiler/latest/linux/lib/x64:/opt/intel/inteloneapi/compiler/latest/linux/compiler/lib/intel64_lin:/opt/intel/inteloneapi/compiler/latest/linux/compiler/lib:/opt/intel/inteloneapi/ccl/2021.1-beta06/lib/cpu_gpu_dpcpp
+      CXX: /opt/intel/oneapi/compiler/latest/linux/bin/dpcpp
+      DPCPP_ROOT: /opt/intel/oneapi
+      INTEL_LICENSE_FILE: /opt/intel/oneapi/compiler/latest/licensing
+      LD_LIBRARY_PATH: /opt/intel/oneapi/compiler/latest/linux/lib:/opt/intel/oneapi/compiler/latest/linux/lib/x64:/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/compiler/latest/linux/compiler/lib:/opt/intel/oneapi/ccl/2021.1-beta09/lib/cpu_gpu_dpcpp
       GTEST_VERSION: 1.10.0
       GTEST_ROOT: ${{ github.workspace }}/googletest
       SYCL_DEVICE_TYPE: host
@@ -26,7 +26,7 @@ jobs:
         echo 'deb [trusted=yes arch=amd64] https://repositories.intel.com/graphics/ubuntu bionic-devel main' > /etc/apt/sources.list.d/intel-graphics.list
         apt-get update -y
     - name: install dpcpp
-      run: apt-get install -y intel-oneapi-dpcpp-compiler clinfo intel-opencl intel-level-zero-gpu level-zero
+      run: apt-get install -y intel-oneapi-dpcpp-cpp-compiler-2021.1-beta09 clinfo intel-opencl intel-level-zero-gpu level-zero
     - uses: actions/checkout@v2
     - name: clinfo
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,11 +131,12 @@ if ("sycl" IN_LIST GTENSOR_BUILD_DEVICES)
 
   if (GTENSOR_DEVICE_SYCL_INTEL
       AND NOT (${GTENSOR_DEVICE_SYCL_SELECTOR} STREQUAL "host"))
-    target_sources(gtensor_sycl INTERFACE
-                   ${DPCPP_LIBDIR}/libsycl-complex-fp64.o
-                   ${DPCPP_LIBDIR}/libsycl-cmath-fp64.o
-                   ${DPCPP_LIBDIR}/libsycl-complex.o
-                   ${DPCPP_LIBDIR}/libsycl-cmath.o)
+    target_link_options(gtensor_sycl INTERFACE -device-math-lib=fp32,fp64)
+    #target_sources(gtensor_sycl INTERFACE
+    #               ${DPCPP_LIBDIR}/libsycl-complex-fp64.o
+    #               ${DPCPP_LIBDIR}/libsycl-cmath-fp64.o
+    #               ${DPCPP_LIBDIR}/libsycl-complex.o
+    #               ${DPCPP_LIBDIR}/libsycl-cmath.o)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,9 @@ set(GTENSOR_BUILD_EXAMPLES OFF CACHE BOOL "Build example programs")
 # SYCL specific configuration
 set(GTENSOR_DEVICE_SYCL_SELECTOR "gpu" CACHE STRING "Use specified sycl device selector ('gpu', 'cpu',  or 'host')")
 set(GTENSOR_DEVICE_SYCL_INTEL ON CACHE BOOL "Using Intel OneAPI SYCL implementation")
-set(DPCPP_ROOT "/opt/intel/inteloneapi" CACHE STRING "Path to DPCPP / Intel OneAPI root")
-set(DPCPP_LIBDIR "${DPCPP_ROOT}/compiler/latest/linux/lib" CACHE STRING "Path to DPCPP compiler lib dir")
+set(DPCPP_ROOT "/opt/intel/inteloneapi/compiler/latest/linux" CACHE STRING "Path to DPCPP / Intel OneAPI root")
+set(DPCPP_LIBDIR "${DPCPP_ROOT}/lib" CACHE STRING "Path to DPCPP compiler lib dir")
+set(DPCPP_INCDIR "${DPCPP_ROOT}/include/sycl" CACHE STRING "Path to DPCPP include dir")
 
 set(GTENSOR_SUPPORTED_DEVICES "host;cuda;hip;sycl")
 set(GTENSOR_TARGETS "")
@@ -112,6 +113,7 @@ if ("sycl" IN_LIST GTENSOR_BUILD_DEVICES)
   add_gtensor_library(sycl)
 
   target_compile_options(gtensor_sycl INTERFACE -fsycl)
+  target_link_options(gtensor_sycl INTERFACE -fsycl)
   target_compile_definitions(gtensor_sycl INTERFACE GTENSOR_HAVE_DEVICE)
   target_compile_definitions(gtensor_sycl INTERFACE GTENSOR_DEVICE_SYCL)
 
@@ -124,6 +126,8 @@ if ("sycl" IN_LIST GTENSOR_BUILD_DEVICES)
   else()
     message(FATAL_ERROR "${PROJECT_NAME}: sycl selector '${GTENSOR_DEVICE_SYCL_SELECTOR}' is not supported")
   endif()
+
+  target_include_directories(gtensor_sycl INTERFACE ${DPCPP_INCDIR})
 
   if (GTENSOR_DEVICE_SYCL_INTEL
       AND NOT (${GTENSOR_DEVICE_SYCL_SELECTOR} STREQUAL "host"))

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Features:
 - easily support both CPU-only and GPU-CPU hybrid code in the same code base,
   with only minimal use of #ifdef.
 - multi-dimensional array slicing similar to numpy
-- GPU support for nVidia via CUDA, AMD via HIP/rocm, and Intel GPUs via SYCL.
+- GPU support for nVidia via CUDA and AMD via HIP/ROCm,
+  and experimental Intel GPU support via SYCL.
 
 ## License
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -33,7 +33,7 @@ else ifeq ($(GTENSOR_DEVICE),hip)
   GTENSOR_DEFINES += -DGTENSOR_HAVE_DEVICE -DNDEBUG
   GTENSOR_INCLUDES += -isystem $(ROCM_PATH)/include -isystem $(ROCM_PATH)/hip/include -isystem $(ROCM_PATH)/rocprim/include -isystem $(ROCM_PATH)/rocthrust/include
 else ifeq ($(GTENSOR_DEVICE),sycl)
-  ONEAPI_PATH ?= /opt/intel/inteloneapi
+  ONEAPI_PATH ?= /opt/intel/oneapi
   GTENSOR_CXX ?= $(ONEAPI_PATH)/compiler/latest/linux/bin/dpcpp
   GTENSOR_OPTIONS += -fsycl
 

--- a/include/gtensor/assign.h
+++ b/include/gtensor/assign.h
@@ -347,8 +347,7 @@ struct assigner<1, space::device>
       using ltype = decltype(k_lhs);
       using rtype = decltype(k_rhs);
       using kname = gt::backend::sycl::Assign1<ltype, rtype>;
-      cgh.parallel_for<kname>(range, [=](sycl::item<1> item)
-      {
+      cgh.parallel_for<kname>(range, [=](sycl::item<1> item) {
         int i = item.get_id();
         k_lhs(i) = k_rhs(i);
       });
@@ -371,8 +370,7 @@ struct assigner<2, space::device>
       using ltype = decltype(k_lhs);
       using rtype = decltype(k_rhs);
       using kname = gt::backend::sycl::Assign2<ltype, rtype>;
-      cgh.parallel_for<kname>(range, [=](sycl::item<2> item)
-      {
+      cgh.parallel_for<kname>(range, [=](sycl::item<2> item) {
         int i = item.get_id(0);
         int j = item.get_id(1);
         k_lhs(i, j) = k_rhs(i, j);
@@ -396,8 +394,7 @@ struct assigner<3, space::device>
       using ltype = decltype(k_lhs);
       using rtype = decltype(k_rhs);
       using kname = gt::backend::sycl::Assign3<ltype, rtype>;
-      cgh.parallel_for<kname>(range, [=](sycl::item<3> item)
-      {
+      cgh.parallel_for<kname>(range, [=](sycl::item<3> item) {
         int i = item.get_id(0);
         int j = item.get_id(1);
         int k = item.get_id(2);

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -404,7 +404,9 @@ struct launch<1, space::device>
     sycl::queue& q = gt::backend::sycl::get_queue();
     auto range = sycl::range<1>(shape[0]);
     auto e = q.submit([&](sycl::handler& cgh) {
-      cgh.parallel_for<class Assign1>(range, [=](sycl::item<1> item) mutable {
+      using kname = gt::backend::sycl::Launch1<decltype(f)>;
+      cgh.parallel_for<kname>(range, [=](sycl::item<1> item)
+      {
         int i = item.get_id(0);
         f(i);
       });
@@ -422,7 +424,9 @@ struct launch<2, space::device>
     sycl::queue& q = gt::backend::sycl::get_queue();
     auto range = sycl::range<2>(shape[0], shape[1]);
     auto e = q.submit([&](sycl::handler& cgh) {
-      cgh.parallel_for<class Assign2>(range, [=](sycl::item<2> item) mutable {
+      using kname = gt::backend::sycl::Launch2<decltype(f)>;
+      cgh.parallel_for<kname>(range, [=](sycl::item<2> item)
+      {
         int i = item.get_id(0);
         int j = item.get_id(1);
         f(i, j);
@@ -441,7 +445,9 @@ struct launch<3, space::device>
     sycl::queue& q = gt::backend::sycl::get_queue();
     auto range = sycl::range<3>(shape[0], shape[1], shape[2]);
     auto e = q.submit([&](sycl::handler& cgh) {
-      cgh.parallel_for<class Assign3>(range, [=](sycl::item<3> item) mutable {
+      using kname = gt::backend::sycl::Launch3<decltype(f)>;
+      cgh.parallel_for<kname>(range, [=](sycl::item<3> item)
+      {
         int i = item.get_id(0);
         int j = item.get_id(1);
         int k = item.get_id(2);
@@ -466,12 +472,13 @@ struct launch<N, space::device>
     auto range =
       sycl::nd_range<1>(sycl::range<1>(size), sycl::range<1>(block_size));
     auto e = q.submit([&](sycl::handler& cgh) {
-      cgh.parallel_for<class AssignN>(range,
-                                      [=](sycl::nd_item<1> item) mutable {
-                                        int i = item.get_global_id(0);
-                                        auto idx = unravel(i, strides);
-                                        index_expression(f, idx);
-                                      });
+      using kname = gt::backend::sycl::LaunchN<decltype(f)>;
+      cgh.parallel_for<kname>(range, [=](sycl::nd_item<1> item)
+      {
+        int i = item.get_global_id(0);
+        auto idx = unravel(i, strides);
+        index_expression(f, idx);
+      });
     });
     e.wait();
   }

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -405,8 +405,7 @@ struct launch<1, space::device>
     auto range = sycl::range<1>(shape[0]);
     auto e = q.submit([&](sycl::handler& cgh) {
       using kname = gt::backend::sycl::Launch1<decltype(f)>;
-      cgh.parallel_for<kname>(range, [=](sycl::item<1> item)
-      {
+      cgh.parallel_for<kname>(range, [=](sycl::item<1> item) {
         int i = item.get_id(0);
         f(i);
       });
@@ -425,8 +424,7 @@ struct launch<2, space::device>
     auto range = sycl::range<2>(shape[0], shape[1]);
     auto e = q.submit([&](sycl::handler& cgh) {
       using kname = gt::backend::sycl::Launch2<decltype(f)>;
-      cgh.parallel_for<kname>(range, [=](sycl::item<2> item)
-      {
+      cgh.parallel_for<kname>(range, [=](sycl::item<2> item) {
         int i = item.get_id(0);
         int j = item.get_id(1);
         f(i, j);
@@ -446,8 +444,7 @@ struct launch<3, space::device>
     auto range = sycl::range<3>(shape[0], shape[1], shape[2]);
     auto e = q.submit([&](sycl::handler& cgh) {
       using kname = gt::backend::sycl::Launch3<decltype(f)>;
-      cgh.parallel_for<kname>(range, [=](sycl::item<3> item)
-      {
+      cgh.parallel_for<kname>(range, [=](sycl::item<3> item) {
         int i = item.get_id(0);
         int j = item.get_id(1);
         int k = item.get_id(2);
@@ -473,8 +470,7 @@ struct launch<N, space::device>
       sycl::nd_range<1>(sycl::range<1>(size), sycl::range<1>(block_size));
     auto e = q.submit([&](sycl::handler& cgh) {
       using kname = gt::backend::sycl::LaunchN<decltype(f)>;
-      cgh.parallel_for<kname>(range, [=](sycl::nd_item<1> item)
-      {
+      cgh.parallel_for<kname>(range, [=](sycl::nd_item<1> item) {
         int i = item.get_global_id(0);
         auto idx = unravel(i, strides);
         index_expression(f, idx);

--- a/include/gtensor/sycl_backend.h
+++ b/include/gtensor/sycl_backend.h
@@ -23,6 +23,24 @@ static inline cl::sycl::queue& get_queue()
   return q;
 }
 
+template <typename E1, typename E2>
+class Assign1;
+template <typename E1, typename E2>
+class Assign2;
+template <typename E1, typename E2>
+class Assign3;
+template <typename E1, typename E2>
+class AssignN;
+
+template <typename F>
+class Launch1;
+template <typename F>
+class Launch2;
+template <typename F>
+class Launch3;
+template <typename F>
+class LaunchN;
+
 } // namespace sycl
 } // namespace backend
 } // namespace gt


### PR DESCRIPTION
Tests and daxpy example run with Intel DPCPP beta09 on CPU, and on GPU on certain Argonne test machines (but unable to get GPU working on my laptop). In any case this should not affect non SYCL backends, and moves things much closer to 2020 provisional spec compliance.

The biggest missing feature here is how to handle explicit kernel launch. This is not exercised well yet by the test cases and the one GPU example.