### PR TITLE
more allocator-related reorg

### DIFF
--- a/benchmarks/ij_deriv.cxx
+++ b/benchmarks/ij_deriv.cxx
@@ -372,7 +372,7 @@ void test_ij_deriv(int li0, int lj0, int lbg0)
   h_coeff[3] = 2.0 / 3.0;
   h_coeff[4] = -1.0 / 12.0;
 
-  gt::backend::device_copy_hd(h_coeff, d_coeff, ncoeff);
+  gt::backend::ops<Real>::copy_hd(h_coeff, d_coeff, ncoeff);
 
 #define ARRIDX(a, b, c) (c * lj0 * lx0 + b * lx0 + a)
 
@@ -393,13 +393,13 @@ void test_ij_deriv(int li0, int lj0, int lbg0)
     }
   }
 
-  gt::backend::device_copy_hd(h_arr, d_arr, arr_size);
+  gt::backend::ops<Complex>::copy_hd(h_arr, d_arr, arr_size);
 
   for (j = 0; j < lj0; j++) {
     h_ikj[j] = Complex(0.0, (2.0 * j * pi));
   }
 
-  gt::backend::device_copy_hd(h_ikj, d_ikj, ikj_size);
+  gt::backend::ops<Complex>::copy_hd(h_ikj, d_ikj, ikj_size);
 
   // cpu reference
   for (int i = 0; i < time_warmup_count; i++) {

--- a/benchmarks/ij_deriv.cxx
+++ b/benchmarks/ij_deriv.cxx
@@ -372,7 +372,7 @@ void test_ij_deriv(int li0, int lj0, int lbg0)
   h_coeff[3] = 2.0 / 3.0;
   h_coeff[4] = -1.0 / 12.0;
 
-  gt::backend::ops<Real>::copy_hd(h_coeff, d_coeff, ncoeff);
+  gt::backend::ops::copy_hd(h_coeff, d_coeff, ncoeff);
 
 #define ARRIDX(a, b, c) (c * lj0 * lx0 + b * lx0 + a)
 
@@ -393,13 +393,13 @@ void test_ij_deriv(int li0, int lj0, int lbg0)
     }
   }
 
-  gt::backend::ops<Complex>::copy_hd(h_arr, d_arr, arr_size);
+  gt::backend::ops::copy_hd(h_arr, d_arr, arr_size);
 
   for (j = 0; j < lj0; j++) {
     h_ikj[j] = Complex(0.0, (2.0 * j * pi));
   }
 
-  gt::backend::ops<Complex>::copy_hd(h_ikj, d_ikj, ikj_size);
+  gt::backend::ops::copy_hd(h_ikj, d_ikj, ikj_size);
 
   // cpu reference
   for (int i = 0; i < time_warmup_count; i++) {

--- a/benchmarks/ij_deriv.cxx
+++ b/benchmarks/ij_deriv.cxx
@@ -372,7 +372,8 @@ void test_ij_deriv(int li0, int lj0, int lbg0)
   h_coeff[3] = 2.0 / 3.0;
   h_coeff[4] = -1.0 / 12.0;
 
-  gt::backend::ops::copy_hd(h_coeff, d_coeff, ncoeff);
+  gt::backend::ops::copy<gt::space::host, gt::space::device>(h_coeff, d_coeff,
+                                                             ncoeff);
 
 #define ARRIDX(a, b, c) (c * lj0 * lx0 + b * lx0 + a)
 
@@ -393,13 +394,15 @@ void test_ij_deriv(int li0, int lj0, int lbg0)
     }
   }
 
-  gt::backend::ops::copy_hd(h_arr, d_arr, arr_size);
+  gt::backend::ops::copy<gt::space::host, gt::space::device>(h_arr, d_arr,
+                                                             arr_size);
 
   for (j = 0; j < lj0; j++) {
     h_ikj[j] = Complex(0.0, (2.0 * j * pi));
   }
 
-  gt::backend::ops::copy_hd(h_ikj, d_ikj, ikj_size);
+  gt::backend::ops::copy<gt::space::host, gt::space::device>(h_ikj, d_ikj,
+                                                             ikj_size);
 
   // cpu reference
   for (int i = 0; i < time_warmup_count; i++) {
@@ -441,7 +444,8 @@ void test_ij_deriv(int li0, int lj0, int lbg0)
   printf("gt host seconds/run: %0.6f\n", seconds_per_run);
 
 #ifdef DEBUG_COMPARE
-  gt::backend::device_copy_dh(d_darr, h_darr, darr_size);
+  gt::backend::ops::copy<gt::space::device, gt::space::host>(d_darr, h_darr,
+                                                             darr_size);
   compare_deriv(&error, &maxError, &relError, &maxRelError, ref_darr, h_darr, 0,
                 li0, 0, lj0, 0, lbg0, 0, li0, lj0, lbg0, 2);
   printf("gt host diff[x]: %0.4e (max %0.4e) | rel %0.4e (max %0.4e)\n", error,
@@ -467,7 +471,8 @@ void test_ij_deriv(int li0, int lj0, int lbg0)
   printf("gpu     seconds/run: %0.6f\n", seconds_per_run);
 
 #ifdef DEBUG_COMPARE
-  gt::backend::device_copy_dh(d_darr, h_darr, darr_size);
+  gt::backend::ops::copy<gt::space::device, gt::space::host>(d_darr, h_darr,
+                                                             darr_size);
   compare_deriv(&error, &maxError, &relError, &maxRelError, ref_darr, h_darr, 0,
                 li0, 0, lj0, 0, lbg0, 0, li0, lj0, lbg0, 2);
   printf("gpu diff[x]: %0.4e (max %0.4e) | rel %0.4e (max %0.4e)\n", error,
@@ -493,7 +498,7 @@ void test_ij_deriv(int li0, int lj0, int lbg0)
   printf("gt gpu  seconds/run: %0.6f\n", seconds_per_run);
 
 #ifdef DEBUG_COMPARE
-  gt::backend::device_copy_dh(d_darr, h_darr, darr_size);
+  gt::backend::ops::copy<space::device, space::host>(d_darr, h_darr, darr_size);
   compare_deriv(&error, &maxError, &relError, &maxRelError, ref_darr, h_darr, 0,
                 li0, 0, lj0, 0, lbg0, 0, li0, lj0, lbg0, 2);
   printf("gt  diff[x]: %0.4e (max %0.4e) | rel %0.4e (max %0.4e)\n", error,

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -243,6 +243,17 @@ template <typename S_src, typename S_to>
 struct copy;
 
 template <>
+struct copy<space::device, space::device>
+{
+  template <typename T>
+  static void run(const T* src, T* dst, size_type count)
+  {
+    gtGpuCheck(
+      cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyDeviceToDevice));
+  }
+};
+
+template <>
 struct copy<space::device, space::host>
 {
   template <typename T>
@@ -259,6 +270,16 @@ struct copy<space::host, space::device>
   static void run(const T* src, T* dst, size_type count)
   {
     gtGpuCheck(cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyHostToDevice));
+  }
+};
+
+template <>
+struct copy<space::host, space::host>
+{
+  template <typename T>
+  static void run(const T* src, T* dst, size_type count)
+  {
+    gtGpuCheck(cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyHostToHost));
   }
 };
 
@@ -282,13 +303,6 @@ struct ops
     static void deallocate(T* p)
     {
       gtGpuCheck(cudaFree(p));
-    }
-
-    template <typename T>
-    static void copy(const T* src, T* dst, size_type count)
-    {
-      gtGpuCheck(
-        cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyDeviceToDevice));
     }
   };
 
