### PR TITLE
finish (hopefully) allocator related work

### DIFF
--- a/examples/src/daxpy.cxx
+++ b/examples/src/daxpy.cxx
@@ -36,18 +36,16 @@ using namespace gt::placeholders;
  * all the data which would happen by default (just like std::vector, gtensor
  * has copy semantics by default).
  */
-template <typename S>
-gt::gtensor<double, 1, S> daxpy(double a, const gt::gtensor<double, 1, S>& x,
-                                const gt::gtensor<double, 1, S>& y)
+template <typename Ex, typename Ey>
+auto daxpy(double a, const Ex& x, const Ey& y)
 {
   // The expression 'a * x + y' generates a gfunction template, which is an
-  // un-evaluated expression. In this case, the return statement and return
-  // type force evaluation so a new gtensor is created. It can be useful to
-  // instead set the return type to 'auto', in which case the un-evaluated
-  // expression will be returned and can be combined with other operations
-  // before being evaluated, or assigned to a gtensor to force immediate
-  // evaluation.
-  return a * x + y;
+  // un-evaluated expression. In this case, we force evaluation in the return
+  // statementso a new gtensor is created. It can be useful to not add the
+  // `gt::eval`, in which case the un-evaluated expression will be returned and
+  // can be combined with other operations before being evaluated, or assigned
+  // to a gtensor to force immediate evaluation.
+  return gt::eval(a * x + y);
 }
 
 int main(int argc, char** argv)

--- a/examples/src/mult_table.cxx
+++ b/examples/src/mult_table.cxx
@@ -2,17 +2,17 @@
 
 #include <gtensor/gtensor.h>
 
-template <typename T, typename S>
-gt::gtensor<T, 2, S> outer_product(gt::gtensor<T, 1, S>& a,
-                                   gt::gtensor<T, 1, S>& b)
+template <typename Ea, typename Eb>
+auto outer_product(const Ea& a, const Eb& b)
 {
   int n = a.shape(0);
   assert(n == b.shape(0));
-  return gt::reshape(a, gt::shape(1, n)) * gt::reshape(b, gt::shape(n, 1));
+  return gt::eval(gt::reshape(a, gt::shape(1, n)) *
+                  gt::reshape(b, gt::shape(n, 1)));
 }
 
