### PR TITLE
gfunction fixes

### DIFF
--- a/include/gtensor/assign.h
+++ b/include/gtensor/assign.h
@@ -418,7 +418,7 @@ struct assigner<N, space::device>
     auto size = calc_size(lhs.shape());
     auto k_lhs = flatten(lhs).to_kernel();
     auto k_rhs = flatten(rhs).to_kernel();
-    auto block_size = std::min(size, BS_LINEAR);
+    auto block_size = std::min(size_type(size), size_type(BS_LINEAR));
     auto range =
       sycl::nd_range<1>(sycl::range<1>(size), sycl::range<1>(block_size));
     auto e = q.submit([&](sycl::handler& cgh) {

--- a/include/gtensor/gfunction.h
+++ b/include/gtensor/gfunction.h
@@ -210,7 +210,7 @@ public:
 
   shape_type shape() const;
   int shape(int i) const;
-  GT_INLINE size_type size() const { return shape().size(); };
+  GT_INLINE size_type size() const { return calc_size(shape()); }
 
   template <typename... Args>
   GT_INLINE value_type operator()(Args... args) const;

--- a/include/gtensor/gfunction.h
+++ b/include/gtensor/gfunction.h
@@ -251,6 +251,7 @@ public:
 
   shape_type shape() const;
   int shape(int i) const;
+  GT_INLINE size_type size() const { return calc_size(shape()); }
 
   template <typename... Args>
   GT_INLINE value_type operator()(Args... args) const;

--- a/tests/test_expression.cxx
+++ b/tests/test_expression.cxx
@@ -105,6 +105,16 @@ TEST(expression, gfunction)
   EXPECT_EQ(e4, (gt::gtensor<double, 1>{11., 12.}));
 }
 
+TEST(expression, gfunction_unary)
+{
+  gt::gtensor<double, 1> t({1., 2.});
+
+  auto e = -t;
+  EXPECT_EQ(e.shape(), gt::shape(2));
+  EXPECT_EQ(e.size(), 2);
+  EXPECT_EQ(e, (gt::gtensor<double, 1>{-1., -2.}));
+}
+
 TEST(expression, gfunction_to_kernel)
 {
   gt::gtensor<double, 1> t1({1., 2.});

--- a/tests/test_expression.cxx
+++ b/tests/test_expression.cxx
@@ -93,6 +93,8 @@ TEST(expression, gfunction)
   EXPECT_EQ(e, (gt::gtensor<double, 1>{4., 6.}));
 
   EXPECT_EQ(e.dimension(), 1);
+  EXPECT_EQ(e.shape(), gt::shape(2));
+  EXPECT_EQ(e.size(), 2);
 
   auto e2 = 10. + t2;
   EXPECT_EQ(e2, (gt::gtensor<double, 1>{13., 14.}));


### PR DESCRIPTION
This fixes a bug in unary `gfunction::size()`, and adds it in the binary case.

This should fix one of the sycl build errors.