### PR TITLE
add operator[] for index by shape

### DIFF
--- a/include/gtensor/assign.h
+++ b/include/gtensor/assign.h
@@ -412,12 +412,11 @@ struct assigner<N, space::device>
   static void run(E1& lhs, const E2& rhs)
   {
     sycl::queue& q = gt::backend::sycl::get_queue();
-    auto size = calc_size(lhs.shape());
-    auto k_lhs = lhs.to_kernel();
-    auto k_rhs = rhs.to_kernel();
     // use linear indexing for simplicity
+    auto size = calc_size(lhs.shape());
+    auto k_lhs = flatten(lhs).to_kernel();
+    auto k_rhs = flatten(rhs).to_kernel();
     auto block_size = std::min(size, BS_LINEAR);
-    auto strides = calc_strides(lhs.shape());
     auto range =
       sycl::nd_range<1>(sycl::range<1>(size), sycl::range<1>(block_size));
     auto e = q.submit([&](sycl::handler& cgh) {
@@ -426,8 +425,7 @@ struct assigner<N, space::device>
       using kname = gt::backend::sycl::AssignN<ltype, rtype>;
       cgh.parallel_for<kname>(range, [=](sycl::nd_item<1> item) {
         int i = item.get_global_id(0);
-        auto idx = unravel(i, strides);
-        index_expression(k_lhs, idx) = index_expression(k_rhs, idx);
+        k_lhs(i) = k_rhs(i);
       });
     });
     e.wait();

--- a/include/gtensor/gcontainer.h
+++ b/include/gtensor/gcontainer.h
@@ -48,6 +48,9 @@ public:
   template <typename... Args>
   GT_INLINE reference operator()(Args&&... args);
 
+  GT_INLINE const_reference operator[](const shape_type& idx) const;
+  GT_INLINE reference operator[](const shape_type& idx);
+
   GT_INLINE const_reference data_access(size_type i) const;
   GT_INLINE reference data_access(size_type i);
 
@@ -56,6 +59,20 @@ public:
 
   GT_INLINE const storage_type& storage() const;
   GT_INLINE storage_type& storage();
+
+private:
+  template <typename S, size_type... I>
+  GT_INLINE const_reference access(std::index_sequence<I...>,
+                                   const S& idx) const
+  {
+    return (*this)(idx[I]...);
+  }
+
+  template <typename S, size_type... I>
+  GT_INLINE reference access(std::index_sequence<I...>, const S& idx)
+  {
+    return (*this)(idx[I]...);
+  }
 };
 
 // ----------------------------------------------------------------------
@@ -105,6 +122,19 @@ template <typename... Args>
 GT_INLINE auto gcontainer<D>::operator()(Args&&... args) -> reference
 {
   return data_access(base_type::index(std::forward<Args>(args)...));
+}
+
+template <typename D>
+GT_INLINE auto gcontainer<D>::operator[](const shape_type& idx) const
+  -> const_reference
+{
+  return access(std::make_index_sequence<shape_type::dimension>(), idx);
+}
+
+template <typename D>
+GT_INLINE auto gcontainer<D>::operator[](const shape_type& idx) -> reference
+{
+  return access(std::make_index_sequence<shape_type::dimension>(), idx);
 }
 
 template <typename D>

--- a/include/gtensor/gcontainer.h
+++ b/include/gtensor/gcontainer.h
@@ -161,6 +161,13 @@ GT_INLINE auto gcontainer<D>::storage() -> storage_type&
   return derived().storage_impl();
 }
 
+// ======================================================================
+// is_gcontainer
+
+template <typename E>
+using is_gcontainer =
+  std::is_base_of<gcontainer<std::decay_t<E>>, std::decay_t<E>>;
+
 } // namespace gt
 
 #endif

--- a/include/gtensor/gfunction.h
+++ b/include/gtensor/gfunction.h
@@ -210,6 +210,7 @@ public:
 
   shape_type shape() const;
   int shape(int i) const;
+  GT_INLINE size_type size() const { return shape().size(); };
 
   template <typename... Args>
   GT_INLINE value_type operator()(Args... args) const;

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -539,17 +539,14 @@ inline auto zeros_like(const expression<E>& _e)
 // eval
 
 template <typename E>
-using is_gcontainer = std::is_base_of<gcontainer<E>, E>;
-
-template <typename E>
-inline std::enable_if_t<is_gcontainer<std::decay_t<E>>::value, E> eval(E&& e)
+inline std::enable_if_t<is_gcontainer<E>::value, E> eval(E&& e)
 {
   return std::forward<E>(e);
 }
 
 template <typename E>
 inline std::enable_if_t<