@@ -324,12 +338,6 @@ struct ops
     {
       gtGpuCheck(cudaFreeHost(p));
     }
-
-    template <typename T>
-    static void copy(const T* src, T* dst, size_type count)
-    {
-      gtGpuCheck(cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyHostToHost));
-    }
   };
 
   template <typename S_src, typename S_to, typename T>
@@ -364,6 +372,16 @@ template <typename S_src, typename S_to>
 struct copy;
 
 template <>
+struct copy<space::device, space::device>
+{
+  template <typename T>
+  static void run(const T* src, T* dst, size_type count)
+  {
+    gtGpuCheck(hipMemcpy(dst, src, sizeof(T) * count, hipMemcpyDeviceToDevice));
+  }
+};
+
+template <>
 struct copy<space::device, space::host>
 {
   template <typename T>
@@ -380,6 +398,16 @@ struct copy<space::host, space::device>
   static void run(const T* src, T* dst, size_type count)
   {
     gtGpuCheck(hipMemcpy(dst, src, sizeof(T) * count, hipMemcpyHostToDevice));
+  }
+};
+
+template <>
+struct copy<space::host, space::host>
+{
+  template <typename T>
+  static void run(const T* src, T* dst, size_type count)
+  {
+    gtGpuCheck(hipMemcpy(dst, src, sizeof(T) * count, hipMemcpyHostToHost));
   }
 };
 
@@ -436,13 +464,6 @@ struct ops
     {
       gtGpuCheck(hipHostFree(p));
     }
-
-    template <typename T>
-    static void copy(const_pointer src, pointer dst, size_type count)
-    {
-      gtGpuCheck(
-        hipMemcpy(dst, src, sizeof(T) * count, hipMemcpyDeviceToDevice));
-    }
   };
 
   template <typename S_src, typename S_to, typename T>
@@ -477,6 +498,16 @@ template <typename S_src, typename S_to>
 struct copy;
 
 template <>
+struct copy<space::device, space::device>
+{
+  template <typename T>
+  static void run(const T* src, T* dst, size_type count)
+  {
+    device_copy(src, dst, count);
+  }
+};
+
+template <>
 struct copy<space::device, space::host>
 {
   template <typename T>
@@ -488,6 +519,16 @@ struct copy<space::device, space::host>
 
 template <>
 struct copy<space::host, space::device>
+{
+  template <typename T>
+  static void run(const T* src, T* dst, size_type count)
+  {
+    device_copy(src, dst, count);
+  }
+};
+
+template <>
+struct copy<space::host, space::host>
 {
   template <typename T>
   static void run(const T* src, T* dst, size_type count)
@@ -512,12 +553,6 @@ struct ops
     static void deallocate(T* p)
     {
       cl::sycl::free(p, gt::backend::sycl::get_queue());
-    }
-
-    template <typename T>
-    static void copy(const_pointer src, pointer dst, size_type count)
-    {
-      device_copy(src, dst, count);
     }
   };
 
@@ -557,12 +592,6 @@ struct ops
     static void deallocate(T* p)
     {
       free(p);
-    }
-
-    template <typename T>
-    static void copy(const_pointer src, pointer dst, size_type count)
-    {
-      device_copy(src, dst, count);
     }
   };
 

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -88,12 +88,6 @@ inline void device_copy_async_dd(const T* src, T* dst, gt::size_type count)
 }
 
 template <typename T>
-inline void device_copy_dh(const T* src, T* dst, gt::size_type count)
-{
-  gtGpuCheck(cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyDeviceToHost));
-}
-
-template <typename T>
 inline void device_copy_hd(const T* src, T* dst, gt::size_type count)
 {
   gtGpuCheck(cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyHostToDevice));
@@ -162,13 +156,6 @@ inline void device_copy_async_dd(const T* src, T* dst, gt::size_type count)
   gtGpuCheck(
     hipMemcpyAsync(dst, src, sizeof(T) * count, hipMemcpyDeviceToDevice));
 }
-
-template <typename T>
-inline void device_copy_dh(const T* src, T* dst, gt::size_type count)
-{
-  gtGpuCheck(hipMemcpy(dst, src, sizeof(T) * count, hipMemcpyDeviceToHost));
-}
-
 template <typename T>
 inline void device_copy_hd(const T* src, T* dst, gt::size_type count)
 {
@@ -213,12 +200,6 @@ inline void device_copy_async_dd(const T* src, T* dst, gt::size_type count)
 {
   cl::sycl::queue& q = gt::backend::sycl::get_queue();
   q.memcpy(dst, src, sizeof(T) * count);
-}
-
-template <typename T>
-inline void device_copy_dh(const T* src, T* dst, gt::size_type count)
-{
-  device_copy(src, dst, count);
 }
 
 template <typename T>
@@ -349,7 +330,7 @@ struct ops
 
   static void copy_dh(const T* src, T* dst, size_type count)
   {
-    device_copy_dh(src, dst, count);
+    gtGpuCheck(cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyDeviceToHost));
   }
 };
 
@@ -417,7 +398,7 @@ struct ops
 
   static void copy_dh(const T* src, const T* dst, size_type count)
   {
-    device_copy_dh(src, dst, count);
+    gtGpuCheck(hipMemcpy(dst, src, sizeof(T) * count, hipMemcpyHostToDevice));
   }
 };
 
@@ -513,9 +494,9 @@ struct ops
 
   static void copy_dh(const T* src, const T* dst, size_type count)
   {
-    device_copy_dh(src, dst, count);
+    device_copy(src, dst, count);
   }
-}; // namespace sycl
+};
 
 template <typename T>
 using device_allocator = wrap_allocator<T, typename ops<T>::device>;

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -276,7 +276,7 @@ struct copy<space::host, space::host>
 
 } // namespace detail
 
-struct ops
+struct gallocator
 {
   using size_type = gt::size_type;
 
@@ -330,7 +330,10 @@ struct ops
       gtGpuCheck(cudaFreeHost(p));
     }
   };
+};
 
+struct ops
+{
   template <typename S_src, typename S_to, typename T>
   static void copy(const T* src, T* dst, gt::size_type count)
   {
@@ -339,10 +342,10 @@ struct ops
 };
 
 template <typename T>
-using device_allocator = wrap_allocator<T, typename ops::device>;
+using device_allocator = wrap_allocator<T, typename gallocator::device>;
 
 template <typename T>
-using host_allocator = wrap_allocator<T, typename ops::host>;
+using host_allocator = wrap_allocator<T, typename gallocator::host>;
 
 } // namespace cuda
 
@@ -404,7 +407,7 @@ struct copy<space::host, space::host>
 
 } // namespace detail
 
-struct ops
+struct gallocator
 {
   struct device
   {
@@ -456,7 +459,10 @@ struct ops
       gtGpuCheck(hipHostFree(p));
     }
   };
+};
 
+struct ops
+{
   template <typename S_src, typename S_to, typename T>
   static void copy(const T* src, T* dst, gt::size_type count)
   {
@@ -465,10 +471,10 @@ struct ops
 };
 
 template <typename T>
-using device_allocator = wrap_allocator<T, typename ops::device>;
+using device_allocator = wrap_allocator<T, typename gallocator::device>;
 
 template <typename T>
-using host_allocator = wrap_allocator<T, typename ops::host>;
+using host_allocator = wrap_allocator<T, typename gallocator::host>;
 
 } // namespace hip
 
@@ -500,7 +506,7 @@ struct copy
 
 } // namespace detail
 
