### PR TITLE
gview: better error on too many args

### DIFF
--- a/include/gtensor/gstrided.h
+++ b/include/gtensor/gstrided.h
@@ -15,7 +15,10 @@ constexpr int view_dimension()
 {
   constexpr std::size_t N_new = detail::count_convertible<gnewaxis, Args...>();
   constexpr std::size_t N_value = detail::count_convertible<int, Args...>();
-  return expr_dimension<E>() - N_value + N_new;
+  constexpr std::size_t N_expr = expr_dimension<E>();
+  constexpr std::size_t N_args = sizeof...(Args);
+  static_assert(N_args <= N_expr + N_new, "too many view args for expression");
+  return N_expr - N_value + N_new;
 }
 
 template <typename E, typename... Args>

--- a/tests/test_view.cxx
+++ b/tests/test_view.cxx
@@ -355,6 +355,22 @@ TEST(gview, gview_owner_operator_parens)
   EXPECT_TRUE((std::is_same<view_gtensor_owner_op_rtype, double&>::value));
 }
 
+TEST(gview, dimension_arg_count)
+{
+  gt::gtensor<double, 2> a = {{11., 12., 13.}, {21., 22., 23.}};
+
+  // less args then dimension - ok, assume others are _all
+  auto a_view = a.view(_s(1, 3));
+  EXPECT_EQ(a_view, (gt::gtensor<double, 2>{{12., 13.}, {22., 23.}}));
+
+  // more args using _newaxis - ok
+  auto a_newaxis = a.view(_s(1, 3), _all, _newaxis);
+  EXPECT_EQ(a_newaxis, (gt::gtensor<double, 3>{{{12., 13.}, {22., 23.}}}));
+
+  // too many args, not new axis - compile error
+  // auto a_view_bad = a.view(_s(1, 3), _all, _all);
+}
+
 #ifdef GTENSOR_HAVE_DEVICE
 
 TEST(gview, device_copy_ctor)


### PR DESCRIPTION
This provides a better error message when doing things like
(gtensor<int, 2>).view(0, 1, _all), while still allowing
newaxis.