-template <typename T, typename S>
-auto outer_product_expr(gt::gtensor<T, 1, S>& a, gt::gtensor<T, 1, S>& b)
+template <typename Ea, typename Eb>
+auto outer_product_expr(const Ea& a, const Eb& b)
 {
   int n = a.shape(0);
   assert(n == b.shape(0));

--- a/include/gtensor/allocator.h
+++ b/include/gtensor/allocator.h
@@ -1,7 +1,10 @@
 
+#include "meta.h"
+
 #include <iostream>
 #include <map>
 #include <memory>
+#include <utility>
 
 #ifdef GTENSOR_USE_THRUST
 #include <thrust/device_ptr.h>
@@ -14,8 +17,10 @@ namespace allocator
 
 namespace detail
 {
-template <typename P, typename std::enable_if_t<
-                        std::is_convertible<P, bool>::value, int> = 0>
+
+template <typename P,
+          // has operator bool?
+          typename Enable = gt::meta::void_t<decltype(bool(std::declval<P>()))>>
 bool is_valid(P p)
 {
   return bool(p);

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -35,11 +35,35 @@ namespace space
 {
 
 struct host;
+#ifdef GTENSOR_USE_THRUST
+struct thrust;
+#endif
+#ifdef GTENSOR_DEVICE_CUDA
+struct cuda;
+#endif
+#ifdef GTENSOR_DEVICE_HIP
+struct hip;
+#endif
+#ifdef GTENSOR_DEVICE_SYCL
+struct sycl;
+#endif
 
 #ifdef GTENSOR_HAVE_DEVICE
-struct device;
-#else
+
+#if GTENSOR_USE_THRUST
+using device = thrust;
+#elif GTENSOR_DEVICE_CUDA
+using device = cuda;
+#elif GTENSOR_DEVICE_HIP
+using device = hip;
+#elif GTENSOR_DEVICE_SYCL
+using device = sycl;
+#endif
+
+#else // !  GTENSOR_HAVE_DEVICE
+
 using device = host;
+
 #endif
 
 } // namespace space

--- a/include/gtensor/expression.h
+++ b/include/gtensor/expression.h
@@ -3,16 +3,13 @@
 #define GTENSOR_EXPRESSION_H
 
 #include "defs.h"
+#include "gtensor_forward.h"
 #include "gtl.h"
 #include "helper.h"
 #include "space.h"
 
 namespace gt
 {
-
-// fwd decl FIXME?
-template <typename T, size_type N, typename S>
-struct gtensor;
 
 template <typename T, size_type N, typename S>
 struct gtensor_span;

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -29,7 +29,8 @@ struct gtensor_inner_types<gtensor<T, N, S>>
   using space_type = S;
   constexpr static size_type dimension = N;
 
-  using storage_type = typename space_type::template Vector<T>;
+  using storage_type =
+    typename space::space_traits<S>::template storage_type<T>;
   using value_type = typename storage_type::value_type;
   using pointer = typename storage_type::pointer;
   using const_pointer = typename storage_type::const_pointer;

--- a/include/gtensor/gtensor_forward.h
+++ b/include/gtensor/gtensor_forward.h
@@ -1,0 +1,20 @@
+
+#ifndef GTENSOR_FORWARD_H
+#define GTENSOR_FORWARD_H
+
+#include "defs.h"
+#include "space.h"
+
+namespace gt
+{
+
+template <typename EC, size_type N, typename S>
+class gtensor_container;
+
+template <typename T, size_type N, typename S = space::host>
+using gtensor =
+  gtensor_container<typename space::space_traits<S>::template storage_type<T>,
+                    N, S>;
+} // namespace gt
+
+#endif

--- a/include/gtensor/gtensor_forward.h
+++ b/include/gtensor/gtensor_forward.h
@@ -8,13 +8,13 @@
 namespace gt
 {
 
-template <typename EC, size_type N, typename S>
+template <typename EC, size_type N>
 class gtensor_container;
 
 template <typename T, size_type N, typename S = space::host>
 using gtensor =
   gtensor_container<typename space::space_traits<S>::template storage_type<T>,
-                    N, S>;
+                    N>;
 } // namespace gt
 
 #endif

--- a/include/gtensor/gtensor_span.h
+++ b/include/gtensor/gtensor_span.h
@@ -67,20 +67,26 @@ public:
       storage_{other.data(), other.size()}
   {}
 
-  // Implicit conversion from a gtensor object with the same or compaitible
+  // Implicit conversion from a gtensor object with the same or compatible
   // element type
-  template <class EC, std::enable_if_t<is_allowed_element_type_conversion<
-                                         typename EC::value_type, T>::value,
-                                       int> = 0>
-  gtensor_span(gtensor_container<EC, N, S>& other)
+  template <
+    class EC,
+    std::enable_if_t<
+      is_allowed_element_type_conversion<typename EC::value_type, T>::value &&
+        std::is_same<S, typename space::storage_traits<EC>::space_type>::value,
+      int> = 0>
+  gtensor_span(gtensor_container<EC, N>& other)
     : base_type{other.shape(), other.strides()},
       storage_{other.data(), other.size()}
   {}
 
-  template <class EC, std::enable_if_t<is_allowed_element_type_conversion<
-                                         typename EC::value_type, T>::value,
-                                       int> = 0>
-  gtensor_span(const gtensor_container<EC, N, S>& other)
+  template <
+    class EC,
+    std::enable_if_t<
+      is_allowed_element_type_conversion<typename EC::value_type, T>::value &&
+        std::is_same<S, typename space::storage_traits<EC>::space_type>::value,
+      int> = 0>
+  gtensor_span(const gtensor_container<EC, N>& other)
     : base_type{other.shape(), other.strides()},
       storage_{other.data(), other.size()}
   {}

--- a/include/gtensor/gtensor_span.h
+++ b/include/gtensor/gtensor_span.h
@@ -29,7 +29,7 @@ struct gtensor_inner_types<gtensor_span<T, N, S>>
   using space_type = S;
   constexpr static size_type dimension = N;
 
-  using storage_type = typename space_type::template Span<T>;
+  using storage_type = typename space::space_traits<S>::template span_type<T>;
   using value_type = typename storage_type::value_type;
   using pointer = typename storage_type::pointer;
   using const_pointer = typename storage_type::const_pointer;

--- a/include/gtensor/gtensor_span.h
+++ b/include/gtensor/gtensor_span.h
@@ -16,10 +16,6 @@ namespace gt
 // ======================================================================
 // gtensor_span
 
-// forward declaration for conversion constructor
-template <typename T, size_type N, typename S>
-class gtensor;
-
 template <typename T, size_type N, typename S = space::host>
 class gtensor_span;
 
@@ -73,18 +69,18 @@ public:
 
   // Implicit conversion from a gtensor object with the same or compaitible
   // element type
-  template <class OtherT,
-            std::enable_if_t<
-              is_allowed_element_type_conversion<OtherT, T>::value, int> = 0>
-  gtensor_span(gtensor<OtherT, N, S>& other)
+  template <class EC, std::enable_if_t<is_allowed_element_type_conversion<
+                                         typename EC::value_type, T>::value,
+                                       int> = 0>
+  gtensor_span(gtensor_container<EC, N, S>& other)
     : base_type{other.shape(), other.strides()},
       storage_{other.data(), other.size()}
   {}
 
-  template <class OtherT,
-            std::enable_if_t<
-              is_allowed_element_type_conversion<OtherT, T>::value, int> = 0>
-  gtensor_span(const gtensor<OtherT, N, S>& other)
+  template <class EC, std::enable_if_t<is_allowed_element_type_conversion<
+                                         typename EC::value_type, T>::value,
+                                       int> = 0>
+  gtensor_span(const gtensor_container<EC, N, S>& other)
     : base_type{other.shape(), other.strides()},
       storage_{other.data(), other.size()}
   {}

--- a/include/gtensor/space.h
+++ b/include/gtensor/space.h
@@ -42,11 +42,11 @@ struct kernel;
 #ifdef GTENSOR_USE_THRUST
 
 template <typename T, typename A = GTENSOR_DEFAULT_HOST_ALLOCATOR(T)>
-using host_vector = thrust::host_vector<T, A>;
+using host_vector = ::thrust::host_vector<T, A>;
 
 #ifdef GTENSOR_HAVE_DEVICE
 template <typename T, typename A = GTENSOR_DEFAULT_DEVICE_ALLOCATOR(T)>
-using device_vector = thrust::device_vector<T, A>;
+using device_vector = ::thrust::device_vector<T, A>;
 #endif
 
 #else

--- a/include/gtensor/space.h
+++ b/include/gtensor/space.h
@@ -61,6 +61,47 @@ using device_vector = gt::backend::device_storage<T, A>;
 
 #endif // GTENSOR_USE_THRUST
 
+// ======================================================================
+// storage_traits
+
+template <typename EC>
+struct storage_traits;
+
+template <typename T, typename A>
+struct storage_traits<gt::backend::host_storage<T, A>>
+{
+  using space_type = space::host;
+};
+
+#ifdef GTENSOR_HAVE_DEVICE
+
+template <typename T, typename A>
+struct storage_traits<gt::backend::device_storage<T, A>>
+{
+  using space_type = space::device;
+};
+
+#endif
+
+#ifdef GTENSOR_USE_THRUST
+
+template <typename T, typename A>
+struct storage_traits<::thrust::host_vector<T, A>>
+{
+  using space_type = space::host;
+};
+
+template <typename T, typename A>
+struct storage_traits<::thrust::device_vector<T, A>>
+{
+  using space_type = space::device;
+};
+
+#endif
+
+// ======================================================================
+// space_traits
+
 template <typename S>
 struct space_traits
 {};

--- a/include/gtensor/space.h
+++ b/include/gtensor/space.h
@@ -61,27 +61,29 @@ using device_vector = gt::backend::device_storage<T, A>;
 
 #endif // GTENSOR_USE_THRUST
 
-struct host
+template <typename S>
+struct space_traits
+{};
+
+template <>
+struct space_traits<host>
 {
   template <typename T>
-  using Vector = host_vector<T>;
+  using storage_type = host_vector<T>;
   template <typename T>
-  using Span = span<T>;
+  using span_type = span<T>;
 };
 
 #ifdef GTENSOR_HAVE_DEVICE
 
-struct device
+template <>
+struct space_traits<device>
 {
   template <typename T>
-  using Vector = device_vector<T>;
+  using storage_type = device_vector<T>;
   template <typename T>
-  using Span = device_span<T>;
+  using span_type = device_span<T>;
 };
-
-#else // not GTENSOR_HAVE_DEVICE
-
-using device = host;
 
 #endif
 

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -279,10 +279,12 @@ TEST(gtensor, is_expression_types)
   EXPECT_TRUE(gt::is_gtensor_span<decltype(aspan)>::value);
 }
 
-template <typename T, gt::size_type N, typename S, typename T2,
-          typename = std::enable_if_t<std::is_convertible<T2, T>::value>>
-void expect_all_eq(gt::gtensor<T, N, S>& a, T2 value)
+template <typename EC, gt::size_type N, typename S, typename T2,
+          typename = std::enable_if_t<
+            std::is_convertible<T2, typename EC::value_type>::value>>
+void expect_all_eq(gt::gtensor_container<EC, N, S>& a, T2 value)
 {
+  using T = typename EC::value_type;
   auto aflat = gt::flatten(a);
   for (int i = 0; i < aflat.shape(0); i++) {
     EXPECT_EQ(aflat(i), T(value));

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -279,10 +279,10 @@ TEST(gtensor, is_expression_types)
   EXPECT_TRUE(gt::is_gtensor_span<decltype(aspan)>::value);
 }
 
-template <typename EC, gt::size_type N, typename S, typename T2,
+template <typename EC, gt::size_type N, typename T2,
           typename = std::enable_if_t<
             std::is_convertible<T2, typename EC::value_type>::value>>
-void expect_all_eq(gt::gtensor_container<EC, N, S>& a, T2 value)
+void expect_all_eq(gt::gtensor_container<EC, N>& a, T2 value)
 {
   using T = typename EC::value_type;
   auto aflat = gt::flatten(a);


### PR DESCRIPTION
There is certainly some more refactoring / generalizing backends to come, but this I think is it in terms of adding flexibility to choose an allocator (as well as backend storage).

The first part is a bit of work towards having different tags for `cuda`, `hip`, etc, and having `device` just be an alias for whatever is default. However, this didn't go very far as other parts aren't really ready for it -- in particular, `gtensor_storage` is still using plain pointers, which are obviously indistinguishable between `cuda`, `hip`, etc, or even `host`.

The second part essentially turns `gtensor` into `gtensor_container`, which is now templated by the underlying storage (`EC`, take from xtensor, I suppose short for `element container`).  `gtensor` itself became an alias, preserving its template arguments, though as can be seen in the examples, that did cause a bit of breakage since template argument deduction is impacted.