### PR TITLE
ci: make sycl version independent

### DIFF
--- a/.github/workflows/sycl.yml
+++ b/.github/workflows/sycl.yml
@@ -56,7 +56,7 @@ jobs:
     - name: cmake host build
       run: cmake --build build-sycl-host -v
     - name: cmake host run tests
-      run: cmake --build build-sycl-host -v -t test
+      run: ./run-gtests.sh build-sycl-host
     - name: cmake host run daxpy
       run: ./daxpy
       working-directory: ${{ github.workspace }}/build-sycl-host/examples

--- a/.github/workflows/sycl.yml
+++ b/.github/workflows/sycl.yml
@@ -5,16 +5,16 @@ on: workflow_dispatch
 jobs:
   test-sycl:
     runs-on: ubuntu-latest
-    #container: intel/oneapi-basekit:devel-ubuntu18.04
-    container: ubuntu:18.04
+    container: ubuntu:20.04
     env:
       CXX: /opt/intel/oneapi/compiler/latest/linux/bin/dpcpp
       DPCPP_ROOT: /opt/intel/oneapi
       INTEL_LICENSE_FILE: /opt/intel/oneapi/compiler/latest/licensing
-      LD_LIBRARY_PATH: /opt/intel/oneapi/compiler/latest/linux/lib:/opt/intel/oneapi/compiler/latest/linux/lib/x64:/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/compiler/latest/linux/compiler/lib:/opt/intel/oneapi/ccl/2021.1-beta10/lib/cpu_gpu_dpcpp
+      LD_LIBRARY_PATH: /opt/intel/oneapi/compiler/latest/linux/lib:/opt/intel/oneapi/compiler/latest/linux/lib/x64:/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/compiler/latest/linux/compiler/lib
       GTEST_VERSION: 1.10.0
       GTEST_ROOT: ${{ github.workspace }}/googletest
       SYCL_DEVICE_TYPE: host
+      DEBIAN_FRONTEND: noninteractive
 
     steps:
     - name: install core packages
@@ -26,13 +26,17 @@ jobs:
         echo 'deb [trusted=yes arch=amd64] https://repositories.intel.com/graphics/ubuntu bionic-devel main' > /etc/apt/sources.list.d/intel-graphics.list
         apt-get update -y
     - name: install dpcpp
-      run: apt-get install -y intel-oneapi-dpcpp-cpp-compiler-2021.1-beta10 intel-oneapi-mkl-2021.1-beta10 clinfo intel-opencl intel-level-zero-gpu level-zero
+      run: apt-get install -y intel-oneapi-compiler-dpcpp-cpp intel-oneapi-mkl clinfo intel-opencl-icd intel-level-zero-gpu level-zero
     - uses: actions/checkout@v2
     - name: clinfo
       run: |
         mkdir -p /etc/OpenCL/vendors
         echo "libintelocl.so" > /etc/OpenCL/vendors/intel-cpu.icd
         clinfo
+    - name: sycl-ls
+      run: |
+        /opt/intel/oneapi/compiler/latest/linux/bin/sycl-ls
+        /opt/intel/oneapi/compiler/latest/linux/bin/sycl-ls --verbose
     - name: install cmake
       run: |
         wget -O cmake.sh 'https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4-Linux-x86_64.sh'
@@ -47,26 +51,26 @@ jobs:
         cmake --build build -t install
       env:
         CXX: clang++-9
-    - name: cmake cpu
-      run: cmake -S . -B build-sycl-cpu -DGTENSOR_DEVICE=sycl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGTENSOR_BUILD_EXAMPLES=ON -DGTENSOR_DEVICE_SYCL_SELECTOR=host -DGTEST_ROOT=${{ env.GTEST_ROOT }} -DGTENSOR_BUILD_CLIB=ON -DGTENSOR_BUILD_BLAS=ON -DGTENSOR_BUILD_FFT=ON
-    - name: cmake cpu build
-      run: cmake --build build-sycl-cpu -v
-    - name: cmake cpu run tests
-      run: cmake --build build-sycl-cpu -v -t test
-    - name: cmake cpu run daxpy
+    - name: cmake host
+      run: cmake -S . -B build-sycl-host -DGTENSOR_DEVICE=sycl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGTENSOR_BUILD_EXAMPLES=ON -DGTENSOR_DEVICE_SYCL_SELECTOR=host -DGTEST_ROOT=${{ env.GTEST_ROOT }} -DGTENSOR_ENABLE_CLIB=ON -DGTENSOR_ENABLE_BLAS=OFF -DGTENSOR_ENABLE_FFT=OFF -DGTENSOR_TEST_DEBUG=ON
+    - name: cmake host build
+      run: cmake --build build-sycl-host -v
+    - name: cmake host run tests
+      run: cmake --build build-sycl-host -v -t test
+    - name: cmake host run daxpy
       run: ./daxpy
