### PR TITLE
work towards standard allocator in gtensor_storage

### DIFF
--- a/benchmarks/ij_deriv.cxx
+++ b/benchmarks/ij_deriv.cxx
@@ -507,16 +507,16 @@ void test_ij_deriv(int li0, int lj0, int lbg0)
   // cleanup
   free(ref_darr);
 
-  gt::backend::host_allocator<Complex>{}.deallocate(h_arr);
-  gt::backend::device_allocator<Complex>{}.deallocate(d_arr);
+  gt::backend::host_allocator<Complex>{}.deallocate(h_arr, arr_size);
+  gt::backend::device_allocator<Complex>{}.deallocate(d_arr, arr_size);
 
-  gt::backend::host_allocator<Complex>{}.deallocate(h_darr);
-  gt::backend::device_allocator<Complex>{}.deallocate(d_darr);
+  gt::backend::host_allocator<Complex>{}.deallocate(h_darr, arr_size);
+  gt::backend::device_allocator<Complex>{}.deallocate(d_darr, arr_size);
 
-  gt::backend::host_allocator<Real>{}.deallocate(h_coeff);
+  gt::backend::host_allocator<Real>{}.deallocate(h_coeff, ncoeff);
 
-  gt::backend::host_allocator<Complex>{}.deallocate(h_ikj);
-  gt::backend::device_allocator<Complex>{}.deallocate(d_ikj);
+  gt::backend::host_allocator<Complex>{}.deallocate(h_ikj, ikj_size);
+  gt::backend::device_allocator<Complex>{}.deallocate(d_ikj, ikj_size);
 }
 
 int main(int argc, char** argv)

--- a/benchmarks/ij_deriv.cxx
+++ b/benchmarks/ij_deriv.cxx
@@ -350,19 +350,19 @@ void test_ij_deriv(int li0, int lj0, int lbg0)
 
   printf("== %dx%dx%d ==\n", li0, lj0, lbg0);
 
-  h_arr = gt::backend::host_allocator<Complex>::allocate(arr_size);
-  d_arr = gt::backend::device_allocator<Complex>::allocate(arr_size);
+  h_arr = gt::backend::host_allocator<Complex>{}.allocate(arr_size);
+  d_arr = gt::backend::device_allocator<Complex>{}.allocate(arr_size);
 
-  h_darr = gt::backend::host_allocator<Complex>::allocate(darr_size);
-  d_darr = gt::backend::device_allocator<Complex>::allocate(darr_size);
+  h_darr = gt::backend::host_allocator<Complex>{}.allocate(darr_size);
+  d_darr = gt::backend::device_allocator<Complex>{}.allocate(darr_size);
 
   ref_darr = (Complex*)malloc(sizeof(Complex) * darr_size);
 
-  h_ikj = gt::backend::host_allocator<Complex>::allocate(ikj_size);
-  d_ikj = gt::backend::device_allocator<Complex>::allocate(ikj_size);
+  h_ikj = gt::backend::host_allocator<Complex>{}.allocate(ikj_size);
+  d_ikj = gt::backend::device_allocator<Complex>{}.allocate(ikj_size);
 
-  h_coeff = gt::backend::host_allocator<Real>::allocate(ncoeff);
-  d_coeff = gt::backend::device_allocator<Real>::allocate(ncoeff);
+  h_coeff = gt::backend::host_allocator<Real>{}.allocate(ncoeff);
+  d_coeff = gt::backend::device_allocator<Real>{}.allocate(ncoeff);
 
   // initialize the input arrays
   // 4th order centered difference
@@ -507,16 +507,16 @@ void test_ij_deriv(int li0, int lj0, int lbg0)
   // cleanup
   free(ref_darr);
 
-  gt::backend::host_allocator<Complex>::deallocate(h_arr);
-  gt::backend::device_allocator<Complex>::deallocate(d_arr);
+  gt::backend::host_allocator<Complex>{}.deallocate(h_arr);
+  gt::backend::device_allocator<Complex>{}.deallocate(d_arr);
 
-  gt::backend::host_allocator<Complex>::deallocate(h_darr);
-  gt::backend::device_allocator<Complex>::deallocate(d_darr);
+  gt::backend::host_allocator<Complex>{}.deallocate(h_darr);
+  gt::backend::device_allocator<Complex>{}.deallocate(d_darr);
 
-  gt::backend::host_allocator<Real>::deallocate(h_coeff);
+  gt::backend::host_allocator<Real>{}.deallocate(h_coeff);
 
-  gt::backend::host_allocator<Complex>::deallocate(h_ikj);
-  gt::backend::device_allocator<Complex>::deallocate(d_ikj);
+  gt::backend::host_allocator<Complex>{}.deallocate(h_ikj);
+  gt::backend::device_allocator<Complex>{}.deallocate(d_ikj);
 }
 
 int main(int argc, char** argv)

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -402,14 +402,14 @@ struct device_allocator
   using value_type = T;
   using size_type = gt::size_type;
 
-  T* allocate(size_type count)
+  T* allocate(size_type n)
   {
     T* p;
-    gtGpuCheck(cudaMalloc(&p, sizeof(T) * count));
+    gtGpuCheck(cudaMalloc(&p, sizeof(T) * n));
     return p;
   }
 
-  void deallocate(T* p) { gtGpuCheck(cudaFree(p)); }
+  void deallocate(T* p, size_type n = 0) { gtGpuCheck(cudaFree(p)); }
 };
 
 template <typename T>
@@ -418,14 +418,14 @@ struct managed_allocator
   using value_type = T;
   using size_type = gt::size_type;
 
-  T* allocate(size_t count)
+  T* allocate(size_t n)
   {
     T* p;
-    gtGpuCheck(cudaMallocManaged(&p, sizeof(T) * count));
+    gtGpuCheck(cudaMallocManaged(&p, sizeof(T) * n));
     return p;
   }
 
-  void deallocate(T* p) { gtGpuCheck(cudaFree(p)); }
+  void deallocate(T* p, size_type n = 0) { gtGpuCheck(cudaFree(p)); }
 };
 
 template <typename T>
