### PR TITLE
Better performance for small 1D assignments and launches with CUDA

### DIFF
--- a/include/gtensor/assign.h
+++ b/include/gtensor/assign.h
@@ -221,7 +221,10 @@ struct assigner<1, space::device>
   static void run(E1& lhs, const E2& rhs)
   {
     // printf("assigner<1, device>\n");
-    const int BS_1D = 256;
+    int BS_1D = 256;
+    if (lhs.shape(0) < BS_1D) {
+      BS_1D = 32;
+    }
     dim3 numThreads(BS_1D);
     dim3 numBlocks((lhs.shape(0) + BS_1D - 1) / BS_1D);
 

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -320,7 +320,10 @@ struct launch<1, space::device>
   template <typename F>
   static void run(const gt::shape_type<1>& shape, F&& f)
   {
-    const int BS_1D = 256;
+    int BS_1D = 256;
+    if (shape[0] < BS_1D) {
+      BS_1D = 32;
+    }
     dim3 numThreads(BS_1D);
     dim3 numBlocks((shape[0] + BS_1D - 1) / BS_1D);
 


### PR DESCRIPTION
If the linear size of a 1D assign or launch is less than the default blocksize BS_1D of 256, use a smaller blocksize to make it possible to have several blocks. This can increase performance a bit due to better latency hiding.