-struct ops
+struct gallocator
 {
   struct device
   {
@@ -569,7 +575,10 @@ struct ops
   //     cl::sycl::free(p, gt::backend::sycl::get_queue());
   //   }
   // };
+};
 
+struct ops
+{
   template <typename S_src, typename S_to, typename T>
   static void copy(const T* src, T* dst, gt::size_type count)
   {
@@ -578,10 +587,10 @@ struct ops
 };
 
 template <typename T>
-using device_allocator = wrap_allocator<T, typename ops::device>;
+using device_allocator = wrap_allocator<T, typename gallocator::device>;
 
 template <typename T>
-using host_allocator = wrap_allocator<T, typename ops::host>;
+using host_allocator = wrap_allocator<T, typename gallocator::host>;
 
 } // namespace sycl
 

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -69,12 +69,6 @@ inline uint32_t device_get_vendor_id(int device_id)
 }
 
 template <typename T>
-inline void device_copy_hh(const T* src, T* dst, gt::size_type count)
-{
-  gtGpuCheck(cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyHostToHost));
-}
-
-template <typename T>
 inline void device_copy_async_dd(const T* src, T* dst, gt::size_type count)
 {
   gtGpuCheck(
@@ -127,12 +121,6 @@ inline uint32_t device_get_vendor_id(int device_id)
 }
 
 template <typename T>
-inline void device_copy_hh(const T* src, T* dst, gt::size_type count)
-{
-  gtGpuCheck(hipMemcpy(dst, src, sizeof(T) * count, hipMemcpyHostToHost));
-}
-
-template <typename T>
 inline void device_copy_async_dd(const T* src, T* dst, gt::size_type count)
 {
   gtGpuCheck(
@@ -158,12 +146,6 @@ inline void device_copy(const T* src, T* dst, gt::size_type count)
   cl::sycl::queue& q = gt::backend::sycl::get_queue();
   q.memcpy(dst, src, sizeof(T) * count);
   q.wait();
-}
-
-template <typename T>
-inline void device_copy_hh(const T* src, T* dst, gt::size_type count)
-{
-  device_copy(src, dst, count);
 }
 
 template <typename T>
@@ -290,7 +272,7 @@ struct ops
 
     static void copy(const T* src, T* dst, size_type count)
     {
-      device_copy_hh(src, dst, count);
+      gtGpuCheck(cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyHostToHost));
     }
   };
 
@@ -451,7 +433,7 @@ struct ops
 
     static void copy(const_pointer src, pointer dst, size_type count)
     {
-      std::memcpy(dst, src, sizeof(value_type) * count);
+      device_copy(src, dst, count);
     }
   };
 

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -75,12 +75,6 @@ inline void device_copy_hh(const T* src, T* dst, gt::size_type count)
 }
 
 template <typename T>
-inline void device_copy_dd(const T* src, T* dst, gt::size_type count)
-{
-  gtGpuCheck(cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyDeviceToDevice));
-}
-
-template <typename T>
 inline void device_copy_async_dd(const T* src, T* dst, gt::size_type count)
 {
   gtGpuCheck(
@@ -145,12 +139,6 @@ inline void device_copy_hh(const T* src, T* dst, gt::size_type count)
 }
 
 template <typename T>
-inline void device_copy_dd(const T* src, T* dst, gt::size_type count)
-{
-  gtGpuCheck(hipMemcpy(dst, src, sizeof(T) * count, hipMemcpyDeviceToDevice));
-}
-
-template <typename T>
 inline void device_copy_async_dd(const T* src, T* dst, gt::size_type count)
 {
   gtGpuCheck(
@@ -185,12 +173,6 @@ inline void device_copy(const T* src, T* dst, gt::size_type count)
 
 template <typename T>
 inline void device_copy_hh(const T* src, T* dst, gt::size_type count)
-{
-  device_copy(src, dst, count);
-}
-
-template <typename T>
-inline void device_copy_dd(const T* src, T* dst, gt::size_type count)
 {
   device_copy(src, dst, count);
 }
@@ -295,7 +277,8 @@ struct ops
 
     static void copy(const T* src, T* dst, size_type count)
     {
-      device_copy_dd(src, dst, count);
+      gtGpuCheck(
+        cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyDeviceToDevice));
     }
   };
 
@@ -392,7 +375,8 @@ struct ops
 
     static void copy(const_pointer src, pointer dst, size_type count)
     {
-      device_copy_hh(src, dst, count);
+      gtGpuCheck(
+        hipMemcpy(dst, src, sizeof(T) * count, hipMemcpyDeviceToDevice));
     }
   };
 
@@ -437,7 +421,7 @@ struct ops
 
     static void copy(const_pointer src, pointer dst, size_type count)
     {
-      device_copy_dd(src, dst, count);
+      device_copy(src, dst, count);
     }
   };
 

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -152,15 +152,6 @@ inline void device_synchronize()
   gt::backend::sycl::get_queue().wait();
 }
 
-// TODO: SYCL exception handler
-template <typename T>
-inline void device_copy(const T* src, T* dst, gt::size_type count)
-{
-  cl::sycl::queue& q = gt::backend::sycl::get_queue();
-  q.memcpy(dst, src, sizeof(T) * count);
-  q.wait();
-}
-
 template <typename T>
 inline void device_copy_async_dd(const T* src, T* dst, gt::size_type count)
 {
@@ -495,45 +486,15 @@ namespace detail
 {
 
 template <typename S_src, typename S_to>
-struct copy;
-
-template <>
-struct copy<space::device, space::device>
+struct copy
 {
+  // TODO: SYCL exception handler
   template <typename T>
   static void run(const T* src, T* dst, size_type count)
   {
-    device_copy(src, dst, count);
-  }
-};
-
-template <>
-struct copy<space::device, space::host>
-{
-  template <typename T>
-  static void run(const T* src, T* dst, size_type count)
-  {
-    device_copy(src, dst, count);
-  }
-};
-
-template <>
-struct copy<space::host, space::device>
-{
-  template <typename T>
-  static void run(const T* src, T* dst, size_type count)
-  {
-    device_copy(src, dst, count);
-  }
-};
-
-template <>
-struct copy<space::host, space::host>
-{
-  template <typename T>
-  static void run(const T* src, T* dst, size_type count)
-  {
-    device_copy(src, dst, count);
+    cl::sycl::queue& q = gt::backend::sycl::get_queue();
+    q.memcpy(dst, src, sizeof(T) * count);
+    q.wait();
   }
 };
 

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -104,20 +104,6 @@ inline void device_memset(void* dst, int value, gt::size_type nbytes)
   gtGpuCheck(cudaMemset(dst, value, nbytes));
 }
 
-template <typename T>
-struct device_ops
-{
-  using value_type = T;
-  using pointer = T*;
-  using const_pointer = const T*;
-  using size_type = gt::size_type;
-
-  static void copy_dh(const_pointer src, pointer dst, size_type count)
-  {
-    device_copy_dh(src, dst, count);
-  }
-};
-
 #elif defined(GTENSOR_DEVICE_HIP)
 
 inline void device_synchronize()
@@ -194,20 +180,6 @@ inline void device_memset(void* dst, int value, gt::size_type nbytes)
   gtGpuCheck(hipMemset(dst, value, nbytes));
 }
 
-template <typename T>
-struct device_ops
-{
-  using value_type = T;
-  using pointer = T*;
-  using const_pointer = const T*;
-  using size_type = gt::size_type;
-
-  static void copy_dh(const_pointer src, pointer dst, size_type count)
-  {
-    device_copy_dh(src, dst, count);
-  }
-};
-
 #elif defined(GTENSOR_DEVICE_SYCL)
 
 inline void device_synchronize()
@@ -260,20 +232,6 @@ inline void device_memset(void* dst, int value, gt::size_type nbytes)
   cl::sycl::queue& q = gt::backend::sycl::get_queue();
   q.memset(dst, value, nbytes);
 }