-      working-directory: ${{ github.workspace }}/build-sycl-cpu/examples
-    - name: cmake cpu run stencil1d
+      working-directory: ${{ github.workspace }}/build-sycl-host/examples
+    - name: cmake host run stencil1d
       run: ./stencil1d
-      working-directory: ${{ github.workspace }}/build-sycl-cpu/examples
-    - name: cmake cpu run mult_table
+      working-directory: ${{ github.workspace }}/build-sycl-host/examples
+    - name: cmake host run mult_table
       run: ./mult_table
-      working-directory: ${{ github.workspace }}/build-sycl-cpu/examples
+      working-directory: ${{ github.workspace }}/build-sycl-host/examples
     - name: GNU make setup gtensor subdir
       run: mkdir -p external/gtensor &&  cp -R ../include external/gtensor/
       working-directory: ${{ github.workspace }}/examples
     - name: GNU make build
-      run: make GTENSOR_DEVICE=sycl GTENSOR_DEVICE_SYCL_SELECTOR=cpu
+      run: make GTENSOR_DEVICE=sycl GTENSOR_DEVICE_SYCL_SELECTOR=host
       working-directory: ${{ github.workspace }}/examples
     - name: GNU make run daxpy
       run: ./daxpy

--- a/include/gtensor/reductions.h
+++ b/include/gtensor/reductions.h
@@ -49,6 +49,12 @@ inline auto min(const Container& a)
 
 #elif defined(GTENSOR_DEVICE_SYCL)
 
+#ifdef GTENSOR_DEVICE_SYCL_HOST
+#define SYCL_REDUCTION_WORK_GROUP_SIZE 16
+#else
+#define SYCL_REDUCTION_WORK_GROUP_SIZE 128
+#endif
+
 template <typename Container,
           typename = std::enable_if_t<
             has_data_method_v<Container> &&
@@ -61,8 +67,8 @@ inline auto sum(const Container& a)
   T sum_result = 0;
   sycl::buffer<T> sum_buf{&sum_result, 1};
   {
-    sycl::nd_range<1> range(a.size(), 128);
-    if (a.size() <= 128) {
+    sycl::nd_range<1> range(a.size(), SYCL_REDUCTION_WORK_GROUP_SIZE);
+    if (a.size() <= SYCL_REDUCTION_WORK_GROUP_SIZE) {
       range = sycl::nd_range<1>(a.size(), a.size());
     }
     auto data = a.data();
@@ -94,8 +100,8 @@ inline auto max(const Container& a)
   T max_result = 0;
   sycl::buffer<T> max_buf{&max_result, 1};
   {
-    sycl::nd_range<1> range(a.size(), 128);
-    if (a.size() <= 128) {
+    sycl::nd_range<1> range(a.size(), SYCL_REDUCTION_WORK_GROUP_SIZE);
+    if (a.size() <= SYCL_REDUCTION_WORK_GROUP_SIZE) {
       range = sycl::nd_range<1>(a.size(), a.size());
     }
     auto data = a.data();
@@ -127,8 +133,8 @@ inline auto min(const Container& a)
   T min_result;
   sycl::buffer<T> min_buf{&min_result, 1};
   {
-    sycl::nd_range<1> range(a.size(), 128);
-    if (a.size() <= 128) {
+    sycl::nd_range<1> range(a.size(), SYCL_REDUCTION_WORK_GROUP_SIZE);
+    if (a.size() <= SYCL_REDUCTION_WORK_GROUP_SIZE) {
       range = sycl::nd_range<1>(a.size(), a.size());
     }
     auto data = a.data();

--- a/run-gtests.sh
+++ b/run-gtests.sh
@@ -2,6 +2,8 @@
 
 build_dir=${1:-.}
 
+exit_code=0
+
 for f in "$build_dir"/tests/test_*; do
     if [ -x "$f" ]; then
         test_dir=$(dirname "$f")
@@ -12,6 +14,9 @@ for f in "$build_dir"/tests/test_*; do
         echo $test_name $result
         if [ $result -ne 0 ]; then
           cat $test_log
+          exit_code=$result
         fi
     fi
 done
+
+exit $exit_code

--- a/run-gtests.sh
+++ b/run-gtests.sh
@@ -6,8 +6,12 @@ for f in "$build_dir"/tests/test_*; do
     if [ -x "$f" ]; then
         test_dir=$(dirname "$f")
         test_name=$(basename "$f")
-        $f >$test_dir/$test_name.log 2>&1
+        test_log=$test_dir/$test_name.log
+        $f >$test_log 2>&1
         result=$?
         echo $test_name $result
+        if [ $result -ne 0 ]; then
+          cat $test_log
+        fi
     fi
 done


### PR DESCRIPTION
Installs latest version, which has it's own drawbacks but the
repo does not keep older versions anyway. Note that this is not
as robust as it could be, because package names could still
change. Installing all of basekit would be more robust as the
documented way of installing, but it would slow the build down
a lot.