### PR TITLE
fix: call sync in caching deallocate

### DIFF
--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -533,6 +533,14 @@ inline Pointer device_pointer_cast(Pointer p)
 
 } // end namespace backend
 
+// ======================================================================
+// synchronize
+
+void inline synchronize()
+{
+  gt::backend::device_synchronize();
+}
+
 } // end namespace gt
 
 #endif // GENSOR_DEVICE_BACKEND_H

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -553,14 +553,6 @@ eval(E&& e)
   return {std::forward<E>(e)};
 }
 
-// ======================================================================
-// synchronize
-
-void inline synchronize()
-{
-  gt::backend::device_synchronize();
-}
-
 } // namespace gt
 
 #endif

--- a/include/gtensor/space.h
+++ b/include/gtensor/space.h
@@ -65,9 +65,7 @@ struct caching_allocator : A
 
   void deallocate(pointer p, size_type cnt)
   {
-#ifdef GTENSOR_HAVE_DEVICE
-    cudaCheck(cudaDeviceSynchronize());
-#endif
+    gt::synchronize();
     auto it = allocated_.find(p);
     assert(it != allocated_.end());
     free_.emplace(std::make_pair(it->second, p));

--- a/include/gtensor/space.h
+++ b/include/gtensor/space.h
@@ -65,6 +65,9 @@ struct caching_allocator : A
 
   void deallocate(pointer p, size_type cnt)
   {
+#ifdef GTENSOR_HAVE_DEVICE
+    cudaCheck(cudaDeviceSynchronize());
+#endif
     auto it = allocated_.find(p);
     assert(it != allocated_.end());
     free_.emplace(std::make_pair(it->second, p));


### PR DESCRIPTION
Usually, cudaFree() is synchronizing, and that needs to be done in the
caching allocator, too, since it's not a good idea to free memory while
it's still being used in a concurrently executing kernel.