-  !is_gcontainer<std::decay_t<E>>::value,
+  !is_gcontainer<E>::value,
   gtensor<expr_value_type<E>, expr_dimension<E>(), expr_space_type<E>>>
 eval(E&& e)
 {

--- a/include/gtensor/gtensor_span.h
+++ b/include/gtensor/gtensor_span.h
@@ -2,6 +2,8 @@
 #ifndef GTENSOR_GTENSOR_VIEW_H
 #define GTENSOR_GTENSOR_VIEW_H
 
+#include <type_traits>
+
 #include "device_backend.h"
 #include "span.h"
 
@@ -213,6 +215,17 @@ gtensor_span<T, N, space::device> adapt_device(T* data, const int* shape_data)
   return adapt_device<N, T>(data, {shape_data, N});
 }
 #endif
+
+// ======================================================================
+// is_gtensor_span
+
+template <typename E>
+struct is_gtensor_span : std::false_type
+{};
+
+template <typename T, int N, typename S>
+struct is_gtensor_span<gtensor_span<T, N, S>> : std::true_type
+{};
 
 } // namespace gt
 

--- a/include/gtensor/gtensor_span.h
+++ b/include/gtensor/gtensor_span.h
@@ -96,12 +96,20 @@ public:
   template <typename... Args>
   GT_INLINE reference operator()(Args&&... args) const;
 
+  GT_INLINE reference operator[](const shape_type& idx) const;
+
   GT_INLINE reference data_access(size_type i) const;
 
 private:
   storage_type storage_;
 
   friend class gstrided<self_type>;
+
+  template <typename Idx, size_type... I>
+  GT_INLINE reference access(std::index_sequence<I...>, const Idx& idx) const
+  {
+    return (*this)(idx[I]...);
+  }
 };
 
 // ======================================================================
@@ -166,6 +174,13 @@ GT_INLINE auto gtensor_span<T, N, S>::operator()(Args&&... args) const
   -> reference
 {
   return data_access(base_type::index(std::forward<Args>(args)...));
+}
+
+template <typename T, int N, typename S>
+GT_INLINE auto gtensor_span<T, N, S>::operator[](const shape_type& idx) const
+  -> reference
+{
+  return access(std::make_index_sequence<shape_type::dimension>(), idx);
 }
 
 // ======================================================================

--- a/include/gtensor/gview.h
+++ b/include/gtensor/gview.h
@@ -161,6 +161,9 @@ public:
   template <typename... Args>
   GT_INLINE decltype(auto) operator()(Args&&... args);
 
+  GT_INLINE decltype(auto) operator[](const shape_type& idx) const;
+  GT_INLINE decltype(auto) operator[](const shape_type& idx);
+
   GT_INLINE decltype(auto) data_access(size_type i) const;
   GT_INLINE decltype(auto) data_access(size_type i);
 
@@ -169,6 +172,18 @@ private:
   size_type offset_;
 
   friend class gstrided<self_type>;
+
+  template <typename S, size_type... I>
+  GT_INLINE decltype(auto) access(std::index_sequence<I...>, const S& idx) const
+  {
+    return (*this)(idx[I]...);
+  }
+
+  template <typename S, size_type... I>
+  GT_INLINE decltype(auto) access(std::index_sequence<I...>, const S& idx)
+  {
+    return (*this)(idx[I]...);
+  }
 };
 
 // ======================================================================
@@ -205,6 +220,18 @@ template <typename... Args>
 GT_INLINE decltype(auto) gview<EC, N>::operator()(Args&&... args)
 {
   return data_access(base_type::index(std::forward<Args>(args)...));
+}
+
+template <typename EC, int N>
+GT_INLINE decltype(auto) gview<EC, N>::operator[](const shape_type& idx) const
+{
+  return access(std::make_index_sequence<shape_type::dimension>(), idx);
+}
+
+template <typename EC, int N>
+GT_INLINE decltype(auto) gview<EC, N>::operator[](const shape_type& idx)
+{
+  return access(std::make_index_sequence<shape_type::dimension>(), idx);
 }
 
 template <typename EC, int N>