-
-template <typename T>
-struct device_ops
-{
-  using value_type = T;
-  using pointer = T*;
-  using const_pointer = const T*;
-  using size_type = gt::size_type;
-
-  static void copy_dh(const_pointer src, pointer dst, size_type count)
-  {
-    device_copy_dh(src, dst, count);
-  }
-};
 
 #endif // GTENSOR_DEVICE_{CUDA,HIP,SYCL}
 
@@ -388,6 +346,11 @@ struct ops
       device_copy_hh(src, dst, count);
     }
   };
+
+  static void copy_dh(const T* src, T* dst, size_type count)
+  {
+    device_copy_dh(src, dst, count);
+  }
 };
 
 template <typename T>
@@ -451,6 +414,11 @@ struct ops
       device_copy_hh(src, dst, count);
     }
   };
+
+  static void copy_dh(const T* src, const T* dst, size_type count)
+  {
+    device_copy_dh(src, dst, count);
+  }
 };
 
 template <typename T>
@@ -543,6 +511,10 @@ struct ops
   //   }
   // };
 
+  static void copy_dh(const T* src, const T* dst, size_type count)
+  {
+    device_copy_dh(src, dst, count);
+  }
 }; // namespace sycl
 
 template <typename T>

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -81,12 +81,6 @@ inline void device_copy_async_dd(const T* src, T* dst, gt::size_type count)
     cudaMemcpyAsync(dst, src, sizeof(T) * count, cudaMemcpyDeviceToDevice));
 }
 
-template <typename T>
-inline void device_copy_hd(const T* src, T* dst, gt::size_type count)
-{
-  gtGpuCheck(cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyHostToDevice));
-}
-
 inline void device_memset(void* dst, int value, gt::size_type nbytes)
 {
   gtGpuCheck(cudaMemset(dst, value, nbytes));
@@ -144,11 +138,6 @@ inline void device_copy_async_dd(const T* src, T* dst, gt::size_type count)
   gtGpuCheck(
     hipMemcpyAsync(dst, src, sizeof(T) * count, hipMemcpyDeviceToDevice));
 }
-template <typename T>
-inline void device_copy_hd(const T* src, T* dst, gt::size_type count)
-{
-  gtGpuCheck(hipMemcpy(dst, src, sizeof(T) * count, hipMemcpyHostToDevice));
-}
 
 inline void device_memset(void* dst, int value, gt::size_type nbytes)
 {
@@ -182,12 +171,6 @@ inline void device_copy_async_dd(const T* src, T* dst, gt::size_type count)
 {
   cl::sycl::queue& q = gt::backend::sycl::get_queue();
   q.memcpy(dst, src, sizeof(T) * count);
-}
-
-template <typename T>
-inline void device_copy_hd(const T* src, T* dst, gt::size_type count)
-{
-  device_copy(src, dst, count);
 }
 
 inline void device_memset(void* dst, int value, gt::size_type nbytes)
@@ -315,6 +298,11 @@ struct ops
   {
     gtGpuCheck(cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyDeviceToHost));
   }
+
+  static void copy_hd(const T* src, T* dst, gt::size_type count)
+  {
+    gtGpuCheck(cudaMemcpy(dst, src, sizeof(T) * count, cudaMemcpyHostToDevice));
+  }
 };
 
 template <typename T>
@@ -381,6 +369,11 @@ struct ops
   };
 
   static void copy_dh(const T* src, const T* dst, size_type count)
+  {
+    gtGpuCheck(hipMemcpy(dst, src, sizeof(T) * count, hipMemcpyHostToDevice));
+  }
+
+  static void copy_hd(const T* src, T* dst, gt::size_type count)
   {
     gtGpuCheck(hipMemcpy(dst, src, sizeof(T) * count, hipMemcpyHostToDevice));
   }
@@ -477,6 +470,11 @@ struct ops
   // };
 
   static void copy_dh(const T* src, const T* dst, size_type count)
+  {
+    device_copy(src, dst, count);
+  }
+
+  static void copy_hd(const T* src, const T* dst, size_type count)
   {
     device_copy(src, dst, count);
   }

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -276,62 +276,6 @@ struct copy<space::host, space::host>
 
 } // namespace detail
 
-struct gallocator
-{
-  using size_type = gt::size_type;
-
-  struct device
-  {
-    template <typename T>
-    static T* allocate(size_type n)
-    {
-      T* p;
-      gtGpuCheck(cudaMalloc(&p, sizeof(T) * n));
-      return p;
-    }
-
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      gtGpuCheck(cudaFree(p));
-    }
-  };
-
-  struct managed
-  {
-    template <typename T>
-    static T* allocate(size_t n)
-    {
-      T* p;
-      gtGpuCheck(cudaMallocManaged(&p, sizeof(T) * n));
-      return p;
-    }
-
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      gtGpuCheck(cudaFree(p));
-    }
-  };
-
-  struct host
-  {
-    template <typename T>
-    static T* allocate(size_type n)
-    {
-      T* p;
-      gtGpuCheck(cudaMallocHost(&p, sizeof(T) * n));
-      return p;
-    }
-
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      gtGpuCheck(cudaFreeHost(p));
-    }
-  };
-};
-
 struct ops
 {
   template <typename S_src, typename S_to, typename T>
@@ -340,6 +284,63 @@ struct ops
     return detail::copy<S_src, S_to>::run(src, dst, count);
   }
 };
+
+namespace gallocator
+{
+using size_type = gt::size_type;
+
+struct device
+{
+  template <typename T>
+  static T* allocate(size_type n)
+  {
+    T* p;
+    gtGpuCheck(cudaMalloc(&p, sizeof(T) * n));
+    return p;
+  }
+
+  template <typename T>
+  static void deallocate(T* p)
+  {
+    gtGpuCheck(cudaFree(p));
+  }
+};
+
+struct managed
+{
+  template <typename T>
+  static T* allocate(size_t n)
+  {
+    T* p;
+    gtGpuCheck(cudaMallocManaged(&p, sizeof(T) * n));
+    return p;
+  }
+
+  template <typename T>
+  static void deallocate(T* p)
+  {
+    gtGpuCheck(cudaFree(p));
+  }
+};
+
+struct host
+{
+  template <typename T>
+  static T* allocate(size_type n)
+  {
+    T* p;
+    gtGpuCheck(cudaMallocHost(&p, sizeof(T) * n));
+    return p;
+  }
+
+  template <typename T>
+  static void deallocate(T* p)
+  {
+    gtGpuCheck(cudaFreeHost(p));
+  }
+};
+
+} // namespace gallocator
 
 template <typename T>
 using device_allocator = wrap_allocator<T, typename gallocator::device>;
@@ -407,60 +408,6 @@ struct copy<space::host, space::host>
 
 } // namespace detail
 
-struct gallocator
-{
-  struct device
-  {
-    template <typename T>
-    static T* allocate(size_type n)
-    {
-      T* p;
-      gtGpuCheck(hipMalloc(&p, sizeof(T) * n));
-      return p;
-    }
-
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      gtGpuCheck(hipFree(p));
-    }
-  };
-
-  struct managed
-  {
-    template <typename T>
-    static T* allocate(size_t n)
-    {
-      T* p;
-      gtGpuCheck(hipMallocManaged(&p, sizeof(T) * n));
-      return p;
-    }
-
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      gtGpuCheck(hipFree(p));
-    }
-  };
-
-  struct host
-  {
-    template <typename T>
-    static T* allocate(size_type n)
-    {
-      T* p;
-      gtGpuCheck(hipHostMalloc(&p, sizeof(T) * n));
-      return p;
-    }
-
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      gtGpuCheck(hipHostFree(p));
-    }
-  };
-};
-
 struct ops
 {
   template <typename S_src, typename S_to, typename T>
@@ -469,6 +416,61 @@ struct ops
     return detail::copy<S_src, S_to>::run(src, dst, count);
   }
 };
