### PR TITLE
fix a couple of warnings

### DIFF
--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -163,13 +163,13 @@ inline void device_synchronize()
 #ifdef GTENSOR_USE_THRUST
 
 template <typename Pointer>
-inline auto raw_pointer_cast(Pointer p)
+GT_INLINE auto raw_pointer_cast(Pointer p)
 {
   return thrust::raw_pointer_cast(p);
 }
 
 template <typename Pointer>
-inline auto device_pointer_cast(Pointer p)
+GT_INLINE auto device_pointer_cast(Pointer p)
 {
   return thrust::device_pointer_cast(p);
 }
@@ -178,13 +178,13 @@ inline auto device_pointer_cast(Pointer p)
 
 // define no-op device_pointer/raw ponter casts
 template <typename Pointer>
-inline Pointer raw_pointer_cast(Pointer p)
+GT_INLINE Pointer raw_pointer_cast(Pointer p)
 {
   return p;
 }
 
 template <typename Pointer>
-inline Pointer device_pointer_cast(Pointer p)
+GT_INLINE Pointer device_pointer_cast(Pointer p)
 {
   return p;
 }

--- a/include/gtensor/gfunction.h
+++ b/include/gtensor/gfunction.h
@@ -393,13 +393,17 @@ MAKE_BINARY_OP(divide, /)
 
 #undef MAKE_BINARY_OP
 
+// FIXME: The nv_exec_check_disable removes a warning cause by std::abs
+// not being usable on the device, but eventually we'll actually want to support
+// this one the device
+
 #define MAKE_UNARY_FUNC(NAME, FUNC)                                            \
                                                                                \
   namespace funcs                                                              \
   {                                                                            \
   struct NAME                                                                  \
   {                                                                            \
-    template <typename T>                                                      \
+    _Pragma("nv_exec_check_disable") template <typename T>                     \
     GT_INLINE auto operator()(T a) const                                       \
     {                                                                          \
       return FUNC(a);                                                          \


### PR DESCRIPTION
I get a bunch of `can't call a __host__ function from a __host__ __device__ function` warnings, and most of them are inside of thrust, so I can't easily do anything about them, but here's a couple that can be worked around.