### PR TITLE
functions: test/support gt::abs on device

### DIFF
--- a/include/gtensor/gfunction.h
+++ b/include/gtensor/gfunction.h
@@ -392,6 +392,23 @@ MAKE_BINARY_OP(divide, /)
 
 #undef MAKE_BINARY_OP
 
+namespace detail
+{
+template <typename T>
+GT_INLINE auto drop_device_reference(T a)
+{
+  return a;
+}
+
+#ifdef GTENSOR_USE_THRUST
+template <typename T>
+GT_INLINE auto drop_device_reference(thrust::device_reference<T> a)
+{
+  return T(a);
+}
+#endif
+} // namespace detail
+
 #define MAKE_UNARY_FUNC(NAME, FUNC)                                            \
                                                                                \
   namespace funcs                                                              \
@@ -401,7 +418,7 @@ MAKE_BINARY_OP(divide, /)
     template <typename T>                                                      \
     GT_INLINE auto operator()(T a) const                                       \
     {                                                                          \
-      return FUNC(a);                                                          \
+      return FUNC(detail::drop_device_reference(a));                           \
     }                                                                          \
   };                                                                           \
   }                                                                            \

--- a/tests/test_expression.cxx
+++ b/tests/test_expression.cxx
@@ -327,6 +327,21 @@ TEST(expression, host_index_expression)
 
 #ifdef GTENSOR_HAVE_DEVICE
 
+TEST(expression, device_abs)
+{
+  gt::gtensor_device<double, 1> t1({1., -2.});
+  auto e1 = gt::abs(t1);
+  EXPECT_EQ(e1, (gt::gtensor_device<double, 1>{1., 2.}));
+}
+
+TEST(expression, device_abs_complex)
+{
+  using T = std::complex<double>;
+  gt::gtensor_device<T, 1> t1({T(3., 4.), -2.});
+  auto e1 = gt::abs(t1);
+  EXPECT_EQ(e1, (gt::gtensor_device<double, 1>{5., 2.}));
+}
+
 TEST(expression, device_eval)
 {
   gt::gtensor_device<double, 2> a = {{11., 12., 13.}, {21., 22., 23.}};


### PR DESCRIPTION
I'm marking this WIP because it's (1) ugly and (2) uses `std::complex` on the device, which gives warnings, though it does actually succeed.

So it's kinda just for reference, if someone gets around to trying to do this right...