### PR TITLE
allocator: allow for overriding default allocator

### DIFF
--- a/include/gtensor/allocator.h
+++ b/include/gtensor/allocator.h
@@ -1,0 +1,122 @@
+
+#include <iostream>
+#include <map>
+#include <memory>
+
+namespace gt
+{
+namespace allocator
+{
+
+// ======================================================================
+// caching_allocator
+
+template <class T, class A>
+struct caching_allocator : A
+{
+  using base_type = A;
+  using value_type = typename std::allocator_traits<A>::value_type;
+  using pointer = typename std::allocator_traits<A>::pointer;
+  using const_pointer = typename std::allocator_traits<A>::const_pointer;
+  using size_type = typename std::allocator_traits<A>::size_type;
+  using difference_type = typename std::allocator_traits<A>::difference_type;
+
+  caching_allocator() {}
+  caching_allocator(const caching_allocator&) {}
+
+  ~caching_allocator() {}
+
+  pointer allocate(size_type cnt)
+  {
+    pointer p;
+    auto it = free_.find(cnt);
+    if (it != free_.end()) {
+      p = it->second;
+      free_.erase(it);
+#ifdef DEBUG
+      std::cout << "ALLOC: allocating " << cnt << " bytes from cache\n";
+#endif
+    } else {
+#ifdef DEBUG
+      std::cout << "ALLOC: total used " << used_ * sizeof(T) << ", allocing "
+                << cnt * sizeof(T) << "\n";
+#endif
+      p = base_type::allocate(cnt);
+      used_ += cnt;
+#ifdef DEBUG
+      std::cout << "ALLOC: allocating " << cnt << " bytes\n";
+#endif
+    }
+    if (p) {
+      allocated_.emplace(std::make_pair(p, cnt));
+    }
+    return p;
+  }
+
+  void deallocate(pointer p, size_type cnt)
+  {
+    gt::synchronize();
+    if (p) {
+      auto it = allocated_.find(p);
+      assert(it != allocated_.end());
+      free_.emplace(std::make_pair(it->second, p));
+      allocated_.erase(it);
+    }
+#ifdef DEBUG
+    std::cout << "ALLOC: deallocing cnt " << cnt
+              << " #allocated = " << allocated_.size()
+              << " #free = " << free_.size() << "\n";
+#endif
+  }
+
+  GT_INLINE void construct(pointer) {}
+
+  static void clear_cache()
+  {
+    for (auto it = free_.begin(); it != free_.end(); it++) {
+      base_type::deallocate(it->second, it->first);
+    }
+    free_.clear();
+  }
+
+  template <class U>
+  struct rebind
+  {
+    using other = caching_allocator<U, typename A::template rebind<U>::other>;
+  };
+
+private:
+  static std::multimap<size_type, pointer> free_;
+  static std::map<pointer, size_type> allocated_;
+  static size_t used_;
+};
+
+template <class T, class A>
+std::multimap<typename caching_allocator<T, A>::size_type,
+              typename caching_allocator<T, A>::pointer>
+  caching_allocator<T, A>::free_;
+
+template <class T, class A>
+std::map<typename caching_allocator<T, A>::pointer,
+         typename caching_allocator<T, A>::size_type>
+  caching_allocator<T, A>::allocated_;
+
+template <class T, class A>
+size_t caching_allocator<T, A>::used_;
+
+template <class T, class AT, class U, class AU>
+inline bool operator==(const caching_allocator<T, AT>&,
+                       const caching_allocator<U, AU>&)
+{
+  return std::is_same<AT, AU>::value;
+}
+
+template <class T, class AT, class U, class AU>
+inline bool operator!=(const caching_allocator<T, AT>& a,
+                       const caching_allocator<U, AU>& b)
+{
+  return !(a == b);
+}
+
+} // namespace allocator
+} // namespace gt

--- a/include/gtensor/space.h
+++ b/include/gtensor/space.h
@@ -168,27 +168,20 @@ struct host
 #ifdef GTENSOR_HAVE_DEVICE
 
 #ifdef GTENSOR_USE_THRUST
-
-struct device
-{
-  template <typename T>
-  using Vector = thrust::device_vector<T, gt::allocator::device_allocator<T>>;
-  template <typename T>
-  using Span = device_span<T>;
-};
-
+template <typename T, typename A>
+using device_vector = thrust::device_vector<T, A>;
 #else