@@ -434,14 +434,14 @@ struct host_allocator
   using value_type = T;
   using size_type = gt::size_type;
 
-  T* allocate(gt::size_type count)
+  T* allocate(gt::size_type n)
   {
     T* p;
-    gtGpuCheck(cudaMallocHost(&p, sizeof(T) * count));
+    gtGpuCheck(cudaMallocHost(&p, sizeof(T) * n));
     return p;
   }
 
-  void deallocate(T* p) { gtGpuCheck(cudaFreeHost(p)); }
+  void deallocate(T* p, size_type n = 0) { gtGpuCheck(cudaFreeHost(p)); }
 };
 
 } // namespace cuda
@@ -462,14 +462,14 @@ struct device_allocator
   using value_type = T;
   using size_type = gt::size_type;
 
-  T* allocate(size_type count)
+  T* allocate(size_type n)
   {
     T* p;
-    gtGpuCheck(hipMalloc(&p, sizeof(T) * count));
+    gtGpuCheck(hipMalloc(&p, sizeof(T) * n));
     return p;
   }
 
-  void deallocate(T* p) { gtGpuCheck(hipFree(p)); }
+  void deallocate(T* p, size_type n = 0) { gtGpuCheck(hipFree(p)); }
 };
 
 template <typename T>
@@ -478,14 +478,14 @@ struct managed_allocator
   using value_type = T;
   using size_type = gt::size_type;
 
-  T* allocate(gt::size_type count)
+  T* allocate(gt::size_type n)
   {
     T* p;
-    gtGpuCheck(hipMallocManaged(&p, sizeof(T) * count));
+    gtGpuCheck(hipMallocManaged(&p, sizeof(T) * n));
     return p;
   }
 
-  void deallocate(T* p) { gtGpuCheck(hipFree(p)); }
+  void deallocate(T* p, size_type n = 0) { gtGpuCheck(hipFree(p)); }
 };
 
 template <typename T>
@@ -494,14 +494,14 @@ struct host_allocator
   using value_type = T;
   using size_type = gt::size_type;
 
-  T* allocate(gt::size_type count)
+  T* allocate(gt::size_type n)
   {
     T* p;
-    gtGpuCheck(hipHostMalloc(&p, sizeof(T) * count, hipHostMallocDefault));
+    gtGpuCheck(hipHostMalloc(&p, sizeof(T) * n, hipHostMallocDefault));
     return p;
   }
 
-  void deallocate(T* p) { gtGpuCheck(hipHostFree(p)); }
+  void deallocate(T* p, size_type n = 0) { gtGpuCheck(hipHostFree(p)); }
 };
 
 } // namespace hip
@@ -522,12 +522,15 @@ struct device_allocator
   using value_type = T;
   using size_type = gt::size_type;
 
-  T* allocate(gt::size_type count)
+  T* allocate(gt::size_type n)
   {
-    return cl::sycl::malloc_device<T>(count, gt::backend::sycl::get_queue());
+    return cl::sycl::malloc_device<T>(n, gt::backend::sycl::get_queue());
   }
 
-  void deallocate(T* p) { cl::sycl::free(p, gt::backend::sycl::get_queue()); }
+  void deallocate(T* p, size_type n = 0)
+  {
+    cl::sycl::free(p, gt::backend::sycl::get_queue());
+  }
 };
 
 } // namespace sycl
@@ -538,12 +541,15 @@ struct managed_allocator
   using value_type = T;
   using size_type = gt::size_type;
 
-  T* allocate(gt::size_type count)
+  T* allocate(gt::size_type n)
   {
-    return cl::sycl::malloc_shared<T>(count, gt::backend::sycl::get_queue());
+    return cl::sycl::malloc_shared<T>(n, gt::backend::sycl::get_queue());
   }
 
-  void deallocate(T* p) { cl::sycl::free(p, gt::backend::sycl::get_queue()); }
+  void deallocate(T* p, size_type n = 0)
+  {
+    cl::sycl::free(p, gt::backend::sycl::get_queue());
+  }
 };
 
 // The host allocation type in SYCL allows device code to directly access
@@ -555,9 +561,9 @@ struct host_allocator
   using value_type = T;
   using size_type = gt::size_type;
 