+
+namespace gallocator
+{
+struct device
+{
+  template <typename T>
+  static T* allocate(size_type n)
+  {
+    T* p;
+    gtGpuCheck(hipMalloc(&p, sizeof(T) * n));
+    return p;
+  }
+
+  template <typename T>
+  static void deallocate(T* p)
+  {
+    gtGpuCheck(hipFree(p));
+  }
+};
+
+struct managed
+{
+  template <typename T>
+  static T* allocate(size_t n)
+  {
+    T* p;
+    gtGpuCheck(hipMallocManaged(&p, sizeof(T) * n));
+    return p;
+  }
+
+  template <typename T>
+  static void deallocate(T* p)
+  {
+    gtGpuCheck(hipFree(p));
+  }
+};
+
+struct host
+{
+  template <typename T>
+  static T* allocate(size_type n)
+  {
+    T* p;
+    gtGpuCheck(hipHostMalloc(&p, sizeof(T) * n));
+    return p;
+  }
+
+  template <typename T>
+  static void deallocate(T* p)
+  {
+    gtGpuCheck(hipHostFree(p));
+  }
+};
+
+} // namespace gallocator
 
 template <typename T>
 using device_allocator = wrap_allocator<T, typename gallocator::device>;
@@ -506,77 +508,6 @@ struct copy
 
 } // namespace detail
 
-struct gallocator
-{
-  struct device
-  {
-    template <typename T>
-    static T* allocate(size_type n)
-    {
-      return cl::sycl::malloc_shared<T>(n, gt::backend::sycl::get_queue());
-    }
-
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      cl::sycl::free(p, gt::backend::sycl::get_queue());
-    }
-  };
-
-  struct managed
-  {
-    template <typename T>
-    static T* allocate(size_t n)
-    {
-      return cl::sycl::malloc_shared<T>(n, gt::backend::sycl::get_queue());
-    }
-
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      cl::sycl::free(p, gt::backend::sycl::get_queue());
-    }
-  };
-
-  // The host allocation type in SYCL allows device code to directly access
-  // the data. This is generally not necessary or effecient for gtensor, so
-  // we opt for the same implementation as for the HOST device below.
-
-  struct host
-  {
-    template <typename T>
-    static T* allocate(size_type n)
-    {
-      T* p = static_cast<T*>(malloc(sizeof(T) * n));
-      if (!p) {
-        std::cerr << "host allocate failed" << std::endl;
-        std::abort();
-      }
-      return p;
-    }
-
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      free(p);
-    }
-  };
-
-  // template <typename T>
-  // struct host
-  // {
-  //   static T* allocate( : size_type count)
-  //   {
-  //     return cl::sycl::malloc_host<T>(count, gt::backend::sycl::get_queue());
-  //   }
-
-  //   static void deallocate(T* p)
-  //   {
-  //     cl::sycl::free(p, gt::backend::sycl::get_queue());
-  //   }
-  // };
-};
-
 struct ops
 {
   template <typename S_src, typename S_to, typename T>
@@ -585,6 +516,78 @@ struct ops
     return detail::copy<S_src, S_to>::run(src, dst, count);
   }
 };
+
+namespace gallocator
+{
+struct device
+{
+  template <typename T>
+  static T* allocate(size_type n)
+  {
+    return cl::sycl::malloc_shared<T>(n, gt::backend::sycl::get_queue());
+  }
+
+  template <typename T>
+  static void deallocate(T* p)
+  {
+    cl::sycl::free(p, gt::backend::sycl::get_queue());
+  }
+};
+
+struct managed
+{
+  template <typename T>
+  static T* allocate(size_t n)
+  {
+    return cl::sycl::malloc_shared<T>(n, gt::backend::sycl::get_queue());
+  }
+
+  template <typename T>
+  static void deallocate(T* p)
+  {
+    cl::sycl::free(p, gt::backend::sycl::get_queue());
+  }
+};
+
+// The host allocation type in SYCL allows device code to directly access
+// the data. This is generally not necessary or effecient for gtensor, so
+// we opt for the same implementation as for the HOST device below.
+
+struct host
+{
+  template <typename T>
+  static T* allocate(size_type n)
+  {
+    T* p = static_cast<T*>(malloc(sizeof(T) * n));
+    if (!p) {
+      std::cerr << "host allocate failed" << std::endl;
+      std::abort();
+    }
+    return p;
+  }
+
+  template <typename T>
+  static void deallocate(T* p)
+  {
+    free(p);
+  }
+};
+
+// template <typename T>
+// struct host
+// {
+//   static T* allocate( : size_type count)
+//   {
+//     return cl::sycl::malloc_host<T>(count, gt::backend::sycl::get_queue());
+//   }
+
+//   static void deallocate(T* p)
+//   {
+//     cl::sycl::free(p, gt::backend::sycl::get_queue());
+//   }
+// };
+
+} // namespace gallocator
 
 template <typename T>
 using device_allocator = wrap_allocator<T, typename gallocator::device>;

--- a/include/gtensor/device_copy.h
+++ b/include/gtensor/device_copy.h
@@ -88,7 +88,7 @@ struct copy<space::host, space::host>
   template <typename T>
   static void run(const T* src, T* dest, std::size_t count)
   {
-    gt::backend::device_copy_hh(src, dest, count);
+    gt::backend::ops<T>::host::copy(src, dest, count);
   }
 };
 

--- a/include/gtensor/device_copy.h
+++ b/include/gtensor/device_copy.h
@@ -78,7 +78,7 @@ struct copy<space::host, space::device>
   template <typename T>
   static void run(const T* src, T* dest, std::size_t count)
   {
-    gt::backend::device_copy_hd(src, dest, count);
+    gt::backend::ops<T>::copy_hd(src, dest, count);
   }
 };
 

--- a/include/gtensor/device_copy.h
+++ b/include/gtensor/device_copy.h
@@ -58,7 +58,7 @@ struct copy<space::device, space::host>
   template <typename T>
   static void run(const T* src, T* dest, std::size_t count)
   {
-    gt::backend::device_copy_dh(src, dest, count);
+    gt::backend::ops<T>::copy_dh(src, dest, count);
   }
 };
 

--- a/include/gtensor/device_copy.h
+++ b/include/gtensor/device_copy.h
@@ -68,7 +68,7 @@ struct copy<space::device, space::device>
   template <typename T>
   static void run(const T* src, T* dest, std::size_t count)
   {
-    gt::backend::device_copy_dd(src, dest, count);
+    gt::backend::ops<T>::device::copy(src, dest, count);
   }
 };
 