--- a/include/gtensor/gview.h
+++ b/include/gtensor/gview.h
@@ -439,7 +439,7 @@ inline auto reshape(E&& _e, gt::shape_type<N> shape)
 template <typename E>
 inline auto flatten(E&& e)
 {
-  return reshape<1, E>(std::forward<E>(e), shape(e.size()));
+  return reshape(std::forward<E>(e), shape(e.size()));
 }
 
 // ======================================================================

--- a/include/gtensor/reductions.h
+++ b/include/gtensor/reductions.h
@@ -264,13 +264,13 @@ inline void sum_axis_to(Eout&& out, Ein&& in, int axis)
     flat_out_shape, GT_LAMBDA(int i) {
       auto idx_out = unravel(i, strides_out);
       auto idx_in = insert(idx_out, axis, 0);
-      Tin tmp = index_expression(k_in, idx_in);
+      Tin tmp = k_in[idx_in];
       idx_in[axis]++;
       for (int j = 1; j < reduction_length; j++) {
-        tmp = tmp + index_expression(k_in, idx_in);
+        tmp = tmp + k_in[idx_in];
         idx_in[axis]++;
       }
-      index_expression(k_out, idx_out) = tmp;
+      k_out[idx_out] = tmp;
     });
 }
 

--- a/include/gtensor/sarray.h
+++ b/include/gtensor/sarray.h
@@ -37,6 +37,7 @@ public:
   template <typename... U, std::enable_if_t<sizeof...(U) == N, int> = 0>
   sarray(U... args);
   sarray(const T* p, std::size_t n);
+  sarray(const T data[N]);
 
   template <typename O>
   bool operator==(const O& o) const;
@@ -76,6 +77,12 @@ inline sarray<T, N>::sarray(const T* p, std::size_t n)
 {
   assert(n == N);
   std::copy(p, p + n, data_);
+}
+
+template <typename T, std::size_t N>
+inline sarray<T, N>::sarray(const T data[N])
+{
+  std::copy(data, data + N, data_);
 }
 
 template <typename T, std::size_t N>

--- a/include/gtensor/sarray.h
+++ b/include/gtensor/sarray.h
@@ -29,6 +29,8 @@ template <typename T, std::size_t N>
 class sarray
 {
 public:
+  constexpr static std::size_t dimension = N;
+
   sarray() = default;
 
   // construct from exactly N elements provided

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_gtensor_test(test_launch)
 add_gtensor_test(test_span)
 add_gtensor_test(test_reductions)
 add_gtensor_test(test_sarray)
+add_gtensor_test(test_assign)
 
 if (GTENSOR_ENABLE_CLIB)
   add_executable(test_clib)

--- a/tests/test_assign.cxx
+++ b/tests/test_assign.cxx
@@ -1,0 +1,45 @@
+#include <gtest/gtest.h>
+
+#include "gtensor/gtensor.h"
+
+#include "test_debug.h"
+
+TEST(assign, gtensor_6d)
+{
+  gt::gtensor<int, 6> a(gt::shape(2, 3, 4, 5, 6, 7));
+  gt::gtensor<int, 6> b(a.shape());
+
+  int* adata = a.data();
+
+  for (int i = 0; i < a.size(); i++) {
+    adata[i] = i;
+  }
+
+  EXPECT_NE(a, b);
+  b = a;
+  EXPECT_EQ(a, b);
+}
+
+#ifdef GTENSOR_HAVE_DEVICE
+
+TEST(assign, device_gtensor_6d)
+{
+  gt::gtensor_device<int, 6> a(gt::shape(2, 3, 4, 5, 6, 7));
+  gt::gtensor_device<int, 6> b(a.shape());
+  gt::gtensor<int, 6> h_a(a.shape());
+  gt::gtensor<int, 6> h_b(a.shape());
+
+  int* adata = h_a.data();
+
+  for (int i = 0; i < a.size(); i++) {
+    adata[i] = i;
+  }
+
+  gt::copy(h_a, a);
+  b = a;
+  gt::copy(b, h_b);
+
+  EXPECT_EQ(h_a, h_b);
+}
+
+#endif // GTENSOR_HAVE_DEVICE

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -241,6 +241,25 @@ TEST(gtensor, index_by_shape)
   EXPECT_EQ(a[gt::shape(2, 1)], 32.);
 }
 