-  T* allocate(gt::size_type count)
+  T* allocate(gt::size_type n)
   {
-    T* p = static_cast<T*>(malloc(sizeof(T) * count));
+    T* p = static_cast<T*>(malloc(sizeof(T) * n));
     if (p == nullptr) {
       std::cerr << "host allocate failed" << std::endl;
       std::abort();
@@ -565,7 +571,7 @@ struct host_allocator
     return p;
   }
 
-  void deallocate(T* p) { free(p); }
+  void deallocate(T* p, size_type n = 0) { free(p); }
 };
 
 /*
@@ -598,9 +604,9 @@ struct host_allocator
   using value_type = T;
   using size_type = gt::size_type;
 
-  T* allocate(gt::size_type count)
+  T* allocate(gt::size_type n)
   {
-    T* p = static_cast<T*>(malloc(sizeof(T) * count));
+    T* p = static_cast<T*>(malloc(sizeof(T) * n));
     if (p == nullptr) {
       std::cerr << "host allocate failed" << std::endl;
       std::abort();
@@ -608,7 +614,7 @@ struct host_allocator
     return p;
   }
 
-  void deallocate(T* p) { free(p); }
+  void deallocate(T* p, size_type n = 0) { free(p); }
 };
 
 } // namespace host

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -120,8 +120,17 @@ struct device_allocator
       gtGpuCheck(cudaFree(p));
     }
   }
+};
 
-  static void copy(const T* src, T* dst, gt::size_type count)
+template <typename T>
+struct device_ops
+{
+  using value_type = T;
+  using pointer = T*;
+  using const_pointer = const T*;
+  using size_type = gt::size_type;
+
+  static void copy(const_pointer src, pointer dst, size_type count)
   {
     device_copy_dd(src, dst, count);
   }
@@ -274,8 +283,17 @@ struct device_allocator
       gtGpuCheck(hipFree(p));
     }
   }
+};
 
-  static void copy(const T* src, T* dst, gt::size_type count)
+template <typename T>
+struct device_ops
+{
+  using value_type = T;
+  using pointer = T*;
+  using const_pointer = const T*;
+  using size_type = gt::size_type;
+
+  static void copy(const_pointer src, pointer dst, size_type count)
   {
     device_copy_dd(src, dst, count);
   }
@@ -403,8 +421,17 @@ struct device_allocator
       cl::sycl::free(p, gt::backend::sycl::get_queue());
     }
   }
+};
 
-  static void copy(const T* src, T* dst, gt::size_type count)
+template <typename T>
+struct device_ops
+{
+  using value_type = T;
+  using pointer = T*;
+  using const_pointer = const T*;
+  using size_type = gt::size_type;
+
+  static void copy(const_pointer src, pointer dst, size_type count)
   {
     device_copy_dd(src, dst, count);
   }

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -153,11 +153,6 @@ struct managed_allocator
   }
 
   void deallocate(T* p) { gtGpuCheck(cudaFree(p)); }
-
-  static void copy(const T* src, T* dst, gt::size_type count)
-  {
-    device_copy_dd(src, dst, count);
-  }
 };
 
 template <typename T>
@@ -315,11 +310,6 @@ struct managed_allocator
   }
 
   void deallocate(T* p) { gtGpuCheck(hipFree(p)); }
-
-  static void copy(const T* src, T* dst, gt::size_type count)
-  {
-    device_copy_dd(src, dst, count);
-  }
 };
 
 template <typename T>
@@ -450,11 +440,6 @@ struct managed_allocator
   }
 
   void deallocate(T* p) { cl::sycl::free(p, gt::backend::sycl::get_queue()); }
-
-  static void copy(const T* src, T* dst, gt::size_type count)
-  {
-    device_copy_dd(src, dst, count);
-  }
 };
 
 // The host allocation type in SYCL allows device code to directly access
@@ -476,12 +461,7 @@ struct host_allocator
     return p;
   }
 
-  static void deallocate(T* p) { free(p); }
-
-  static void copy(const T* src, T* dst, gt::size_type count)
-  {
-    std::memcpy(dst, src, sizeof(T) * count);
-  }
+  void deallocate(T* p) { free(p); }
 };
 
 /*

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -107,19 +107,17 @@ inline void device_memset(void* dst, int value, gt::size_type nbytes)
 template <typename T>
 struct device_allocator
 {
-  static T* allocate(size_t count)
+  using value_type = T;
+  using size_type = gt::size_type;
+
+  T* allocate(size_type count)
   {
     T* p;
     gtGpuCheck(cudaMalloc(&p, sizeof(T) * count));
     return p;
   }
 
-  static void deallocate(T* p)
-  {
-    if (p != nullptr) {
-      gtGpuCheck(cudaFree(p));
-    }
-  }
+  void deallocate(T* p) { gtGpuCheck(cudaFree(p)); }
 };
 
 template <typename T>
@@ -144,19 +142,17 @@ struct device_ops
 template <typename T>
 struct managed_allocator
 {
-  static T* allocate(size_t count)
+  using value_type = T;
+  using size_type = gt::size_type;
+
+  T* allocate(size_t count)
   {
     T* p;
     gtGpuCheck(cudaMallocManaged(&p, sizeof(T) * count));
     return p;
   }
 
-  static void deallocate(T* p)
-  {
-    if (p != nullptr) {
-      gtGpuCheck(cudaFree(p));
-    }
-  }
+  void deallocate(T* p) { gtGpuCheck(cudaFree(p)); }
 
   static void copy(const T* src, T* dst, gt::size_type count)
   {
@@ -167,19 +163,17 @@ struct managed_allocator
 template <typename T>
 struct host_allocator
 {
-  static T* allocate(gt::size_type count)
+  using value_type = T;
+  using size_type = gt::size_type;
+
+  T* allocate(gt::size_type count)
   {
     T* p;
     gtGpuCheck(cudaMallocHost(&p, sizeof(T) * count));
     return p;
   }
 
-  static void deallocate(T* p)
-  {
-    if (p != nullptr) {
-      gtGpuCheck(cudaFreeHost(p));
-    }
-  }
+  void deallocate(T* p) { gtGpuCheck(cudaFreeHost(p)); }
 };
 
 template <typename T>
@@ -275,19 +269,17 @@ inline void device_memset(void* dst, int value, gt::size_type nbytes)
 template <typename T>
 struct device_allocator
 {
-  static T* allocate(gt::size_type count)
+  using value_type = T;
+  using size_type = gt::size_type;
+
+  T* allocate(size_type count)
   {
     T* p;
     gtGpuCheck(hipMalloc(&p, sizeof(T) * count));
     return p;
   }
 
-  static void deallocate(T* p)
-  {
-    if (p != nullptr) {
-      gtGpuCheck(hipFree(p));
-    }
-  }
+  void deallocate(T* p) { gtGpuCheck(hipFree(p)); }
 };
 
 template <typename T>
@@ -312,19 +304,17 @@ struct device_ops
 template <typename T>
 struct managed_allocator
 {
-  static T* allocate(gt::size_type count)
+  using value_type = T;
+  using size_type = gt::size_type;
+
+  T* allocate(gt::size_type count)
   {
     T* p;
     gtGpuCheck(hipMallocManaged(&p, sizeof(T) * count));
     return p;
   }
 
-  static void deallocate(T* p)
-  {
-    if (p != nullptr) {
-      gtGpuCheck(hipFree(p));
-    }
-  }
+  void deallocate(T* p) { gtGpuCheck(hipFree(p)); }
 
   static void copy(const T* src, T* dst, gt::size_type count)
   {
@@ -335,19 +325,17 @@ struct managed_allocator
 template <typename T>
 struct host_allocator
 {
-  static T* allocate(gt::size_type count)
+  using value_type = T;
+  using size_type = gt::size_type;
+
+  T* allocate(gt::size_type count)
   {
     T* p;
     gtGpuCheck(hipHostMalloc(&p, sizeof(T) * count, hipHostMallocDefault));
     return p;
   }
 
-  static void deallocate(T* p)
-  {
-    if (p != nullptr) {
-      gtGpuCheck(hipHostFree(p));
-    }
-  }
+  void deallocate(T* p) { gtGpuCheck(hipHostFree(p)); }
 };
 
 template <typename T>
@@ -420,17 +408,15 @@ inline void device_memset(void* dst, int value, gt::size_type nbytes)
 template <typename T>
 struct device_allocator
 {
-  static T* allocate(gt::size_type count)
+  using value_type = T;
+  using size_type = gt::size_type;
+
+  T* allocate(gt::size_type count)
   {
     return cl::sycl::malloc_device<T>(count, gt::backend::sycl::get_queue());
   }
 
-  static void deallocate(T* p)
-  {
-    if (p != nullptr) {
-      cl::sycl::free(p, gt::backend::sycl::get_queue());
-    }
-  }
+  Void deallocate(T* p) { cl::sycl::free(p, gt::backend::sycl::get_queue()); }
 };
 
 template <typename T>
@@ -455,17 +441,15 @@ struct device_ops
 template <typename T>
 struct managed_allocator
 {
-  static T* allocate(gt::size_type count)
+  using value_type = T;
+  using size_type = gt::size_type;
+
+  T* allocate(gt::size_type count)
   {
     return cl::sycl::malloc_shared<T>(count, gt::backend::sycl::get_queue());
   }
 
-  static void deallocate(T* p)
-  {
-    if (p != nullptr) {
-      cl::sycl::free(p, gt::backend::sycl::get_queue());
-    }
-  }
+  void deallocate(T* p) { cl::sycl::free(p, gt::backend::sycl::get_queue()); }
 
   static void copy(const T* src, T* dst, gt::size_type count)
   {
@@ -479,7 +463,10 @@ struct managed_allocator
 template <typename T>
 struct host_allocator
 {
-  static T* allocate(gt::size_type count)
+  using value_type = T;
+  using size_type = gt::size_type;
+
+  T* allocate(gt::size_type count)
   {
     T* p = static_cast<T*>(malloc(sizeof(T) * count));
     if (p == nullptr) {
@@ -489,12 +476,7 @@ struct host_allocator
     return p;
   }
 
-  static void deallocate(T* p)
-  {
-    if (p != nullptr) {
-      free(p);
-    }
-  }
+  static void deallocate(T* p) { free(p); }
 
   static void copy(const T* src, T* dst, gt::size_type count)
   {
@@ -549,7 +531,10 @@ inline void device_synchronize()
 template <typename T>
 struct host_allocator
 {
-  static T* allocate(gt::size_type count)
+  using value_type = T;
+  using size_type = gt::size_type;
+
+  T* allocate(gt::size_type count)
   {
     T* p = static_cast<T*>(malloc(sizeof(T) * count));
     if (p == nullptr) {
@@ -559,12 +544,7 @@ struct host_allocator
     return p;
   }
 
-  static void deallocate(T* p)
-  {
-    if (p != nullptr) {
-      free(p);
-    }
-  }
+  void deallocate(T* p) { free(p); }
 };
 
 template <typename T>
@@ -614,7 +594,7 @@ inline Pointer device_pointer_cast(Pointer p)
 
 #endif // GTENSOR_USE_THRUST
 
-} // end namespace backend
+} // namespace backend
 
 // ======================================================================
 // synchronize

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -397,7 +397,7 @@ struct wrap_allocator
   using size_type = gt::size_type;
 
   T* allocate(size_type n) { return A::allocate(n); }
-  void deallocate(T* p, size_type n = 0) { A::deallocate(p); }
+  void deallocate(T* p, size_type n) { A::deallocate(p); }
 };
 
 // ======================================================================

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -452,9 +452,6 @@ template <typename T>
 using device_allocator = wrap_allocator<T, typename ops<T>::device>;
 
 template <typename T>
-using managed_allocator = wrap_allocator<T, typename ops<T>::managed>;
-
-template <typename T>
 using host_allocator = wrap_allocator<T, typename ops<T>::host>;
 
 } // namespace cuda
@@ -511,9 +508,6 @@ struct ops
 
 template <typename T>
 using device_allocator = wrap_allocator<T, typename ops<T>::device>;
-
-template <typename T>
-using managed_allocator = wrap_allocator<T, typename ops<T>::managed>;
 
 template <typename T>
 using host_allocator = wrap_allocator<T, typename ops<T>::host>;
@@ -595,9 +589,6 @@ struct ops
 
 template <typename T>
 using device_allocator = wrap_allocator<T, typename ops<T>::device>;
-
-template <typename T>
-using managed_allocator = wrap_allocator<T, typename ops<T>::managed>;
 
 template <typename T>
 using host_allocator = wrap_allocator<T, typename ops<T>::host>;

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -613,26 +613,7 @@ namespace host
 {
 
 template <typename T>
-struct ops
-{
-  struct host
-  {
-    static T* allocate(size_type n)
-    {
-      T* p = static_cast<T*>(malloc(sizeof(T) * n));
-      if (p == nullptr) {
-        std::cerr << "host allocate failed" << std::endl;
-        std::abort();
-      }
-      return p;
-    }
-
-    static void deallocate(T* p) { free(p); }
-  };
-};
-
-template <typename T>
-using host_allocator = wrap_allocator<T, typename ops<T>::host>;
+using host_allocator = std::allocator<T>;
 
 }; // namespace host
 

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -166,8 +166,17 @@ struct host_allocator
       gtGpuCheck(cudaFreeHost(p));
     }
   }
+};
 
-  static void copy(const T* src, T* dst, gt::size_type count)
+template <typename T>
+struct host_ops
+{
+  using value_type = T;
+  using pointer = T*;
+  using const_pointer = const T*;
+  using size_type = gt::size_type;
+
+  static void copy(const_pointer src, pointer dst, size_type count)
   {
     device_copy_hh(src, dst, count);
   }
@@ -311,8 +320,17 @@ struct host_allocator
       gtGpuCheck(hipHostFree(p));
     }
   }
+};
 
-  static void copy(const T* src, T* dst, gt::size_type count)
+template <typename T>
+struct host_ops
+{
+  using value_type = T;
+  using pointer = T*;
+  using const_pointer = const T*;
+  using size_type = gt::size_type;
+
+  static void copy(const_pointer src, pointer dst, size_type count)
   {
     device_copy_hh(src, dst, count);
   }
@@ -463,6 +481,20 @@ struct host_allocator
 };
 */
 