--- a/include/gtensor/device_copy.h
+++ b/include/gtensor/device_copy.h
@@ -46,58 +46,10 @@ inline void copy(thrust::device_ptr<const T> src, thrust::device_ptr<T> dest,
 
 #else // using gt::backend::device_storage
 
-namespace detail
-{
-
-template <typename S_from, typename S_to>
-struct copy;
-
-template <>
-struct copy<space::device, space::host>
-{
-  template <typename T>
-  static void run(const T* src, T* dest, std::size_t count)
-  {
-    gt::backend::ops<T>::copy_dh(src, dest, count);
-  }
-};
-
-template <>
-struct copy<space::device, space::device>
-{
-  template <typename T>
-  static void run(const T* src, T* dest, std::size_t count)
-  {
-    gt::backend::ops<T>::device::copy(src, dest, count);
-  }
-};
-
-template <>
-struct copy<space::host, space::device>
-{
-  template <typename T>
-  static void run(const T* src, T* dest, std::size_t count)
-  {
-    gt::backend::ops<T>::copy_hd(src, dest, count);
-  }
-};
-
-template <>
-struct copy<space::host, space::host>
-{
-  template <typename T>
-  static void run(const T* src, T* dest, std::size_t count)
-  {
-    gt::backend::ops<T>::host::copy(src, dest, count);
-  }
-};
-
-} // end namespace detail
-
 template <typename T, typename S_from, typename S_to>
 inline void copy(const T* src, T* dest, std::size_t count)
 {
-  detail::copy<S_from, S_to>::run(src, dest, count);
+  gt::backend::ops::copy<S_from, S_to>(src, dest, count);
 }
 
 #endif

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -107,12 +107,14 @@ private:
 #ifdef GTENSOR_HAVE_DEVICE
 
 template <typename T>
-using device_storage = gtensor_storage<T, device_allocator<T>, device_ops<T>>;
+using device_storage =
+  gtensor_storage<T, device_allocator<T>, typename ops<T>::device>;
 
 #endif
 
 template <typename T>
-using host_storage = gtensor_storage<T, host_allocator<T>, host_ops<T>>;
+using host_storage =
+  gtensor_storage<T, host_allocator<T>, typename ops<T>::host>;
 
 template <typename T, typename A, typename O>
 inline void gtensor_storage<T, A, O>::resize(

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -194,6 +194,13 @@ void copy(const device_storage<T>& d, host_storage<T>& h)
   ops<T>::copy_dh(d.data(), h.data(), d.size());
 }
 
+template <typename T>
+void copy(const host_storage<T>& h, device_storage<T>& d)
+{
+  assert(h.size() == d.size());
+  device_copy_hd(h.data(), d.data(), h.size());
+}
+
 #endif
 
 template <typename T, typename A, typename O>

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -198,7 +198,7 @@ template <typename T>
 void copy(const host_storage<T>& h, device_storage<T>& d)
 {
   assert(h.size() == d.size());
-  device_copy_hd(h.data(), d.data(), h.size());
+  ops<T>::copy_hd(h.data(), d.data(), h.size());
 }
 
 #endif

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -15,7 +15,7 @@ namespace backend
  * Note that this is a small subset of the features in thrust::device_vector.
  * In particular, iterators are not yet supported.
  */
-template <typename T, typename Allocator, typename Ops>
+template <typename T, typename Allocator, typename S>
 class gtensor_storage
 {
 public:
@@ -29,7 +29,7 @@ public:
   using const_reference =
     std::add_lvalue_reference_t<std::add_const_t<element_type>>;
   using size_type = gt::size_type;
-  using ops = Ops;
+  using space_type = S;
 
   gtensor_storage(size_type count)
     : data_(nullptr), size_(count), capacity_(count)
@@ -69,7 +69,7 @@ public:
     resize_discard(dv.size_);
 
     if (size_ > 0) {
-      ops::copy(dv.data_, data_, size_);
+      backend::ops::copy<space_type, space_type>(dv.data_, data_, size_);
     }
 
     return *this;
@@ -107,12 +107,12 @@ private:
 #ifdef GTENSOR_HAVE_DEVICE
 
 template <typename T>
-using device_storage = gtensor_storage<T, device_allocator<T>, ops::device>;
+using device_storage = gtensor_storage<T, device_allocator<T>, space::device>;
 
 #endif
 
 template <typename T>
-using host_storage = gtensor_storage<T, host_allocator<T>, ops::host>;
+using host_storage = gtensor_storage<T, host_allocator<T>, space::host>;
 
 template <typename T, typename A, typename O>
 inline void gtensor_storage<T, A, O>::resize(
@@ -128,7 +128,7 @@ inline void gtensor_storage<T, A, O>::resize(
     pointer new_data = allocator_.allocate(new_size);
     if (!discard && size_ > 0) {
       size_type copy_size = std::min(size_, new_size);
-      ops::copy(data_, new_data, copy_size);
+      backend::ops::copy<space_type, space_type>(data_, new_data, copy_size);
     }
     allocator_.deallocate(data_, capacity_);
     data_ = new_data;

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -191,7 +191,7 @@ template <typename T>
 void copy(const device_storage<T>& d, host_storage<T>& h)
 {
   assert(h.size() == d.size());
-  device_ops<T>::copy_dh(d.data(), h.data(), d.size());
+  ops<T>::copy_dh(d.data(), h.data(), d.size());
 }
 
 #endif

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -49,7 +49,7 @@ public:
     resize_discard(dv.size_);
 
     if (size_ > 0) {
-      ops::copy(dv.data_, data_, size_);
+      backend::ops::copy<space_type, space_type>(dv.data_, data_, size_);
     }
   }
 
@@ -189,14 +189,14 @@ template <typename T>
 void copy(const device_storage<T>& d, host_storage<T>& h)
 {
   assert(h.size() == d.size());
-  ops::copy_dh(d.data(), h.data(), d.size());
+  ops::copy<space::device, space::host>(d.data(), h.data(), d.size());
 }
 
 template <typename T>
 void copy(const host_storage<T>& h, device_storage<T>& d)
 {
   assert(h.size() == d.size());
-  ops::copy_hd(h.data(), d.data(), h.size());
+  ops::copy<space::host, space::device>(h.data(), d.data(), h.size());
 }
 
 #endif

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -107,14 +107,12 @@ private:
 #ifdef GTENSOR_HAVE_DEVICE
 
 template <typename T>
-using device_storage =
-  gtensor_storage<T, device_allocator<T>, typename ops<T>::device>;
+using device_storage = gtensor_storage<T, device_allocator<T>, ops::device>;
 
 #endif
 
 template <typename T>
-using host_storage =
-  gtensor_storage<T, host_allocator<T>, typename ops<T>::host>;
+using host_storage = gtensor_storage<T, host_allocator<T>, ops::host>;
 
 template <typename T, typename A, typename O>
 inline void gtensor_storage<T, A, O>::resize(
@@ -191,14 +189,14 @@ template <typename T>
 void copy(const device_storage<T>& d, host_storage<T>& h)
 {
   assert(h.size() == d.size());
-  ops<T>::copy_dh(d.data(), h.data(), d.size());
+  ops::copy_dh(d.data(), h.data(), d.size());
 }
 
 template <typename T>
 void copy(const host_storage<T>& h, device_storage<T>& d)
 {
   assert(h.size() == d.size());
-  ops<T>::copy_hd(h.data(), d.data(), h.size());
+  ops::copy_hd(h.data(), d.data(), h.size());
 }
 
 #endif

--- a/include/gtensor/memset.h
+++ b/include/gtensor/memset.h
@@ -27,7 +27,7 @@ template <>
 inline void memset<gt::space::device>(void* dst, int value,
                                       gt::size_type nbytes)
 {
-  device_memset(dst, value, nbytes);
+  gt::backend::ops::memset(dst, value, nbytes);
 }
 
 #endif

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -66,7 +66,7 @@ void gt_backend_managed_deallocate(void* p)
 
 void gt_backend_memcpy_hh(void* dst, const void* src, size_t nbytes)
 {
-  gt::backend::device_copy_hh<uint8_t>((uint8_t*)src, (uint8_t*)dst, nbytes);
+  gt::backend::ops<uint8_t>::host::copy((uint8_t*)src, (uint8_t*)dst, nbytes);
 }
 
 void gt_backend_memcpy_dd(void* dst, const void* src, size_t nbytes)

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -66,12 +66,14 @@ void gt_backend_managed_deallocate(void* p)
 
 void gt_backend_memcpy_hh(void* dst, const void* src, size_t nbytes)
 {
-  gt::backend::ops::host::copy((uint8_t*)src, (uint8_t*)dst, nbytes);
+  gt::backend::ops::copy<gt::space::host, gt::space::host>(
+    (uint8_t*)src, (uint8_t*)dst, nbytes);
 }
 
 void gt_backend_memcpy_dd(void* dst, const void* src, size_t nbytes)
 {
-  gt::backend::ops::device::copy((uint8_t*)src, (uint8_t*)dst, nbytes);
+  gt::backend::ops::copy<gt::space::device, gt::space::device>(
+    (uint8_t*)src, (uint8_t*)dst, nbytes);
 }
 
 void gt_backend_memcpy_async_dd(void* dst, const void* src, size_t nbytes)

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -36,32 +36,32 @@ uint32_t gt_backend_device_get_vendor_id(int device_id)
 
 void* gt_backend_host_allocate(size_t nbytes)
 {
-  return (void*)gt::backend::ops::host::allocate<uint8_t>(nbytes);
+  return (void*)gt::backend::gallocator::host::allocate<uint8_t>(nbytes);
 }
 
 void* gt_backend_device_allocate(size_t nbytes)
 {
-  return (void*)gt::backend::ops::device::allocate<uint8_t>(nbytes);
+  return (void*)gt::backend::gallocator::device::allocate<uint8_t>(nbytes);
 }
 
 void* gt_backend_managed_allocate(size_t nbytes)
 {
-  return (void*)gt::backend::ops::managed::allocate<uint8_t>(nbytes);
+  return (void*)gt::backend::gallocator::managed::allocate<uint8_t>(nbytes);
 }
 
 void gt_backend_host_deallocate(void* p)
 {
-  gt::backend::ops::host::deallocate((uint8_t*)p);
+  gt::backend::gallocator::host::deallocate((uint8_t*)p);
 }
 
 void gt_backend_device_deallocate(void* p)
 {
-  gt::backend::ops::device::deallocate((uint8_t*)p);
+  gt::backend::gallocator::device::deallocate((uint8_t*)p);
 }
 
 void gt_backend_managed_deallocate(void* p)
 {
-  gt::backend::ops::managed::deallocate((uint8_t*)p);
+  gt::backend::gallocator::managed::deallocate((uint8_t*)p);
 }
 
 void gt_backend_memcpy_hh(void* dst, const void* src, size_t nbytes)

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -82,7 +82,7 @@ void gt_backend_memcpy_async_dd(void* dst, const void* src, size_t nbytes)
 
 void gt_backend_memcpy_dh(void* dst, const void* src, size_t nbytes)
 {
-  gt::backend::device_copy_dh<uint8_t>((uint8_t*)src, (uint8_t*)dst, nbytes);
+  gt::backend::ops<uint8_t>::copy_dh((uint8_t*)src, (uint8_t*)dst, nbytes);
 }
 
 void gt_backend_memcpy_hd(void* dst, const void* src, size_t nbytes)

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -82,12 +82,14 @@ void gt_backend_memcpy_async_dd(void* dst, const void* src, size_t nbytes)
 
 void gt_backend_memcpy_dh(void* dst, const void* src, size_t nbytes)
 {
-  gt::backend::ops::copy_dh((uint8_t*)src, (uint8_t*)dst, nbytes);
+  gt::backend::ops::copy<gt::space::device, gt::space::host>(
+    (uint8_t*)src, (uint8_t*)dst, nbytes);
 }
 
 void gt_backend_memcpy_hd(void* dst, const void* src, size_t nbytes)
 {
-  gt::backend::ops::copy_hd((uint8_t*)src, (uint8_t*)dst, nbytes);
+  gt::backend::ops::copy<gt::space::host, gt::space::device>(
+    (uint8_t*)src, (uint8_t*)dst, nbytes);
 }
 
 void gt_backend_memset(void* dst, int value, size_t nbytes)

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -96,7 +96,7 @@ void gt_backend_memcpy_hd(void* dst, const void* src, size_t nbytes)
 
 void gt_backend_memset(void* dst, int value, size_t nbytes)
 {
-  gt::backend::device_memset(dst, value, nbytes);
+  gt::backend::ops::memset(dst, value, nbytes);
 }
 
 #endif

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -71,7 +71,7 @@ void gt_backend_memcpy_hh(void* dst, const void* src, size_t nbytes)
 
 void gt_backend_memcpy_dd(void* dst, const void* src, size_t nbytes)
 {
-  gt::backend::device_copy_dd<uint8_t>((uint8_t*)src, (uint8_t*)dst, nbytes);
+  gt::backend::ops<uint8_t>::device::copy((uint8_t*)src, (uint8_t*)dst, nbytes);
 }
 
 void gt_backend_memcpy_async_dd(void* dst, const void* src, size_t nbytes)

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -87,7 +87,7 @@ void gt_backend_memcpy_dh(void* dst, const void* src, size_t nbytes)
 
 void gt_backend_memcpy_hd(void* dst, const void* src, size_t nbytes)
 {
-  gt::backend::device_copy_hd<uint8_t>((uint8_t*)src, (uint8_t*)dst, nbytes);
+  gt::backend::ops<uint8_t>::copy_hd((uint8_t*)src, (uint8_t*)dst, nbytes);
 }
 
 void gt_backend_memset(void* dst, int value, size_t nbytes)

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -36,42 +36,42 @@ uint32_t gt_backend_device_get_vendor_id(int device_id)
 
 void* gt_backend_host_allocate(size_t nbytes)
 {
-  return (void*)gt::backend::ops<uint8_t>::host::allocate(nbytes);
+  return (void*)gt::backend::ops::host::allocate<uint8_t>(nbytes);
 }
 
 void* gt_backend_device_allocate(size_t nbytes)
 {
-  return (void*)gt::backend::ops<uint8_t>::device::allocate(nbytes);
+  return (void*)gt::backend::ops::device::allocate<uint8_t>(nbytes);
 }
 
 void* gt_backend_managed_allocate(size_t nbytes)
 {
-  return (void*)gt::backend::ops<uint8_t>::managed::allocate(nbytes);
+  return (void*)gt::backend::ops::managed::allocate<uint8_t>(nbytes);
 }
 
 void gt_backend_host_deallocate(void* p)
 {
-  gt::backend::ops<uint8_t>::host::deallocate((uint8_t*)p);
+  gt::backend::ops::host::deallocate((uint8_t*)p);
 }
 
 void gt_backend_device_deallocate(void* p)
 {
-  gt::backend::ops<uint8_t>::device::deallocate((uint8_t*)p);
+  gt::backend::ops::device::deallocate((uint8_t*)p);
 }
 
 void gt_backend_managed_deallocate(void* p)
 {
-  gt::backend::ops<uint8_t>::managed::deallocate((uint8_t*)p);
+  gt::backend::ops::managed::deallocate((uint8_t*)p);
 }
 
 void gt_backend_memcpy_hh(void* dst, const void* src, size_t nbytes)
 {
-  gt::backend::ops<uint8_t>::host::copy((uint8_t*)src, (uint8_t*)dst, nbytes);
+  gt::backend::ops::host::copy((uint8_t*)src, (uint8_t*)dst, nbytes);
 }
 
 void gt_backend_memcpy_dd(void* dst, const void* src, size_t nbytes)
 {
-  gt::backend::ops<uint8_t>::device::copy((uint8_t*)src, (uint8_t*)dst, nbytes);
+  gt::backend::ops::device::copy((uint8_t*)src, (uint8_t*)dst, nbytes);
 }
 
 void gt_backend_memcpy_async_dd(void* dst, const void* src, size_t nbytes)
@@ -82,12 +82,12 @@ void gt_backend_memcpy_async_dd(void* dst, const void* src, size_t nbytes)
 
 void gt_backend_memcpy_dh(void* dst, const void* src, size_t nbytes)
 {
-  gt::backend::ops<uint8_t>::copy_dh((uint8_t*)src, (uint8_t*)dst, nbytes);
+  gt::backend::ops::copy_dh((uint8_t*)src, (uint8_t*)dst, nbytes);
 }
 
 void gt_backend_memcpy_hd(void* dst, const void* src, size_t nbytes)
 {
-  gt::backend::ops<uint8_t>::copy_hd((uint8_t*)src, (uint8_t*)dst, nbytes);
+  gt::backend::ops::copy_hd((uint8_t*)src, (uint8_t*)dst, nbytes);
 }
 
 void gt_backend_memset(void* dst, int value, size_t nbytes)

--- a/tests/test_device_backend.cxx
+++ b/tests/test_device_backend.cxx
@@ -36,7 +36,7 @@ TEST(device_backend, list_devices)
 #define N 10
 TEST(device_backend, managed_allocate)
 {
-  double* a = gt::backend::ops::managed::allocate<double>(N);
+  double* a = gt::backend::gallocator::managed::allocate<double>(N);
   for (int i = 0; i < N; i++) {
     a[i] = ((double)i) / N;
   }
@@ -46,7 +46,7 @@ TEST(device_backend, managed_allocate)
   for (int i = 0; i < N; i++) {
     EXPECT_EQ(a[i], 1.0 + ((double)i) / N);
   }
-  gt::backend::ops::managed::deallocate(a);
+  gt::backend::gallocator::managed::deallocate(a);
 }
 
 #endif

--- a/tests/test_device_backend.cxx
+++ b/tests/test_device_backend.cxx
@@ -36,7 +36,7 @@ TEST(device_backend, list_devices)
 #define N 10
 TEST(device_backend, managed_allocate)
 {
-  double* a = gt::backend::ops<double>::managed::allocate(N);
+  double* a = gt::backend::ops::managed::allocate<double>(N);
   for (int i = 0; i < N; i++) {
     a[i] = ((double)i) / N;
   }
@@ -46,7 +46,7 @@ TEST(device_backend, managed_allocate)
   for (int i = 0; i < N; i++) {
     EXPECT_EQ(a[i], 1.0 + ((double)i) / N);
   }
-  gt::backend::ops<double>::managed::deallocate(a);
+  gt::backend::ops::managed::deallocate(a);
 }
 
 #endif

--- a/tests/test_fft.cxx
+++ b/tests/test_fft.cxx
@@ -43,8 +43,8 @@ void fft_r2c_1d()
 
   // zero output array, rocfft at least does not zero padding elements
   // for real to complex transform
-  gt::backend::device_memset(gt::backend::raw_pointer_cast(d_B.data()), 0,
-                             batch_size * Nout * sizeof(T*));
+  gt::backend::ops::memset(gt::backend::raw_pointer_cast(d_B.data()), 0,
+                           batch_size * Nout * sizeof(T*));
 
   gt::copy(h_A, d_A);
 
@@ -284,8 +284,8 @@ TEST(fft, move_only)
 
   // zero output array, rocfft at least does not zero padding elements
   // for real to complex transform
-  gt::backend::device_memset(gt::backend::raw_pointer_cast(d_B.data()), 0,
-                             batch_size * Nout * sizeof(T*));
+  gt::backend::ops::memset(gt::backend::raw_pointer_cast(d_B.data()), 0,
+                           batch_size * Nout * sizeof(T*));
 
   gt::copy(h_A, d_A);
 

--- a/tests/test_gtensor_storage.cxx
+++ b/tests/test_gtensor_storage.cxx
@@ -172,11 +172,11 @@ TEST(gtensor_storage, device_copy_assign)
     h1[i] = static_cast<T>(i);
   }
 
-  gt::backend::device_copy_hd(h1.data(), d1.data(), h1.size());
+  gt::backend::copy(h1, d1);
+
   d2 = d1;
 
   EXPECT_EQ(d2.size(), N);
-
   EXPECT_EQ(d2, d1);
 }
 
@@ -192,7 +192,7 @@ TEST(gtensor_storage, device_move_assign)
   for (int i = 0; i < h1.size(); i++) {
     h1[i] = static_cast<T>(i);
   }
-  gt::backend::device_copy_hd(h1.data(), d1.data(), h1.size());
+  gt::backend::copy(h1, d1);
   d1_copy = d1;
 
   d2 = std::move(d1);
@@ -217,7 +217,7 @@ TEST(gtensor_storage, device_move_ctor)
   for (int i = 0; i < h1.size(); i++) {
     h1[i] = static_cast<T>(i);
   }
-  gt::backend::device_copy_hd(h1.data(), d1.data(), h1.size());
+  gt::backend::copy(h1, d1);
   d1_copy = d1;
 
   auto d2 = std::move(d1);
@@ -251,7 +251,7 @@ TEST(gtensor_storage, device_resize_from_zero)
   EXPECT_NE(d1.data(), nullptr);
 
   // make sure new pointer is viable by copying data to it
-  gt::backend::device_copy_hd(h1.data(), d1.data(), h1.size());
+  gt::backend::copy(h1, d1);
 
   EXPECT_EQ(d1.size(), N);
   EXPECT_EQ(d1.capacity(), N);
@@ -266,7 +266,7 @@ TEST(gtensor_storage, device_resize_to_zero)
   for (int i = 0; i < h1.size(); i++) {
     h1[i] = static_cast<T>(i);
   }
-  gt::backend::device_copy_hd(h1.data(), d1.data(), h1.size());
+  gt::backend::copy(h1, d1);
 
   d1.resize(0);
 
@@ -285,7 +285,7 @@ TEST(gtensor_storage, device_resize_expand)
   for (int i = 0; i < h1.size(); i++) {
     h1[i] = static_cast<T>(i);
   }
-  gt::backend::device_copy_hd(h1.data(), d1.data(), h1.size());
+  gt::backend::copy(h1, d1);
 
   d1.resize(N2);
 
@@ -293,7 +293,7 @@ TEST(gtensor_storage, device_resize_expand)
   EXPECT_EQ(d1.capacity(), N2);
 
   h1.resize(N2);
-  gt::backend::device_copy_hd(d1.data(), h1.data(), N2);
+  gt::backend::copy(d1, h1);
   for (int i = 0; i < N; i++) {
     EXPECT_EQ(h1[i], (double)i);
   }
@@ -309,14 +309,15 @@ TEST(gtensor_storage, device_resize_shrink)
   for (int i = 0; i < h1.size(); i++) {
     h1[i] = static_cast<T>(i);
   }
-  gt::backend::device_copy_hd(h1.data(), d1.data(), h1.size());
+  gt::backend::copy(h1, d1);
 
   d1.resize(N2);
 
   EXPECT_EQ(d1.size(), N2);
   EXPECT_EQ(d1.capacity(), N);
 
-  gt::backend::device_copy_hd(d1.data(), h1.data(), N2);
+  h1.resize(N2);
+  gt::backend::copy(d1, h1);
   for (int i = 0; i < N2; i++) {
     EXPECT_EQ(h1[i], (double)i);
   }


### PR DESCRIPTION
It's kinda beyond actual allocator stuff, more of a some ongoing reorganization of the backend stuff. In particular, the copy and memset functions are now put into `struct ops` in the various `cuda`/`hip`/ etc namespaces.