### PR TITLE
implement 4d assign based on 1d block/thread index, benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,7 +239,7 @@ add_library(gtensor ALIAS gtensor_${GTENSOR_DEVICE})
 add_library(gtensor::gtensor ALIAS gtensor_${GTENSOR_DEVICE})
 
 include(CTest)
-if (BUILD_TESTING AND IS_MAIN_PROJECT)
+if ((BUILD_TESTING AND IS_MAIN_PROJECT) OR GTENSOR_BUILD_BENCHMARKS)
   message(STATUS "${PROJECT_NAME}: build testing is ON")
 
   CPMAddPackage(
@@ -260,6 +260,19 @@ if (BUILD_TESTING AND IS_MAIN_PROJECT)
   include(GoogleTest)
 else()
   message(STATUS "${PROJECT_NAME}: build testing is OFF")
+endif()
+
+if (GTENSOR_BUILD_BENCHMARKS)
+  CPMAddPackage(
+    NAME benchmark
+    GITHUB_REPOSITORY germasch/benchmark
+    GIT_TAG kg
+    VERSION 1.5.3kg
+    GIT_SHALLOW TRUE
+    OPTIONS
+      "BENCHMARK_ENABLE_TESTING OFF"
+      "BENCHMARK_ENABLE_INSTALL OFF"
+  )
 endif()
 
 function(target_gtensor_sources TARGET)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -2,3 +2,7 @@
 add_executable(ij_deriv)
 target_gtensor_sources(ij_deriv PRIVATE ij_deriv.cxx)
 target_link_libraries(ij_deriv gtensor::gtensor)
+
+add_executable(bench_assign)
+target_gtensor_sources(bench_assign PRIVATE bench_assign.cxx)
+target_link_libraries(bench_assign PRIVATE gtensor::gtensor benchmark::benchmark)

--- a/benchmarks/bench_assign.cxx
+++ b/benchmarks/bench_assign.cxx
@@ -1,0 +1,18 @@
+
+#include <benchmark/benchmark.h>
+
+#include <gtensor/gtensor.h>
+
+static void BM_device_assign_4d(benchmark::State& state)
+{
+  auto a = gt::zeros_device<double>(gt::shape(100, 100, 100, 100));
+  auto b = gt::empty_like(a);
+
+  for (auto _ : state) {
+    b = a + 2 * a;
+  }
+}
+
+BENCHMARK(BM_device_assign_4d)->Unit(benchmark::kMillisecond);
+
+BENCHMARK_MAIN();

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -566,6 +566,24 @@ TEST(gtensor, device_assign_expression)
             (gt::gtensor_device<double, 2>{{22., 24., 26.}, {42., 44., 46.}}));
 }
 
+TEST(gtensor, device_assign_expression_4d)
+{
+  auto a = gt::empty_device<double>(gt::shape(2, 3, 4, 5));
+  auto h_a = gt::empty<double>(gt::shape(2, 3, 4, 5));
+  for (int i = 0; i < h_a.size(); i++) {
+    h_a.data()[i] = double(i);
+  }
+  gt::copy(h_a, a);
+
+  auto b = a + a;
+
+  auto h_b = gt::empty<double>(gt::shape(2, 3, 4, 5));
+  gt::copy(gt::eval(b), h_b);
+  for (int i = 0; i < h_b.size(); i++) {
+    EXPECT_EQ(h_b.data()[i], 2. * i);
+  }
+}
+
 TEST(gtensor, device_move_ctor)
 {
   gt::gtensor<double, 1> h_a{11., 12., 13.};


### PR DESCRIPTION
Doing some semi-arbitrary mapping between 4-d index space and threads/blocks is fragile, e.g., 
I hit the case where blockIdx.z exceeds the allow limit.

Using 1-d index space for launch and then calculating back a 4-d index is something that could be detrimental to performance, due to the integer divisions, but at least in the included benchmark it essentially doesn't make a difference (it's actually slightly faster on V100 for the particular case.)

There's definitely more that could be done, including
* same for other dimensionality
* don't map every index to a new thread in the first place, but map to enough threads and then loop.
* avoid mapping back to multi-d in the first place where the underlying storage is contiguous (that probably needs bigger changes in gtensor to know when that is the case.)