+template <typename T>
+struct host_ops
+{
+  using value_type = T;
+  using pointer = T*;
+  using const_pointer = const T*;
+  using size_type = gt::size_type;
+
+  static void copy(const_pointer src, pointer dst, size_type count)
+  {
+    std::memcpy(dst, src, sizeof(value_type) * count);
+  }
+};
+
 #endif // GTENSOR_DEVICE_{CUDA,HIP,SYCL}
 
 #ifdef GTENSOR_DEVICE_HOST
@@ -491,10 +523,19 @@ struct host_allocator
       free(p);
     }
   }
+};
 
-  static void copy(const T* src, T* dst, gt::size_type count)
+template <typename T>
+struct host_ops
+{
+  using value_type = T;
+  using pointer = T*;
+  using const_pointer = const T*;
+  using size_type = gt::size_type;
+
+  static void copy(const_pointer src, pointer dst, size_type count)
   {
-    std::memcpy(dst, src, count * sizeof(T));
+    std::memcpy(dst, src, sizeof(value_type) * count);
   }
 };
 

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -134,6 +134,11 @@ struct device_ops
   {
     device_copy_dd(src, dst, count);
   }
+
+  static void copy_dh(const_pointer src, pointer dst, size_type count)
+  {
+    device_copy_dh(src, dst, count);
+  }
 };
 
 template <typename T>
