### PR TITLE
use CPM as cmake package manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(gtensor
         LANGUAGES CXX
         HOMEPAGE_URL https://github.com/wdmapp/gtensor)
 
+include(cmake/CPM.cmake)
+
 option(USE_GTEST_DISCOVER_TESTS "use gtest_discover_tests()" ON)
 set(GTENSOR_DEVICE "cuda" CACHE STRING "Device type 'host', 'cuda', or 'hip'")
 set_property(CACHE GTENSOR_DEVICE PROPERTY STRINGS "host" "cuda" "hip" "sycl")
@@ -234,27 +236,22 @@ include(CTest)
 if (BUILD_TESTING AND IS_MAIN_PROJECT)
   message(STATUS "${PROJECT_NAME}: build testing is ON")
 
-  # try to find gtest, otherwise fetch and add to build
-  find_package(GTest QUIET)
-
-  if (NOT GTEST_FOUND)
-    message(STATUS "${PROJECT_NAME}: googletest not found, fetching source and adding to build")
-    include(FetchContent)
-    FetchContent_Declare(googletest
-      GIT_REPOSITORY    https://github.com/google/googletest.git
-      GIT_TAG           release-1.10.0
-      )
-    FetchContent_GetProperties(googletest)
-    if (NOT googletest_POPULATED)
-      FetchContent_Populate(googletest)
-      add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
-    endif()
-    add_library(GTest::GTest INTERFACE IMPORTED)
-    target_include_directories(GTest::GTest INTERFACE "${googletest_SOURCE_DIR}/googletest/include")
-    target_link_libraries(GTest::GTest INTERFACE gtest)
-    add_library(GTest::Main INTERFACE IMPORTED)
-    target_link_libraries(GTest::Main INTERFACE gtest_main)
+  CPMAddPackage(
+    NAME googletest
+    GITHUB_REPOSITORY google/googletest
+    # There is no release yet, but we want post 1.10.0 with
+    # cmake_minimum_required updated
+    GIT_TAG 32f4f52d95dc99c35f51deed552a6ba700567f94
+    VERSION 1.10.0x
+    OPTIONS
+      "INSTALL_GTEST OFF"
+      "gtest_force_shared_crt ON"
+  )
+  if (googletest_ADDED)
+    add_library(GTest::GTest ALIAS gtest)
+    add_library(GTest::Main ALIAS gtest_main)
   endif()
+  include(GoogleTest)
 else()
   message(STATUS "${PROJECT_NAME}: build testing is OFF")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ project(gtensor
         LANGUAGES CXX
         HOMEPAGE_URL https://github.com/wdmapp/gtensor)
 
+if (NOT CMAKE_BUILD_TYPE)
+  message(STATUS "gtensor: Setting build type to 'Release' since none specified.")
+  set(CMAKE_BUILD_TYPE "Release"
+      CACHE STRING "Choose the type of build." FORCE)
+endif()
+
 include(cmake/CPM.cmake)
 
 option(USE_GTEST_DISCOVER_TESTS "use gtest_discover_tests()" ON)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,0 +1,21 @@
+set(CPM_DOWNLOAD_VERSION 0.32.1)
+
+if(CPM_SOURCE_CACHE)
+  # Expand relative path. This is important if the provided path contains a tilde (~)
+  get_filename_component(CPM_SOURCE_CACHE ${CPM_SOURCE_CACHE} ABSOLUTE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
+  message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
+  file(DOWNLOAD
+       https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+       ${CPM_DOWNLOAD_LOCATION}
+  )
+endif()
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -20,6 +20,7 @@ if(NOT TARGET gtensor::gtensor)
     file(MAKE_DIRECTORY external/gtensor)
     file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../include
               ${CMAKE_CURRENT_SOURCE_DIR}/../CMakeLists.txt
+              ${CMAKE_CURRENT_SOURCE_DIR}/../cmake
               ${CMAKE_CURRENT_SOURCE_DIR}/../gtensor-config.cmake.in
          DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/external/gtensor
          PATTERN examples EXCLUDE)


### PR DESCRIPTION
It makes it easier to deal with a choice of pre-installed packages or
downloading them on demand, including overriding things to point to
a local copy when desired for development.

It'd help more if there was more than googletest that we use it for, but
that's it at this time. At least the googletest it downloads now doesn't
have the annoying warnings about ancient cmake.