+template <typename T, typename A>
+using device_vector = gt::backend::device_storage<T, A>;
+#endif // GTENSOR_USE_THRUST
 
 struct device
 {
   template <typename T>
-  using Vector =
-    gt::backend::device_storage<T, gt::allocator::device_allocator<T>>;
+  using Vector = device_vector<T, gt::allocator::device_allocator<T>>;
   template <typename T>
   using Span = device_span<T>;
 };
-
-#endif // GTENSOR_USE_THRUST
 
 #else // not GTENSOR_HAVE_DEVICE
 

--- a/include/gtensor/space.h
+++ b/include/gtensor/space.h
@@ -133,6 +133,11 @@ inline bool operator!=(const caching_allocator<T, AT>& a,
   return !(a == b);
 }
 
+// ======================================================================
+
+template <typename T>
+using host_allocator = gt::backend::system::host_allocator<T>;
+
 #ifdef GTENSOR_HAVE_DEVICE
 
 template <typename T>
@@ -155,8 +160,8 @@ struct kernel;
 
 #ifdef GTENSOR_USE_THRUST
 
-template <typename T>
-using host_vector = thrust::device_vector<T>;
+template <typename T, typename A>
+using host_vector = thrust::host_vector<T, A>;
 
 #ifdef GTENSOR_HAVE_DEVICE
 template <typename T, typename A>
@@ -165,11 +170,11 @@ using device_vector = thrust::device_vector<T, A>;
 
 #else
 
-template <typename T>
+template <typename T, typename A = gt::allocator::host_allocator<T>>
 using host_vector = gt::backend::host_storage<T>;
 
 #ifdef GTENSOR_HAVE_DEVICE
-template <typename T, typename A>
+template <typename T, typename A = gt::allocator::device_allocator<T>>
 using device_vector = gt::backend::device_storage<T, A>;
 #endif
 
@@ -177,8 +182,8 @@ using device_vector = gt::backend::device_storage<T, A>;
 
 struct host
 {
-  template <typename T>
-  using Vector = host_vector<T>;
+  template <typename T, typename A = gt::allocator::host_allocator<T>>
+  using Vector = host_vector<T, A>;
   template <typename T>
   using Span = span<T>;
 };
@@ -187,8 +192,8 @@ struct host
 
 struct device
 {
-  template <typename T>
-  using Vector = device_vector<T, gt::allocator::device_allocator<T>>;
+  template <typename T, typename A = gt::allocator::device_allocator<T>>
+  using Vector = device_vector<T, A>;
   template <typename T>
   using Span = device_span<T>;
 };

--- a/include/gtensor/space.h
+++ b/include/gtensor/space.h
@@ -153,27 +153,37 @@ struct any;
 
 struct kernel;
 
+#ifdef GTENSOR_USE_THRUST
+
+template <typename T>
+using host_vector = thrust::device_vector<T>;
+
+#ifdef GTENSOR_HAVE_DEVICE
+template <typename T, typename A>
+using device_vector = thrust::device_vector<T, A>;
+#endif
+
+#else
+
+template <typename T>
+using host_vector = gt::backend::host_storage<T>;
+
+#ifdef GTENSOR_HAVE_DEVICE
+template <typename T, typename A>
+using device_vector = gt::backend::device_storage<T, A>;
+#endif
+
+#endif // GTENSOR_USE_THRUST
+
 struct host
 {
   template <typename T>
-#ifdef GTENSOR_USE_THRUST
-  using Vector = thrust::host_vector<T>;
-#else
-  using Vector = gt::backend::host_storage<T>;
-#endif
+  using Vector = host_vector<T>;
   template <typename T>
   using Span = span<T>;
 };
 
 #ifdef GTENSOR_HAVE_DEVICE
