### PR TITLE
fft: remove const on input

### DIFF
--- a/include/gt-fft/backend/cuda.h
+++ b/include/gt-fft/backend/cuda.h
@@ -140,32 +140,30 @@ public:
     }
   }
 
-  void operator()(const typename detail::fft_config<D, R>::Tin* indata,
+  void operator()(typename detail::fft_config<D, R>::Tin* indata,
                   typename detail::fft_config<D, R>::Tout* outdata) const
   {
     if (!is_valid_) {
       throw std::runtime_error("can't use a moved-from plan");
     }
-    using Tin = typename detail::fft_config<D, R>::Tin;
     using Bin = typename detail::fft_config<D, R>::Bin;
     using Bout = typename detail::fft_config<D, R>::Bout;
-    auto bin = reinterpret_cast<Bin*>(const_cast<Tin*>(indata));
+    auto bin = reinterpret_cast<Bin*>(indata);
     auto bout = reinterpret_cast<Bout*>(outdata);
     auto fn = detail::fft_config<D, R>::exec_fn_forward;
     auto result = fn(plan_forward_, bin, bout);
     assert(result == CUFFT_SUCCESS);
   }
 
-  void inverse(const typename detail::fft_config<D, R>::Tout* indata,
+  void inverse(typename detail::fft_config<D, R>::Tout* indata,
                typename detail::fft_config<D, R>::Tin* outdata) const
   {
     if (!is_valid_) {
       throw std::runtime_error("can't use a moved-from plan");
     }
-    using Tout = typename detail::fft_config<D, R>::Tout;
     using Bin = typename detail::fft_config<D, R>::Bin;
     using Bout = typename detail::fft_config<D, R>::Bout;
-    auto bin = reinterpret_cast<Bout*>(const_cast<Tout*>(indata));
+    auto bin = reinterpret_cast<Bout*>(indata);
     auto bout = reinterpret_cast<Bin*>(outdata);
     auto fn = detail::fft_config<D, R>::exec_fn_inverse;
     auto result = fn(plan_inverse_, bin, bout);
@@ -222,32 +220,30 @@ public:
     }
   }
 
-  void operator()(const typename detail::fft_config<D, R>::Tin* indata,
+  void operator()(typename detail::fft_config<D, R>::Tin* indata,
                   typename detail::fft_config<D, R>::Tout* outdata) const
   {
     if (!is_valid_) {
       throw std::runtime_error("can't use a moved-from plan");
     }
-    using Tin = typename detail::fft_config<D, R>::Tin;
     using Bin = typename detail::fft_config<D, R>::Bin;
     using Bout = typename detail::fft_config<D, R>::Bout;
-    auto bin = reinterpret_cast<Bin*>(const_cast<Tin*>(indata));
+    auto bin = reinterpret_cast<Bin*>(indata);
     auto bout = reinterpret_cast<Bout*>(outdata);
     auto fn = detail::fft_config<D, R>::exec_fn_forward;
     auto result = fn(plan_, bin, bout, CUFFT_FORWARD);
     assert(result == CUFFT_SUCCESS);
   }
 
-  void inverse(const typename detail::fft_config<D, R>::Tout* indata,
+  void inverse(typename detail::fft_config<D, R>::Tout* indata,
                typename detail::fft_config<D, R>::Tin* outdata) const
   {
     if (!is_valid_) {
       throw std::runtime_error("can't use a moved-from plan");
     }
-    using Tout = typename detail::fft_config<D, R>::Tout;
     using Bin = typename detail::fft_config<D, R>::Bin;
     using Bout = typename detail::fft_config<D, R>::Bout;
-    auto bin = reinterpret_cast<Bout*>(const_cast<Tout*>(indata));
+    auto bin = reinterpret_cast<Bout*>(indata);
     auto bout = reinterpret_cast<Bin*>(outdata);
     auto fn = detail::fft_config<D, R>::exec_fn_inverse;
     auto result = fn(plan_, bin, bout, CUFFT_INVERSE);

--- a/include/gt-fft/backend/sycl.h
+++ b/include/gt-fft/backend/sycl.h
@@ -144,31 +144,29 @@ public:
   FFTPlanManySYCL(FFTPlanManySYCL&& other) = default;
   FFTPlanManySYCL& operator=(FFTPlanManySYCL&& other) = default;
 
-  void operator()(const typename detail::fft_config<D, R>::Tin* indata,
+  void operator()(typename detail::fft_config<D, R>::Tin* indata,
                   typename detail::fft_config<D, R>::Tout* outdata) const
   {
     if (plan_ == nullptr) {
       throw std::runtime_error("can't use a moved-from plan");
     }
-    using Tin = typename detail::fft_config<D, R>::Tin;
     using Bin = typename detail::fft_config<D, R>::Bin;
     using Bout = typename detail::fft_config<D, R>::Bout;
-    auto bin = reinterpret_cast<Bin*>(const_cast<Tin*>(indata));
+    auto bin = reinterpret_cast<Bin*>(indata);
     auto bout = reinterpret_cast<Bout*>(outdata);
     auto e = oneapi::mkl::dft::compute_forward(*plan_, bin, bout);
     e.wait();
   }
 
-  void inverse(const typename detail::fft_config<D, R>::Tout* indata,
+  void inverse(typename detail::fft_config<D, R>::Tout* indata,
                typename detail::fft_config<D, R>::Tin* outdata) const
   {
     if (plan_ == nullptr) {
       throw std::runtime_error("can't use a moved-from plan");
     }
-    using Tout = typename detail::fft_config<D, R>::Tout;
     using Bin = typename detail::fft_config<D, R>::Bin;
     using Bout = typename detail::fft_config<D, R>::Bout;
-    auto bin = reinterpret_cast<Bout*>(const_cast<Tout*>(indata));
+    auto bin = reinterpret_cast<Bout*>(indata);
     auto bout = reinterpret_cast<Bin*>(outdata);
     auto e = oneapi::mkl::dft::compute_backward(*plan_, bin, bout);
     e.wait();

--- a/include/gt-fft/fft.h
+++ b/include/gt-fft/fft.h
@@ -50,7 +50,7 @@ public:
             typename = std::enable_if_t<
               has_container_methods_v<C1> && has_space_type_device_v<C1> &&
               has_container_methods_v<C2> && has_space_type_device_v<C2>>>
-  void operator()(const C1& in, C2& out) const
+  void operator()(C1& in, C2& out) const
   {
     operator()(gt::backend::raw_pointer_cast(in.data()),
                gt::backend::raw_pointer_cast(out.data()));
@@ -60,7 +60,7 @@ public:
             typename = std::enable_if_t<
               has_container_methods_v<C1> && has_space_type_device_v<C1> &&
               has_container_methods_v<C2> && has_space_type_device_v<C2>>>
-  void inverse(const C1& in, C2& out) const
+  void inverse(C1& in, C2& out) const
   {
     inverse(gt::backend::raw_pointer_cast(in.data()),
             gt::backend::raw_pointer_cast(out.data()));


### PR DESCRIPTION
cuFFT, particularly starting with CUDA 11, will modify input
with out of place transform on c2r. None of the underlying
libraries advertise const input, so to be safe we will remove
this promise as well, even though it appears to be true for
the other transforms.