### PR TITLE
little bits and pieces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build*/
+.vscode/

--- a/include/gtensor/gstrided.h
+++ b/include/gtensor/gstrided.h
@@ -51,7 +51,7 @@ public:
   using base_type::derived;
 
   gstrided() = default;
-  gstrided(const shape_type& shape, const strides_type& strides);
+  GT_INLINE gstrided(const shape_type& shape, const strides_type& strides);
 
   GT_INLINE int shape(int i) const;
   GT_INLINE const shape_type& shape() const;
@@ -77,8 +77,8 @@ protected:
 // gstrided implementation
 
 template <typename D>
-inline gstrided<D>::gstrided(const shape_type& shape,
-                             const strides_type& strides)
+GT_INLINE gstrided<D>::gstrided(const shape_type& shape,
+                                const strides_type& strides)
   : shape_(shape), strides_(strides)
 {}
 

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -324,6 +324,66 @@ struct launch<3, space::host>
   }
 };
 
+template <>
+struct launch<4, space::host>
+{
+  template <typename F>
+  static void run(const gt::shape_type<4>& shape, F&& f)
+  {
+    for (int l = 0; l < shape[3]; l++) {
+      for (int k = 0; k < shape[2]; k++) {
+        for (int j = 0; j < shape[1]; j++) {
+          for (int i = 0; i < shape[0]; i++) {
+            std::forward<F>(f)(i, j, k, l);
+          }
+        }
+      }
+    }
+  }
+};
+
+template <>
+struct launch<5, space::host>
+{
+  template <typename F>
+  static void run(const gt::shape_type<5>& shape, F&& f)
+  {
+    for (int m = 0; m < shape[4]; m++) {
+      for (int l = 0; l < shape[3]; l++) {
+        for (int k = 0; k < shape[2]; k++) {
+          for (int j = 0; j < shape[1]; j++) {
+            for (int i = 0; i < shape[0]; i++) {
+              std::forward<F>(f)(i, j, k, l, m);
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+template <>
+struct launch<6, space::host>
+{
+  template <typename F>
+  static void run(const gt::shape_type<6>& shape, F&& f)
+  {
+    for (int n = 0; n < shape[5]; n++) {
+      for (int m = 0; m < shape[4]; m++) {
+        for (int l = 0; l < shape[3]; l++) {
+          for (int k = 0; k < shape[2]; k++) {
+            for (int j = 0; j < shape[1]; j++) {
+              for (int i = 0; i < shape[0]; i++) {
+                std::forward<F>(f)(i, j, k, l, m, n);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
 #if defined(GTENSOR_DEVICE_CUDA) || defined(GTENSOR_DEVICE_HIP)
 template <>
 struct launch<1, space::device>

--- a/include/gtensor/gtensor_span.h
+++ b/include/gtensor/gtensor_span.h
@@ -57,8 +57,8 @@ public:
   using typename base_type::strides_type;
 
   gtensor_span() = default;
-  gtensor_span(pointer data, const shape_type& shape,
-               const strides_type& strides);
+  GT_INLINE gtensor_span(pointer data, const shape_type& shape,
+                         const strides_type& strides);
 
   gtensor_span(const gtensor_span& other) = default;
 
@@ -123,13 +123,13 @@ private:
 // gtensor_span implementation
 
 template <typename T, size_type N, typename S>
-inline gtensor_span<T, N, S>::gtensor_span(pointer data,
-                                           const shape_type& shape,
-                                           const strides_type& strides)
+GT_INLINE gtensor_span<T, N, S>::gtensor_span(pointer data,
+                                              const shape_type& shape,
+                                              const strides_type& strides)
   : base_type(shape, strides), storage_(data, calc_size(shape))
 {
 #ifndef NDEBUG
-#ifdef GTENSOR_DEVICE_CUDA
+#if defined(GTENSOR_DEVICE_CUDA) && !defined(__CUDACC__)
   if (std::is_same<S, space::device>::value) {
     cudaPointerAttributes attr;
     gtGpuCheck(

--- a/include/gtensor/helper.h
+++ b/include/gtensor/helper.h
@@ -12,7 +12,7 @@ namespace gt
 {
 
 template <typename... Args>
-auto shape(Args... args)
+GT_INLINE auto shape(Args... args)
 {
   return shape_type<sizeof...(args)>(std::forward<Args>(args)...);
 }

--- a/include/gtensor/macros.h
+++ b/include/gtensor/macros.h
@@ -13,7 +13,7 @@
 
 #if defined(GTENSOR_DEVICE_CUDA) || defined(GTENSOR_DEVICE_HIP)
 
-#define GT_INLINE __host__ __device__
+#define GT_INLINE inline __host__ __device__
 #define GT_LAMBDA [=] __host__ __device__
 
 #elif defined(GTENSOR_DEVICE_SYCL)

--- a/include/gtensor/sarray.h
+++ b/include/gtensor/sarray.h
@@ -35,14 +35,14 @@ public:
 
   // construct from exactly N elements provided
   template <typename... U, std::enable_if_t<sizeof...(U) == N, int> = 0>
-  sarray(U... args);
+  GT_INLINE sarray(U... args);
   sarray(const T* p, std::size_t n);
   sarray(const T data[N]);
 
   template <typename O>
-  bool operator==(const O& o) const;
+  GT_INLINE bool operator==(const O& o) const;
   template <typename O>
-  bool operator!=(const O& o) const;
+  GT_INLINE bool operator!=(const O& o) const;
 
   GT_INLINE constexpr static std::size_t size();
 
@@ -69,25 +69,25 @@ inline std::ostream& operator<<(std::ostream& os, const sarray<T, N>& arr);
 
 template <typename T, std::size_t N>
 template <typename... U, std::enable_if_t<sizeof...(U) == N, int>>
-sarray<T, N>::sarray(U... args) : data_{T(args)...}
+GT_INLINE sarray<T, N>::sarray(U... args) : data_{T(args)...}
 {}
 
 template <typename T, std::size_t N>
-inline sarray<T, N>::sarray(const T* p, std::size_t n)
+sarray<T, N>::sarray(const T* p, std::size_t n)
 {
   assert(n == N);
   std::copy(p, p + n, data_);
 }
 
 template <typename T, std::size_t N>
-inline sarray<T, N>::sarray(const T data[N])
+sarray<T, N>::sarray(const T data[N])
 {
   std::copy(data, data + N, data_);
 }
 
 template <typename T, std::size_t N>
 template <typename O>
-inline bool sarray<T, N>::operator==(const O& o) const
+GT_INLINE bool sarray<T, N>::operator==(const O& o) const
 {
   if (size() != o.size()) {
     return false;
@@ -97,7 +97,7 @@ inline bool sarray<T, N>::operator==(const O& o) const
 
 template <typename T, std::size_t N>
 template <typename O>
-inline bool sarray<T, N>::operator!=(const O& o) const
+GT_INLINE bool sarray<T, N>::operator!=(const O& o) const
 {
   return !(*this == o);
 }

--- a/include/gtensor/sarray.h
+++ b/include/gtensor/sarray.h
@@ -40,9 +40,9 @@ public:
   sarray(const T data[N]);
 
   template <typename O>
-  GT_INLINE bool operator==(const O& o) const;
+  bool operator==(const O& o) const;
   template <typename O>
-  GT_INLINE bool operator!=(const O& o) const;
+  bool operator!=(const O& o) const;
 
   GT_INLINE constexpr static std::size_t size();
 
@@ -87,7 +87,7 @@ sarray<T, N>::sarray(const T data[N])
 
 template <typename T, std::size_t N>
 template <typename O>
-GT_INLINE bool sarray<T, N>::operator==(const O& o) const
+inline bool sarray<T, N>::operator==(const O& o) const
 {
   if (size() != o.size()) {
     return false;
@@ -97,7 +97,7 @@ GT_INLINE bool sarray<T, N>::operator==(const O& o) const
 
 template <typename T, std::size_t N>
 template <typename O>
-GT_INLINE bool sarray<T, N>::operator!=(const O& o) const
+inline bool sarray<T, N>::operator!=(const O& o) const
 {
   return !(*this == o);
 }

--- a/include/gtensor/span.h
+++ b/include/gtensor/span.h
@@ -63,14 +63,15 @@ public:
   using size_type = gt::size_type;
 
   span() = default;
-  span(pointer data, size_type size) : data_{data}, size_{size} {}
+  GT_INLINE span(pointer data, size_type size) : data_{data}, size_{size} {}
 
   span(const span& other) = default;
 
   template <class OtherT,
             std::enable_if_t<
               is_allowed_element_type_conversion<OtherT, T>::value, int> = 0>
-  span(const span<OtherT>& other) : data_{other.data()}, size_{other.size()}
+  GT_INLINE span(const span<OtherT>& other)
+    : data_{other.data()}, size_{other.size()}
   {}
 
   span& operator=(const span& other) = default;
@@ -110,14 +111,15 @@ public:
   using size_type = gt::size_type;
 
   device_span() = default;
-  device_span(pointer data, size_type size) : data_{data}, size_{size} {}
+  GT_INLINE device_span(pointer data, size_type size) : data_{data}, size_{size}
+  {}
 
   device_span(const device_span& other) = default;
 
   template <class OtherT,
             std::enable_if_t<
               is_allowed_element_type_conversion<OtherT, T>::value, int> = 0>
-  device_span(const device_span<OtherT>& other)
+  GT_INLINE device_span(const device_span<OtherT>& other)
     : data_{other.data()}, size_{other.size()}
   {}
 


### PR DESCRIPTION
This add some `GT_INLINE` to functions that should be usable from the device (ie., which I needed to be usable on the device), and also adds `inline` to  `GT_INLINE` macro, which was missing in the CUDA case.