+TEST(gtensor, is_expression_types)
+{
+  gt::gtensor<double, 1> a({3, 4});
+
+  EXPECT_TRUE(gt::is_gcontainer<decltype(a)>::value);
+  EXPECT_TRUE(gt::is_expression<decltype(a)>::value);
+  EXPECT_FALSE(gt::is_gtensor_span<decltype(a)>::value);
+
+  auto aview = a.view(gt::all);
+  EXPECT_FALSE(gt::is_gcontainer<decltype(aview)>::value);
+  EXPECT_TRUE(gt::is_expression<decltype(aview)>::value);
+  EXPECT_FALSE(gt::is_gtensor_span<decltype(aview)>::value);
+
+  auto aspan = a.to_kernel();
+  EXPECT_FALSE(gt::is_gcontainer<decltype(aspan)>::value);
+  EXPECT_TRUE(gt::is_expression<decltype(aspan)>::value);
+  EXPECT_TRUE(gt::is_gtensor_span<decltype(aspan)>::value);
+}
+
 #if defined GTENSOR_HAVE_DEVICE
 
 TEST(gtensor, device_assign_gtensor)

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -229,6 +229,18 @@ TEST(gtensor, type_aliases)
     (std::is_same<decltype(h1)::const_pointer, const double*>::value));
 }
 
+TEST(gtensor, index_by_shape)
+{
+  gt::gtensor<double, 2> a{{11., 21., 31.}, {12., 22., 32.}};
+
+  EXPECT_EQ(a[gt::shape(0, 0)], 11.);
+  EXPECT_EQ(a[gt::shape(1, 0)], 21.);
+  EXPECT_EQ(a[gt::shape(2, 0)], 31.);
+  EXPECT_EQ(a[gt::shape(0, 1)], 12.);
+  EXPECT_EQ(a[gt::shape(1, 1)], 22.);
+  EXPECT_EQ(a[gt::shape(2, 1)], 32.);
+}
+
 #if defined GTENSOR_HAVE_DEVICE
 
 TEST(gtensor, device_assign_gtensor)

--- a/tests/test_gtensor_span.cxx
+++ b/tests/test_gtensor_span.cxx
@@ -98,3 +98,16 @@ TEST(gtensor_span, convert_const)
   EXPECT_EQ(a_view.data(), a_view_const2.data());
   EXPECT_EQ(&a_view(N - 1), &a_view_const2(N - 1));
 }
+
+TEST(gtensor_span, index_by_shape)
+{
+  gt::gtensor<double, 2> a{{11., 21., 31.}, {12., 22., 32.}};
+  auto aspan = a.to_kernel();
+
+  EXPECT_EQ(aspan[gt::shape(0, 0)], 11.);
+  EXPECT_EQ(aspan[gt::shape(1, 0)], 21.);
+  EXPECT_EQ(aspan[gt::shape(2, 0)], 31.);
+  EXPECT_EQ(aspan[gt::shape(0, 1)], 12.);
+  EXPECT_EQ(aspan[gt::shape(1, 1)], 22.);
+  EXPECT_EQ(aspan[gt::shape(2, 1)], 32.);
+}

--- a/tests/test_sarray.cxx
+++ b/tests/test_sarray.cxx
@@ -5,6 +5,17 @@
 
 #include "test_debug.h"
 
+TEST(sarray, construct)
+{
+  gt::sarray<int, 4> a(1, 2, 3, 4);
+  gt::sarray<int, 4> b({1, 2, 3, 4});
+  int data[4] = {1, 2, 3, 4};
+  gt::sarray<int, 4> c(&data[0], 4);
+
+  EXPECT_EQ(a, b);
+  EXPECT_EQ(a, c);
+}
+
 template <typename S>
 void test_launch_insert()
 {

--- a/tests/test_view.cxx
+++ b/tests/test_view.cxx
@@ -371,6 +371,19 @@ TEST(gview, dimension_arg_count)
   // auto a_view_bad = a.view(_s(1, 3), _all, _all);
 }
 
+TEST(gview, index_by_shape)
+{
+  gt::gtensor<double, 2> a{{11., 21., 31.}, {12., 22., 32.}};
+  auto aview = a.view(_all, _all);
+
+  EXPECT_EQ(aview[gt::shape(0, 0)], 11.);
+  EXPECT_EQ(aview[gt::shape(1, 0)], 21.);
+  EXPECT_EQ(aview[gt::shape(2, 0)], 31.);
+  EXPECT_EQ(aview[gt::shape(0, 1)], 12.);
+  EXPECT_EQ(aview[gt::shape(1, 1)], 22.);
+  EXPECT_EQ(aview[gt::shape(2, 1)], 32.);
+}
+
 #ifdef GTENSOR_HAVE_DEVICE
 
 TEST(gview, device_copy_ctor)

