### PR TITLE
allow adapt() to be called on the device

### DIFF
--- a/include/gtensor/gtensor_span.h
+++ b/include/gtensor/gtensor_span.h
@@ -205,13 +205,13 @@ GT_INLINE auto gtensor_span<T, N, S>::operator[](const shape_type& idx) const
 // adapt
 
 template <size_type N, typename T>
-gtensor_span<T, N> adapt(T* data, const shape_type<N>& shape)
+GT_INLINE gtensor_span<T, N> adapt(T* data, const shape_type<N>& shape)
 {
   return gtensor_span<T, N>(data, shape, calc_strides(shape));
 }
 
 template <size_type N, typename T>
-gtensor_span<T, N> adapt(T* data, const int* shape_data)
+GT_INLINE gtensor_span<T, N> adapt(T* data, const int* shape_data)
 {
   return adapt<N, T>(data, {shape_data, N});
 }


### PR DESCRIPTION
It's probably not what usually should be done, but it may sometimes make sense,
if only to work around some other limitation like I'm currently doing
(the other limitation being that one can't createa view on the device,
which probably should be enabled, too.)