-
-#ifdef GTENSOR_USE_THRUST
-template <typename T, typename A>
-using device_vector = thrust::device_vector<T, A>;
-#else
-template <typename T, typename A>
-using device_vector = gt::backend::device_storage<T, A>;
-#endif // GTENSOR_USE_THRUST
 
 struct device
 {

--- a/include/gtensor/space.h
+++ b/include/gtensor/space.h
@@ -2,13 +2,13 @@
 #ifndef GTENSOR_SPACE_H
 #define GTENSOR_SPACE_H
 
+#include "allocator.h"
 #include "defs.h"
 #include "gtensor_storage.h"
 #include "helper.h"
 #include "meta.h"
 #include "span.h"
 
-#include <map>
 #include <vector>
 
 #ifdef GTENSOR_USE_THRUST
@@ -16,124 +16,6 @@
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 #endif
-
-namespace gt
-{
-
-namespace allocator
-{
-
-// ======================================================================
-// caching_allocator
-
-template <class T, class A>
-struct caching_allocator : A
-{
-  using base_type = A;
-  using value_type = typename std::allocator_traits<A>::value_type;
-  using pointer = typename std::allocator_traits<A>::pointer;
-  using const_pointer = typename std::allocator_traits<A>::const_pointer;
-  using size_type = typename std::allocator_traits<A>::size_type;
-  using difference_type = typename std::allocator_traits<A>::difference_type;
-
-  caching_allocator() {}
-  caching_allocator(const caching_allocator&) {}
-
-  ~caching_allocator() {}
-
-  pointer allocate(size_type cnt)
-  {
-    pointer p;
-    auto it = free_.find(cnt);
-    if (it != free_.end()) {
-      p = it->second;
-      free_.erase(it);
-#ifdef DEBUG
-      std::cout << "ALLOC: allocating " << cnt << " bytes from cache\n";
-#endif
-    } else {
-#ifdef DEBUG
-      std::cout << "ALLOC: total used " << used_ * sizeof(T) << ", allocing "
-                << cnt * sizeof(T) << "\n";
-#endif
-      p = base_type::allocate(cnt);
-      used_ += cnt;
-#ifdef DEBUG
-      std::cout << "ALLOC: allocating " << cnt << " bytes\n";
-#endif
-    }
-    if (p) {
-      allocated_.emplace(std::make_pair(p, cnt));
-    }
-    return p;
-  }
-
-  void deallocate(pointer p, size_type cnt)
-  {
-    gt::synchronize();
-    if (p) {
-      auto it = allocated_.find(p);
-      assert(it != allocated_.end());
-      free_.emplace(std::make_pair(it->second, p));
-      allocated_.erase(it);
-    }
-#ifdef DEBUG
-    std::cout << "ALLOC: deallocing cnt " << cnt
-              << " #allocated = " << allocated_.size()
-              << " #free = " << free_.size() << "\n";
-#endif
-  }
-
-  GT_INLINE void construct(pointer) {}
-
-  static void clear_cache()
-  {
-    for (auto it = free_.begin(); it != free_.end(); it++) {
-      base_type::deallocate(it->second, it->first);
-    }
-    free_.clear();
-  }
-
-  template <class U>
-  struct rebind
-  {
-    using other = caching_allocator<U, typename A::template rebind<U>::other>;
-  };
-
-private:
-  static std::multimap<size_type, pointer> free_;
-  static std::map<pointer, size_type> allocated_;
-  static size_t used_;
-};
-
-template <class T, class A>
-std::multimap<typename caching_allocator<T, A>::size_type,
-              typename caching_allocator<T, A>::pointer>
-  caching_allocator<T, A>::free_;
-
-template <class T, class A>
-std::map<typename caching_allocator<T, A>::pointer,
-         typename caching_allocator<T, A>::size_type>
-  caching_allocator<T, A>::allocated_;
-
-template <class T, class A>
-size_t caching_allocator<T, A>::used_;
-
-template <class T, class AT, class U, class AU>
-inline bool operator==(const caching_allocator<T, AT>&,
-                       const caching_allocator<U, AU>&)
-{
-  return std::is_same<AT, AU>::value;
-}
-
-template <class T, class AT, class U, class AU>
-inline bool operator!=(const caching_allocator<T, AT>& a,
-                       const caching_allocator<U, AU>& b)
-{
-  return !(a == b);
-}
-
-} // namespace allocator
 
 #ifndef GTENSOR_DEFAULT_HOST_ALLOCATOR
 #define GTENSOR_DEFAULT_HOST_ALLOCATOR(T) gt::backend::system::host_allocator<T>
@@ -143,6 +25,9 @@ inline bool operator!=(const caching_allocator<T, AT>& a,
 #define GTENSOR_DEFAULT_DEVICE_ALLOCATOR(T)                                    \
   gt::allocator::caching_allocator<T, gt::backend::system::device_allocator<T>>
 #endif
+
+namespace gt
+{
 
 // ======================================================================
 // space

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -99,18 +99,18 @@ TEST(gtensor, copy_ctor)
   EXPECT_EQ(b, a);
 
   // underlying storage copied
-  double* adata = gt::backend::raw_pointer_cast(a.data());
-  double* bdata = gt::backend::raw_pointer_cast(b.data());
+  auto adata = a.data();
+  auto bdata = b.data();
   EXPECT_NE(adata, bdata);
 }
 
 TEST(gtensor, move_ctor)
 {
   gt::gtensor<double, 1> a{11., 12., 13.};
-  double* adata = gt::backend::raw_pointer_cast(a.data());
+  auto adata = a.data();
 
   auto b = std::move(a);
-  double* bdata = gt::backend::raw_pointer_cast(b.data());
+  auto bdata = b.data();
 
   EXPECT_EQ(b, (gt::gtensor<double, 1>{11., 12., 13.}));
 
@@ -164,10 +164,10 @@ TEST(gtensor, copy_assign3)
 TEST(gtensor, move_assign)
 {
   gt::gtensor<double, 1> a{11., 12., 13.};
-  double* adata = gt::backend::raw_pointer_cast(a.data());
+  double* adata = a.data();
   gt::gtensor<double, 1> b;
   b = std::move(a);
-  double* bdata = gt::backend::raw_pointer_cast(b.data());
+  double* bdata = b.data();
 
   EXPECT_EQ(b, (gt::gtensor<double, 1>{11., 12., 13.}));
 
@@ -592,10 +592,10 @@ TEST(gtensor, device_move_ctor)
   gt::gtensor_device<double, 1> a(h_a.shape());
 
   gt::copy(h_a, a);
-  double* adata = gt::backend::raw_pointer_cast(a.data());
+  auto adata = a.data();
 
   auto b = std::move(a);
-  double* bdata = gt::backend::raw_pointer_cast(b.data());
+  auto bdata = b.data();
 
   // Note: explicit copy to avoid thrust implicit kernel for accessing
   // device vector from host. Aids in understanding thrust backend behavior.
@@ -614,10 +614,10 @@ TEST(gtensor, device_move_assign)
   gt::gtensor_device<double, 1> b(h_a.shape());
 
   gt::copy(h_a, a);
-  double* adata = gt::backend::raw_pointer_cast(a.data());
+  auto adata = a.data();
 
   b = std::move(a);
-  double* bdata = gt::backend::raw_pointer_cast(b.data());
+  auto bdata = b.data();
 
   // Note: explicit copy to avoid thrust implicit kernel for accessing
   // device vector from host. Aids in understanding thrust backend behavior.

--- a/tests/test_thrust_ext.cxx
+++ b/tests/test_thrust_ext.cxx
@@ -101,9 +101,9 @@ TEST(thrust_ext, move_construct)
   v[0] = T(12., 0.);
   v[1] = T(2., 0.);
 
-  T* vp = thrust::raw_pointer_cast(v.data());
+  auto vp = v.data();
   thrust::device_vector<T> v2(std::move(v));
-  T* v2p = thrust::raw_pointer_cast(v2.data());
+  auto v2p = v2.data();
 
   // make sure that no data was copied
   EXPECT_EQ(vp, v2p);

--- a/tests/test_view.cxx
+++ b/tests/test_view.cxx
@@ -39,7 +39,7 @@ auto get_linear_index_gtensor(gt::shape_type<2> shape)
 
   int size = calc_size(shape);
 
-  double* h_data = gt::backend::raw_pointer_cast(h_a.data());
+  double* h_data = h_a.data();
   for (int i = 0; i < size; i++) {
     h_data[i] = i;
   }
@@ -461,12 +461,12 @@ TEST(gview, device_copy_ctor)
   gt::copy(h_a, d_a);
 
   auto d_av = d_a.view(_s(1, 3), _all);
-  auto d_av00_addr = gt::backend::raw_pointer_cast(&d_av(0, 0));
+  auto d_av00_addr = &d_av(0, 0);
 
   auto d_av2(d_av);
 
   // make sure that no data was copied
-  EXPECT_EQ(gt::backend::raw_pointer_cast(&d_av2(0, 0)), d_av00_addr);
+  EXPECT_EQ(&d_av2(0, 0), d_av00_addr);
 }
 
 // Note: this case reproduces a performance regression in GENE, where a


### PR DESCRIPTION
This separates out the caching allocator into a separate file, and introduces `GTENSOR_DEFAULT_{HOST,DEVICE}_ALLOCATOR` macros which can be set to override the default allocator.

Though by now I think that, for my purposes, I'll rather make my own variant of `gt::gtensor` that allow me to use my choice of allocator without relying on macro hackery. 