--- a/tests/test_view.cxx
+++ b/tests/test_view.cxx
@@ -432,6 +432,25 @@ TEST(gview, reshape_reshape)
   EXPECT_EQ(aview2, (gt::gtensor<double, 2>{{11., 21., 31., 12., 22., 32.}}));
 }
 
+TEST(gview, flatten_gtensor)
+{
+  gt::gtensor<double, 2> a{{11., 21., 31.}, {12., 22., 32.}};
+  auto aflat = gt::flatten(a);
+
+  EXPECT_EQ(aflat, (gt::gtensor<double, 1>{11., 21., 31., 12., 22., 32.}));
+}
+
+TEST(gview, flatten_view)
+{
+  gt::gtensor<double, 2> a{{11., 21., 31.}, {12., 22., 32.}};
+
+  auto aview = a.view(_s(1, 3), _all);
+  EXPECT_EQ(aview, (gt::gtensor<double, 2>{{21., 31.}, {22., 32.}}));
+
+  auto aflat = gt::flatten(aview);
+  EXPECT_EQ(aflat, (gt::gtensor<double, 1>{21., 31., 22., 32.}));
+}
+
 #ifdef GTENSOR_HAVE_DEVICE
 
 TEST(gview, device_copy_ctor)

--- a/tests/test_view.cxx
+++ b/tests/test_view.cxx
@@ -384,6 +384,54 @@ TEST(gview, index_by_shape)
   EXPECT_EQ(aview[gt::shape(2, 1)], 32.);
 }
 
+TEST(gview, view_of_view)
+{
+  gt::gtensor<double, 2> a{{11., 21., 31.}, {12., 22., 32.}};
+
+  auto aview = a.view(_s(1, 3), _all);
+  EXPECT_EQ(aview, (gt::gtensor<double, 2>{{21., 31.}, {22., 32.}}));
+
+  auto aview2 = gt::view(aview, _all, _s(1, 2));
+  EXPECT_EQ(aview2, (gt::gtensor<double, 2>{{22., 32.}}));
+
+  auto aview3 = gt::view(aview, _s(1, 2), _all);
+  EXPECT_EQ(aview3, (gt::gtensor<double, 2>{{31.}, {32.}}));
+}
+
+TEST(gview, transpose_view)
+{
+  gt::gtensor<double, 2> a{{11., 21., 31.}, {12., 22., 32.}};
+  auto aview = a.view(_s(1, 2), _all);
+  EXPECT_EQ(aview.shape(), gt::shape(1, 2));
+  EXPECT_EQ(aview, (gt::gtensor<double, 2>{{21.}, {22.}}));
+
+  auto avtranspose = gt::transpose(aview, gt::shape(1, 0));
+  EXPECT_EQ(avtranspose, (gt::gtensor<double, 2>{{21., 22.}}));
+}
+
+TEST(gview, reshape_view)
+{
+  gt::gtensor<double, 2> a{{11., 21., 31.}, {12., 22., 32.}};
+  auto aview = a.view(_s(1, 2), _all);
+  EXPECT_EQ(aview.shape(), gt::shape(1, 2));
+  EXPECT_EQ(aview, (gt::gtensor<double, 2>{{21.}, {22.}}));
+
+  auto aview2 = gt::reshape(aview, gt::shape(2, 1));
+  EXPECT_EQ(aview2, (gt::gtensor<double, 2>{{21., 22.}}));
+}
+
+TEST(gview, reshape_reshape)
+{
+  gt::gtensor<double, 2> a{{11., 21., 31.}, {12., 22., 32.}};
+
+  auto aview = gt::reshape(a, gt::shape(2, 3));
+  EXPECT_EQ(aview,
+            (gt::gtensor<double, 2>{{11., 21.}, {31., 12.}, {22., 32.}}));
+
+  auto aview2 = gt::reshape(aview, gt::shape(6, 1));
+  EXPECT_EQ(aview2, (gt::gtensor<double, 2>{{11., 21., 31., 12., 22., 32.}}));
+}
+
 #ifdef GTENSOR_HAVE_DEVICE
 
 TEST(gview, device_copy_ctor)


### PR DESCRIPTION
mirrors operator() for proper const behavior. Does not support
index by initializer list, this would provide a redundant
syntax for literal indexes and while it looks nice in
tests and examples, it doesn't seem to be necessary.