@@ -297,6 +302,11 @@ struct device_ops
   {
     device_copy_dd(src, dst, count);
   }
+
+  static void copy_dh(const_pointer src, pointer dst, size_type count)
+  {
+    device_copy_dh(src, dst, count);
+  }
 };
 
 template <typename T>
@@ -434,6 +444,11 @@ struct device_ops
   static void copy(const_pointer src, pointer dst, size_type count)
   {
     device_copy_dd(src, dst, count);
+  }
+
+  static void copy_dh(const_pointer src, pointer dst, size_type count)
+  {
+    device_copy_dh(src, dst, count);
   }
 };
 

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -40,7 +40,7 @@ public:
   }
   gtensor_storage() : gtensor_storage(0) {}
 
-  ~gtensor_storage() { allocator_.deallocate(data_); }
+  ~gtensor_storage() { allocator_.deallocate(data_, capacity_); }
 
   // copy and move constructors
   gtensor_storage(const gtensor_storage& dv)
@@ -130,7 +130,7 @@ inline void gtensor_storage<T, A, O>::resize(
       size_type copy_size = std::min(size_, new_size);
       ops::copy(data_, new_data, copy_size);
     }
-    allocator_.deallocate(data_);
+    allocator_.deallocate(data_, capacity_);
     data_ = new_data;
     capacity_ = size_ = new_size;
   } else {

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -156,13 +156,19 @@ inline void gtensor_storage<T, A, O>::resize(
 // equality operators (for testing)
 
 template <typename T>
-host_storage<T>& host_mirror(const host_storage<T>& h)
+host_storage<T>& host_mirror(host_storage<T>& h)
 {
   return h;
 }
 
 template <typename T>
-void copy(const host_storage<T>& d, host_storage<T>& h)
+const host_storage<T>& host_mirror(const host_storage<T>& h)
+{
+  return h;
+}
+
+template <typename T>
+void copy(const host_storage<T>& d, const host_storage<T>& h)
 {
   // this copy is, at this time, only for use with host_mirror,
   // which return a reference to the very same object in the host
@@ -176,8 +182,12 @@ bool operator==(const host_storage<T>& v1, const host_storage<T>& v2)
   if (v1.size() != v2.size()) {
     return false;
   }
-  for (int i = 0; i < v1.size(); i++) {
-    if (v1[i] != v2[i]) {
+  auto&& h1 = host_mirror(v1);
+  auto&& h2 = host_mirror(v2);
+  copy(v1, h1);
+  copy(v2, h2);
+  for (int i = 0; i < h1.size(); i++) {
+    if (h1[i] != h2[i]) {
       return false;
     }
   }

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -35,12 +35,12 @@ public:
     : data_(nullptr), size_(count), capacity_(count)
   {
     if (capacity_ > 0) {
-      data_ = allocator_type::allocate(capacity_);
+      data_ = allocator_.allocate(capacity_);
     }
   }
   gtensor_storage() : gtensor_storage(0) {}
 
-  ~gtensor_storage() { allocator_type::deallocate(data_); }
+  ~gtensor_storage() { allocator_.deallocate(data_); }
 
   // copy and move constructors
   gtensor_storage(const gtensor_storage& dv)
@@ -101,6 +101,7 @@ private:
   pointer data_;
   size_type size_;
   size_type capacity_;
+  allocator_type allocator_;
 };
 
 #ifdef GTENSOR_HAVE_DEVICE
@@ -122,14 +123,14 @@ inline void gtensor_storage<T, A, O>::resize(
       return;
     }
     capacity_ = size_ = new_size;
-    data_ = allocator_type::allocate(capacity_);
+    data_ = allocator_.allocate(capacity_);
   } else if (new_size > capacity_) {
-    pointer new_data = allocator_type::allocate(new_size);
+    pointer new_data = allocator_.allocate(new_size);
     if (!discard && size_ > 0) {
       size_type copy_size = std::min(size_, new_size);
       ops::copy(data_, new_data, copy_size);
     }
-    allocator_type::deallocate(data_);
+    allocator_.deallocate(data_);
     data_ = new_data;
     capacity_ = size_ = new_size;
   } else {

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -179,6 +179,13 @@ host_storage<T> host_mirror(const device_storage<T>& d)
 }
 
 template <typename T>
+void copy(const device_storage<T>& d, host_storage<T>& h)
+{
+  assert(h.size() == d.size());
+  device_ops<T>::copy_dh(d.data(), h.data(), d.size());
+}
+
+template <typename T>
 bool operator==(const device_storage<T>& v1, const device_storage<T>& v2)
 {
   if (v1.size() != v2.size()) {
@@ -186,9 +193,9 @@ bool operator==(const device_storage<T>& v1, const device_storage<T>& v2)
   }
   auto&& h1 = host_mirror(v1);
   auto&& h2 = host_mirror(v2);
-  device_ops<T>::copy_dh(v1.data(), h1.data(), v1.size());
-  device_ops<T>::copy_dh(v2.data(), h2.data(), v2.size());
-  for (int i = 0; i < v1.size(); i++) {
+  copy(v1, h1);
+  copy(v2, h2);
+  for (int i = 0; i < h1.size(); i++) {
     if (h1[i] != h2[i]) {
       return false;
     }

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -182,8 +182,8 @@ bool operator==(
   }
   host_storage<T> h1(v1.size());
   host_storage<T> h2(v2.size());
-  device_copy_dh(v1.data(), h1.data(), v1.size());
-  device_copy_dh(v2.data(), h2.data(), v2.size());
+  device_ops<T>::copy_dh(v1.data(), h1.data(), v1.size());
+  device_ops<T>::copy_dh(v2.data(), h2.data(), v2.size());
   for (int i = 0; i < v1.size(); i++) {
     if (h1[i] != h2[i]) {
       return false;

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -171,8 +171,7 @@ void copy(const host_storage<T>& d, host_storage<T>& h)
 }
 
 template <typename T>
-bool operator==(const gtensor_storage<T, host_allocator<T>, host_ops<T>>& v1,
-                const gtensor_storage<T, host_allocator<T>, host_ops<T>>& v2)
+bool operator==(const host_storage<T>& v1, const host_storage<T>& v2)
 {
   if (v1.size() != v2.size()) {
     return false;

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -173,15 +173,19 @@ bool operator==(const gtensor_storage<T, host_allocator<T>, host_ops<T>>& v1,
 #ifdef GTENSOR_HAVE_DEVICE
 
 template <typename T>
-bool operator==(
-  const gtensor_storage<T, device_allocator<T>, device_ops<T>>& v1,
-  const gtensor_storage<T, device_allocator<T>, device_ops<T>>& v2)
+host_storage<T> host_mirror(const device_storage<T>& d)
+{
+  return host_storage<T>(d.size());
+}
+
+template <typename T>
+bool operator==(const device_storage<T>& v1, const device_storage<T>& v2)
 {
   if (v1.size() != v2.size()) {
     return false;
   }
-  host_storage<T> h1(v1.size());
-  host_storage<T> h2(v2.size());
+  auto&& h1 = host_mirror(v1);
+  auto&& h2 = host_mirror(v2);
   device_ops<T>::copy_dh(v1.data(), h1.data(), v1.size());
   device_ops<T>::copy_dh(v2.data(), h2.data(), v2.size());
   for (int i = 0; i < v1.size(); i++) {

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -156,6 +156,21 @@ inline void gtensor_storage<T, A, O>::resize(
 // equality operators (for testing)
 
 template <typename T>
+host_storage<T>& host_mirror(const host_storage<T>& h)
+{
+  return h;
+}
+
+template <typename T>
+void copy(const host_storage<T>& d, host_storage<T>& h)
+{
+  // this copy is, at this time, only for use with host_mirror,
+  // which return a reference to the very same object in the host
+  // case
+  assert(&h == &d);
+}
+
+template <typename T>
 bool operator==(const gtensor_storage<T, host_allocator<T>, host_ops<T>>& v1,
                 const gtensor_storage<T, host_allocator<T>, host_ops<T>>& v2)
 {
@@ -214,6 +229,6 @@ bool operator!=(const gtensor_storage<T, A, O>& v1,
 
 } // end namespace backend
 
-} // end namespace gt
+} // namespace gt
 
 #endif // GTENSOR_DEVICE_STORAGE_H

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -106,20 +106,6 @@ private:
 #ifdef GTENSOR_HAVE_DEVICE
 
 template <typename T>
-struct device_ops
-{
-  using value_type = T;
-  using pointer = T*;
-  using const_pointer = const T*;
-  using size_type = gt::size_type;
-
-  static void copy(const_pointer src, pointer dest, size_type count)
-  {
-    return device_allocator<T>::copy(src, dest, count);
-  }
-};
-
-template <typename T>
 using device_storage = gtensor_storage<T, device_allocator<T>, device_ops<T>>;
 
 #endif

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -176,24 +176,6 @@ void copy(const host_storage<T>& d, const host_storage<T>& h)
   assert(&h == &d);
 }
 
-template <typename T>
-bool operator==(const host_storage<T>& v1, const host_storage<T>& v2)
-{
-  if (v1.size() != v2.size()) {
-    return false;
-  }
-  auto&& h1 = host_mirror(v1);
-  auto&& h2 = host_mirror(v2);
-  copy(v1, h1);
-  copy(v2, h2);
-  for (int i = 0; i < h1.size(); i++) {
-    if (h1[i] != h2[i]) {
-      return false;
-    }
-  }
-  return true;
-}
-
 #ifdef GTENSOR_HAVE_DEVICE
 
 template <typename T>
@@ -209,8 +191,11 @@ void copy(const device_storage<T>& d, host_storage<T>& h)
   device_ops<T>::copy_dh(d.data(), h.data(), d.size());
 }
 
-template <typename T>
-bool operator==(const device_storage<T>& v1, const device_storage<T>& v2)
+#endif
+
+template <typename T, typename A, typename O>
+bool operator==(const gtensor_storage<T, A, O>& v1,
+                const gtensor_storage<T, A, O>& v2)
 {
   if (v1.size() != v2.size()) {
     return false;
@@ -226,8 +211,6 @@ bool operator==(const device_storage<T>& v1, const device_storage<T>& v2)
   }
   return true;
 }
-
-#endif
 
 template <typename T, typename A, typename O>
 bool operator!=(const gtensor_storage<T, A, O>& v1,

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -125,20 +125,6 @@ using device_storage = gtensor_storage<T, device_allocator<T>, device_ops<T>>;
 #endif
 
 template <typename T>
-struct host_ops
-{
-  using value_type = T;
-  using pointer = T*;
-  using const_pointer = const T*;
-  using size_type = gt::size_type;
-
-  static void copy(const_pointer src, pointer dest, size_type count)
-  {
-    return host_allocator<T>::copy(src, dest, count);
-  }
-};
-
-template <typename T>
 using host_storage = gtensor_storage<T, host_allocator<T>, host_ops<T>>;
 
 template <typename T, typename A, typename O>

--- a/include/gtensor/space.h
+++ b/include/gtensor/space.h
@@ -20,6 +20,9 @@
 namespace gt
 {
 
+namespace allocator
+{
+
 // ======================================================================
 // caching_allocator
 
@@ -128,8 +131,6 @@ inline bool operator!=(const caching_allocator<T, AT>& a,
   return !(a == b);
 }
 
-namespace allocator
-{
 #ifdef GTENSOR_HAVE_DEVICE
 #ifdef GTENSOR_USE_THRUST
 
@@ -144,6 +145,7 @@ using device_allocator = caching_allocator<T, thrust::device_allocator<T>>;
 
 #endif
 #endif
+
 } // namespace allocator
 
 // ======================================================================

--- a/include/gtensor/space.h
+++ b/include/gtensor/space.h
@@ -128,6 +128,24 @@ inline bool operator!=(const caching_allocator<T, AT>& a,
   return !(a == b);
 }
 
+namespace allocator
+{
+#ifdef GTENSOR_HAVE_DEVICE
+#ifdef GTENSOR_USE_THRUST
+
+#if GTENSOR_DEVICE_CUDA && THRUST_VERSION <= 100903
+template <typename T>
+using device_allocator =
+  caching_allocator<T, thrust::device_malloc_allocator<T>>;
+#else
+template <typename T>
+using device_allocator = caching_allocator<T, thrust::device_allocator<T>>;
+#endif
+
+#endif
+#endif
+} // namespace allocator
+
 // ======================================================================
 // space
 
@@ -154,19 +172,10 @@ struct host
 
 #ifdef GTENSOR_USE_THRUST
 
-#if GTENSOR_DEVICE_CUDA && THRUST_VERSION <= 100903
-template <typename T>
-using device_allocator =
-  caching_allocator<T, thrust::device_malloc_allocator<T>>;
-#else
-template <typename T>
-using device_allocator = caching_allocator<T, thrust::device_allocator<T>>;
-#endif
-
 struct device
 {
   template <typename T>
-  using Vector = thrust::device_vector<T, device_allocator<T>>;
+  using Vector = thrust::device_vector<T, gt::allocator::device_allocator<T>>;
   template <typename T>
   using Span = device_span<T>;
 };

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -36,32 +36,32 @@ uint32_t gt_backend_device_get_vendor_id(int device_id)
 
 void* gt_backend_host_allocate(size_t nbytes)
 {
-  return (void*)gt::backend::host_allocator<uint8_t>::allocate(nbytes);
+  return (void*)gt::backend::host_allocator<uint8_t>{}.allocate(nbytes);
 }
 
 void* gt_backend_device_allocate(size_t nbytes)
 {
-  return (void*)gt::backend::device_allocator<uint8_t>::allocate(nbytes);
+  return (void*)gt::backend::device_allocator<uint8_t>{}.allocate(nbytes);
 }
 
 void* gt_backend_managed_allocate(size_t nbytes)
 {
-  return (void*)gt::backend::managed_allocator<uint8_t>::allocate(nbytes);
+  return (void*)gt::backend::managed_allocator<uint8_t>{}.allocate(nbytes);
 }
 
 void gt_backend_host_deallocate(void* p)
 {
-  gt::backend::host_allocator<uint8_t>::deallocate((uint8_t*)p);
+  gt::backend::host_allocator<uint8_t>{}.deallocate((uint8_t*)p);
 }
 
 void gt_backend_device_deallocate(void* p)
 {
-  gt::backend::device_allocator<uint8_t>::deallocate((uint8_t*)p);
+  gt::backend::device_allocator<uint8_t>{}.deallocate((uint8_t*)p);
 }
 
 void gt_backend_managed_deallocate(void* p)
 {
-  gt::backend::managed_allocator<uint8_t>::deallocate((uint8_t*)p);
+  gt::backend::managed_allocator<uint8_t>{}.deallocate((uint8_t*)p);
 }
 
 void gt_backend_memcpy_hh(void* dst, const void* src, size_t nbytes)

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -36,32 +36,32 @@ uint32_t gt_backend_device_get_vendor_id(int device_id)
 
 void* gt_backend_host_allocate(size_t nbytes)
 {
-  return (void*)gt::backend::host_allocator<uint8_t>{}.allocate(nbytes);
+  return (void*)gt::backend::ops<uint8_t>::host::allocate(nbytes);
 }
 
 void* gt_backend_device_allocate(size_t nbytes)
 {
-  return (void*)gt::backend::device_allocator<uint8_t>{}.allocate(nbytes);
+  return (void*)gt::backend::ops<uint8_t>::device::allocate(nbytes);
 }
 
 void* gt_backend_managed_allocate(size_t nbytes)
 {
-  return (void*)gt::backend::managed_allocator<uint8_t>{}.allocate(nbytes);
+  return (void*)gt::backend::ops<uint8_t>::managed::allocate(nbytes);
 }
 
 void gt_backend_host_deallocate(void* p)
 {
-  gt::backend::host_allocator<uint8_t>{}.deallocate((uint8_t*)p);
+  gt::backend::ops<uint8_t>::host::deallocate((uint8_t*)p);
 }
 
 void gt_backend_device_deallocate(void* p)
 {
-  gt::backend::device_allocator<uint8_t>{}.deallocate((uint8_t*)p);
+  gt::backend::ops<uint8_t>::device::deallocate((uint8_t*)p);
 }
 
 void gt_backend_managed_deallocate(void* p)
 {
-  gt::backend::managed_allocator<uint8_t>{}.deallocate((uint8_t*)p);
+  gt::backend::ops<uint8_t>::managed::deallocate((uint8_t*)p);
 }
 
 void gt_backend_memcpy_hh(void* dst, const void* src, size_t nbytes)

--- a/tests/test_adapt.cxx
+++ b/tests/test_adapt.cxx
@@ -12,7 +12,7 @@ TEST(adapt, adapt_complex)
   constexpr int M = 16;
   constexpr int S = N * M;
   using T = gt::complex<double>;
-  T* a = gt::backend::host_allocator<T>::allocate(S);
+  T* a = gt::backend::host_allocator<T>{}.allocate(S);
   auto gta = gt::adapt<2>(a, gt::shape(N, M));
 
   GT_DEBUG_TYPE(gta);
@@ -28,7 +28,7 @@ TEST(adapt, adapt_complex)
   EXPECT_EQ(a[0], (T{1., 1.}));
   EXPECT_EQ(a[S - 1], (T{1., -1.}));
 
-  gt::backend::host_allocator<T>::deallocate(a);
+  gt::backend::host_allocator<T>{}.deallocate(a);
 }
 
 #ifdef GTENSOR_HAVE_DEVICE
@@ -36,7 +36,7 @@ TEST(adapt, adapt_complex)
 TEST(adapt, adapt_device)
 {
   constexpr int N = 10;
-  int* a = gt::backend::device_allocator<int>::allocate(N);
+  int* a = gt::backend::device_allocator<int>{}.allocate(N);
   auto aview = gt::adapt_device(a, gt::shape(N));
 
   aview = gt::scalar(7);
@@ -49,7 +49,7 @@ TEST(adapt, adapt_device)
 
   EXPECT_EQ(aview, h_expected);
 
-  gt::backend::device_allocator<int>::deallocate(a);
+  gt::backend::device_allocator<int>{}.deallocate(a);
 }
 
 #endif // GTENSOR_HAVE_DEVICE

--- a/tests/test_adapt.cxx
+++ b/tests/test_adapt.cxx
@@ -28,7 +28,7 @@ TEST(adapt, adapt_complex)
   EXPECT_EQ(a[0], (T{1., 1.}));
   EXPECT_EQ(a[S - 1], (T{1., -1.}));
 
-  gt::backend::host_allocator<T>{}.deallocate(a);
+  gt::backend::host_allocator<T>{}.deallocate(a, S);
 }
 
 #ifdef GTENSOR_HAVE_DEVICE
@@ -49,7 +49,7 @@ TEST(adapt, adapt_device)
 
   EXPECT_EQ(aview, h_expected);
 
-  gt::backend::device_allocator<int>{}.deallocate(a);
+  gt::backend::device_allocator<int>{}.deallocate(a, N);
 }
 
 #endif // GTENSOR_HAVE_DEVICE

--- a/tests/test_device_backend.cxx
+++ b/tests/test_device_backend.cxx
@@ -36,7 +36,7 @@ TEST(device_backend, list_devices)
 #define N 10
 TEST(device_backend, managed_allocate)
 {
-  double* a = gt::backend::managed_allocator<double>::allocate(N);
+  double* a = gt::backend::managed_allocator<double>{}.allocate(N);
   for (int i = 0; i < N; i++) {
     a[i] = ((double)i) / N;
   }
@@ -46,7 +46,7 @@ TEST(device_backend, managed_allocate)
   for (int i = 0; i < N; i++) {
     EXPECT_EQ(a[i], 1.0 + ((double)i) / N);
   }
-  gt::backend::managed_allocator<double>::deallocate(a);
+  gt::backend::managed_allocator<double>{}.deallocate(a);
 }
 
 #endif

--- a/tests/test_device_backend.cxx
+++ b/tests/test_device_backend.cxx
@@ -46,7 +46,7 @@ TEST(device_backend, managed_allocate)
   for (int i = 0; i < N; i++) {
     EXPECT_EQ(a[i], 1.0 + ((double)i) / N);
   }
-  gt::backend::managed_allocator<double>{}.deallocate(a);
+  gt::backend::managed_allocator<double>{}.deallocate(a, N);
 }
 
 #endif

--- a/tests/test_device_backend.cxx
+++ b/tests/test_device_backend.cxx
@@ -36,7 +36,7 @@ TEST(device_backend, list_devices)
 #define N 10
 TEST(device_backend, managed_allocate)
 {
-  double* a = gt::backend::managed_allocator<double>{}.allocate(N);
+  double* a = gt::backend::ops<double>::managed::allocate(N);
   for (int i = 0; i < N; i++) {
     a[i] = ((double)i) / N;
   }
@@ -46,7 +46,7 @@ TEST(device_backend, managed_allocate)
   for (int i = 0; i < N; i++) {
     EXPECT_EQ(a[i], 1.0 + ((double)i) / N);
   }
-  gt::backend::managed_allocator<double>{}.deallocate(a, N);
+  gt::backend::ops<double>::managed::deallocate(a);
 }
 
 #endif


### PR DESCRIPTION
This is just part of some bigger revamp of things (which I haven't even completed).

My particular motivation was being able to support standard allocators not only in thrust but also gtensor_storage, so that whoever is using gtensor can choose their preferred pool allocator or whatever. However, it's not nearly there yet, instead it opened the opportunity to do some more not quite directly related refactoring.

In particular, I'd like to make `gtensor_storage` and `thrust::device/host_vector` more directly interchangeable, forming a separate layer from, e.g., the allocator. I'd also like to see `gtensor_storage`'s implementation to be less directly dependent on whether the underlying storage is on the host, the device, managed or whatever. For now, this PR makes things a bit more complicated by introducing an additional `ops` template arg that's designed to encode the things that are still dependent on host/device. Eventually, this should be able to be eliminated.

The other thing that this is starting is to make the code less `#ifdef` dependent -- e.g., there's no fundamental reason why we shouldn't be able to  support both thrust and gtensor_storage as the backend at the same time. This does work toward that by organizing some backend stuff into namespaces -- which actually won't be the final solution, since one cannot template by namespace, but it's somewhat of a step toward it.

In the "unification", I needed to make some code independent of the backend, so this is an opportunity to generally try out approaches to allow for writing truly "portable" code. I went with a `host_mirror` and `copy` approach, I believe pretty much what kokkos does. I'm not so sure that'll be my final preference, but it's non-invasive (it doesn't change existing behavior), and explicit.