### PR TITLE
backend

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cxx: [ 'g++-9', 'clang++-9' ]
+        cxx: [ 'g++-11', 'clang++-11' ]
     name: tests-cpu-cxx20-${{ matrix.cxx }}
 
     steps:

--- a/benchmarks/ij_deriv.cxx
+++ b/benchmarks/ij_deriv.cxx
@@ -455,17 +455,17 @@ void test_ij_deriv(int li0, int lj0, int lbg0)
 
   // native GPU api
   for (int i = 0; i < time_warmup_count; i++) {
-    ij_deriv_gpu(li0, lj0, lbg0, gt::backend::raw_pointer_cast(d_arr.data()),
-                 ncoeff, gt::backend::raw_pointer_cast(d_coeff.data()),
-                 gt::backend::raw_pointer_cast(d_ikj.data()),
-                 gt::backend::raw_pointer_cast(d_darr.data()));
+    ij_deriv_gpu(li0, lj0, lbg0, gt::raw_pointer_cast(d_arr.data()), ncoeff,
+                 gt::raw_pointer_cast(d_coeff.data()),
+                 gt::raw_pointer_cast(d_ikj.data()),
+                 gt::raw_pointer_cast(d_darr.data()));
   }
   clock_gettime(CLOCK_MONOTONIC, &start);
   for (int i = 0; i < time_run_count; i++) {
-    ij_deriv_gpu(li0, lj0, lbg0, gt::backend::raw_pointer_cast(d_arr.data()),
-                 ncoeff, gt::backend::raw_pointer_cast(d_coeff.data()),
-                 gt::backend::raw_pointer_cast(d_ikj.data()),
-                 gt::backend::raw_pointer_cast(d_darr.data()));
+    ij_deriv_gpu(li0, lj0, lbg0, gt::raw_pointer_cast(d_arr.data()), ncoeff,
+                 gt::raw_pointer_cast(d_coeff.data()),
+                 gt::raw_pointer_cast(d_ikj.data()),
+                 gt::raw_pointer_cast(d_darr.data()));
   }
   clock_gettime(CLOCK_MONOTONIC, &end);
   seconds_per_run =
@@ -487,17 +487,17 @@ void test_ij_deriv(int li0, int lj0, int lbg0)
 
   // gtensor gpu
   for (int i = 0; i < time_warmup_count; i++) {
-    ij_deriv_gt_device(
-      li0, lj0, lbg0, gt::backend::raw_pointer_cast(d_arr.data()), ncoeff,
-      h_coeff.data(), gt::backend::raw_pointer_cast(d_ikj.data()),
-      gt::backend::raw_pointer_cast(d_darr.data()));
+    ij_deriv_gt_device(li0, lj0, lbg0, gt::raw_pointer_cast(d_arr.data()),
+                       ncoeff, h_coeff.data(),
+                       gt::raw_pointer_cast(d_ikj.data()),
+                       gt::raw_pointer_cast(d_darr.data()));
   }
   clock_gettime(CLOCK_MONOTONIC, &start);
   for (int i = 0; i < time_run_count; i++) {
-    ij_deriv_gt_device(
-      li0, lj0, lbg0, gt::backend::raw_pointer_cast(d_arr.data()), ncoeff,
-      h_coeff.data(), gt::backend::raw_pointer_cast(d_ikj.data()),
-      gt::backend::raw_pointer_cast(d_darr.data()));
+    ij_deriv_gt_device(li0, lj0, lbg0, gt::raw_pointer_cast(d_arr.data()),
+                       ncoeff, h_coeff.data(),
+                       gt::raw_pointer_cast(d_ikj.data()),
+                       gt::raw_pointer_cast(d_darr.data()));
   }
   clock_gettime(CLOCK_MONOTONIC, &end);
   seconds_per_run =

--- a/include/gt-fft/fft.h
+++ b/include/gt-fft/fft.h
@@ -52,8 +52,8 @@ public:
               has_container_methods_v<C2> && has_space_type_device_v<C2>>>
   void operator()(C1& in, C2& out) const
   {
-    operator()(gt::backend::raw_pointer_cast(in.data()),
-               gt::backend::raw_pointer_cast(out.data()));
+    operator()(gt::raw_pointer_cast(in.data()),
+               gt::raw_pointer_cast(out.data()));
   }
 
   template <typename C1, typename C2,
@@ -62,8 +62,7 @@ public:
               has_container_methods_v<C2> && has_space_type_device_v<C2>>>
   void inverse(C1& in, C2& out) const
   {
-    inverse(gt::backend::raw_pointer_cast(in.data()),
-            gt::backend::raw_pointer_cast(out.data()));
+    inverse(gt::raw_pointer_cast(in.data()), gt::raw_pointer_cast(out.data()));
   }
 };
 

--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -16,60 +16,61 @@ namespace backend
 
 namespace allocator_impl
 {
+
 template <>
 struct gallocator<gt::space::cuda>
 {
-  struct device
+  template <typename T>
+  static T* allocate(size_type n)
   {
-    template <typename T>
-    static T* allocate(size_type n)
-    {
-      T* p;
-      gtGpuCheck(cudaMalloc(&p, sizeof(T) * n));
-      return p;
-    }
+    T* p;
+    gtGpuCheck(cudaMalloc(&p, sizeof(T) * n));
+    return p;
+  }
 
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      gtGpuCheck(cudaFree(p));
-    }
-  };
-
-  struct managed
+  template <typename T>
+  static void deallocate(T* p)
   {
-    template <typename T>
-    static T* allocate(size_t n)
-    {
-      T* p;
-      gtGpuCheck(cudaMallocManaged(&p, sizeof(T) * n));
-      return p;
-    }
-
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      gtGpuCheck(cudaFree(p));
-    }
-  };
-
-  struct host
-  {
-    template <typename T>
-    static T* allocate(size_type n)
-    {
-      T* p;
-      gtGpuCheck(cudaMallocHost(&p, sizeof(T) * n));
-      return p;
-    }
-
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      gtGpuCheck(cudaFreeHost(p));
-    }
-  };
+    gtGpuCheck(cudaFree(p));
+  }
 };
+
+template <>
+struct gallocator<gt::space::cuda_managed>
+{
+  template <typename T>
+  static T* allocate(size_t n)
+  {
+    T* p;
+    gtGpuCheck(cudaMallocManaged(&p, sizeof(T) * n));
+    return p;
+  }
+
+  template <typename T>
+  static void deallocate(T* p)
+  {
+    gtGpuCheck(cudaFree(p));
+  }
+};
+
+template <>
+struct gallocator<gt::space::cuda_host>
+{
+  template <typename T>
+  static T* allocate(size_type n)
+  {
+    T* p;
+    gtGpuCheck(cudaMallocHost(&p, sizeof(T) * n));
+    return p;
+  }
+
+  template <typename T>
+  static void deallocate(T* p)
+  {
+    gtGpuCheck(cudaFreeHost(p));
+  }
+};
+
 } // namespace allocator_impl
 
 namespace cuda

--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -149,7 +149,7 @@ inline void copy_n(gt::space::cuda tag_in, gt::space::cuda tag_out, InputPtr in,
                    size_type count, OutputPtr out)
 {
   gtGpuCheck(cudaMemcpy(
-    backend::raw_pointer_cast(out), backend::raw_pointer_cast(in),
+    gt::raw_pointer_cast(out), gt::raw_pointer_cast(in),
     sizeof(typename gt::pointer_traits<InputPtr>::element_type) * count,
     cudaMemcpyDeviceToDevice));
 }
@@ -159,7 +159,7 @@ inline void copy_n(gt::space::cuda tag_in, gt::space::host tag_out, InputPtr in,
                    size_type count, OutputPtr out)
 {
   gtGpuCheck(cudaMemcpy(
-    backend::raw_pointer_cast(out), backend::raw_pointer_cast(in),
+    gt::raw_pointer_cast(out), gt::raw_pointer_cast(in),
     sizeof(typename gt::pointer_traits<InputPtr>::element_type) * count,
     cudaMemcpyDeviceToHost));
 }
@@ -169,7 +169,7 @@ inline void copy_n(gt::space::host tag_in, gt::space::cuda tag_out, InputPtr in,
                    size_type count, OutputPtr out)
 {
   gtGpuCheck(cudaMemcpy(
-    backend::raw_pointer_cast(out), backend::raw_pointer_cast(in),
+    gt::raw_pointer_cast(out), gt::raw_pointer_cast(in),
     sizeof(typename gt::pointer_traits<InputPtr>::element_type) * count,
     cudaMemcpyHostToDevice));
 }
@@ -180,7 +180,7 @@ inline void copy_n(gt::space::host tag_in, gt::space::host tag_out, InputPtr in,
                    size_type count, OutputPtr out)
 {
   gtGpuCheck(cudaMemcpy(
-    backend::raw_pointer_cast(out), backend::raw_pointer_cast(in),
+    gt::raw_pointer_cast(out), gt::raw_pointer_cast(in),
     sizeof(typename gt::pointer_traits<InputPtr>::element_type) * count,
     cudaMemcpyHostToHost));
 }
@@ -195,11 +195,11 @@ inline void fill(gt::space::cuda tag, Ptr first, Ptr last, const T& value)
 {
   using element_type = typename gt::pointer_traits<Ptr>::element_type;
   if (element_type(value) == element_type()) {
-    gtGpuCheck(cudaMemset(backend::raw_pointer_cast(first), 0,
+    gtGpuCheck(cudaMemset(gt::raw_pointer_cast(first), 0,
                           (last - first) * sizeof(element_type)));
   } else {
     assert(sizeof(element_type) == 1);
-    gtGpuCheck(cudaMemset(backend::raw_pointer_cast(first), value,
+    gtGpuCheck(cudaMemset(gt::raw_pointer_cast(first), value,
                           (last - first) * sizeof(element_type)));
   }
 }

--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -122,27 +122,6 @@ inline uint32_t device_get_vendor_id(int device_id)
 
 } // namespace cuda
 
-namespace allocator_impl
-{
-
-template <typename T>
-struct selector<T, gt::space::cuda>
-{
-  using type =
-    wrap_allocator<T, gallocator<gt::space::cuda>::device, gt::space::cuda>;
-};
-
-#if 0
-template <typename T>
-struct selector<T, gt::space::host>
-{
-  using type =
-    wrap_allocator<T, gallocator<gt::space::cuda>::host, gt::space::host>;
-};
-#endif
-
-} // namespace allocator_impl
-
 namespace copy_impl
 {
 

--- a/include/gtensor/backend_hip.h
+++ b/include/gtensor/backend_hip.h
@@ -149,7 +149,7 @@ inline void copy_n(gt::space::hip tag_in, gt::space::hip tag_out, InputPtr in,
                    size_type count, OutputPtr out)
 {
   gtGpuCheck(hipMemcpy(
-    backend::raw_pointer_cast(out), backend::raw_pointer_cast(in),
+    gt::raw_pointer_cast(out), gt::raw_pointer_cast(in),
     sizeof(typename gt::pointer_traits<InputPtr>::element_type) * count,
     hipMemcpyDeviceToDevice));
 }
@@ -159,7 +159,7 @@ inline void copy_n(gt::space::hip tag_in, gt::space::host tag_out, InputPtr in,
                    size_type count, OutputPtr out)
 {
   gtGpuCheck(hipMemcpy(
-    backend::raw_pointer_cast(out), backend::raw_pointer_cast(in),
+    gt::raw_pointer_cast(out), gt::raw_pointer_cast(in),
     sizeof(typename gt::pointer_traits<InputPtr>::element_type) * count,
     hipMemcpyDeviceToHost));
 }
@@ -169,7 +169,7 @@ inline void copy_n(gt::space::host tag_in, gt::space::hip tag_out, InputPtr in,
                    size_type count, OutputPtr out)
 {
   gtGpuCheck(hipMemcpy(
-    backend::raw_pointer_cast(out), backend::raw_pointer_cast(in),
+    gt::raw_pointer_cast(out), gt::raw_pointer_cast(in),
     sizeof(typename gt::pointer_traits<InputPtr>::element_type) * count,
     hipMemcpyHostToDevice));
 }
@@ -180,7 +180,7 @@ inline void copy_n(gt::space::host tag_in, gt::space::host tag_out, InputPtr in,
                    size_type count, OutputPtr out)
 {
   gtGpuCheck(hipMemcpy(
-    backend::raw_pointer_cast(out), backend::raw_pointer_cast(in),
+    gt::raw_pointer_cast(out), gt::raw_pointer_cast(in),
     sizeof(typename gt::pointer_traits<InputPtr>::element_type) * count,
     hipMemcpyHostToHost));
 }
@@ -195,11 +195,11 @@ inline void fill(gt::space::hip tag, Ptr first, Ptr last, const T& value)
 {
   using element_type = typename gt::pointer_traits<Ptr>::element_type;
   if (element_type(value) == element_type()) {
-    gtGpuCheck(hipMemset(backend::raw_pointer_cast(first), 0,
+    gtGpuCheck(hipMemset(gt::raw_pointer_cast(first), 0,
                          (last - first) * sizeof(element_type)));
   } else {
     assert(sizeof(element_type) == 1);
-    gtGpuCheck(hipMemset(backend::raw_pointer_cast(first), value,
+    gtGpuCheck(hipMemset(gt::raw_pointer_cast(first), value,
                          (last - first) * sizeof(element_type)));
   }
 }

--- a/include/gtensor/backend_hip.h
+++ b/include/gtensor/backend_hip.h
@@ -122,27 +122,6 @@ inline uint32_t device_get_vendor_id(int device_id)
 
 } // namespace hip
 
-namespace allocator_impl
-{
-
-template <typename T>
-struct selector<T, gt::space::hip>
-{
-  using type =
-    wrap_allocator<T, gallocator<gt::space::hip>::device, gt::space::hip>;
-};
-
-#if 0
-template <typename T>
-struct selector<T, gt::space::host>
-{
-  using type =
-    wrap_allocator<T, gallocator<gt::space::hip>::host, gt::space::host>;
-};
-#endif
-
-} // namespace allocator_impl
-
 namespace copy_impl
 {
 

--- a/include/gtensor/backend_hip.h
+++ b/include/gtensor/backend_hip.h
@@ -16,60 +16,61 @@ namespace backend
 
 namespace allocator_impl
 {
+
 template <>
 struct gallocator<gt::space::hip>
 {
-  struct device
+  template <typename T>
+  static T* allocate(size_type n)
   {
-    template <typename T>
-    static T* allocate(size_type n)
-    {
-      T* p;
-      gtGpuCheck(hipMalloc(&p, sizeof(T) * n));
-      return p;
-    }
+    T* p;
+    gtGpuCheck(hipMalloc(&p, sizeof(T) * n));
+    return p;
+  }
 
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      gtGpuCheck(hipFree(p));
-    }
-  };
-
-  struct managed
+  template <typename T>
+  static void deallocate(T* p)
   {
-    template <typename T>
-    static T* allocate(size_t n)
-    {
-      T* p;
-      gtGpuCheck(hipMallocManaged(&p, sizeof(T) * n));
-      return p;
-    }
-
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      gtGpuCheck(hipFree(p));
-    }
-  };
-
-  struct host
-  {
-    template <typename T>
-    static T* allocate(size_type n)
-    {
-      T* p;
-      gtGpuCheck(hipHostMalloc(&p, sizeof(T) * n));
-      return p;
-    }
-
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      gtGpuCheck(hipHostFree(p));
-    }
-  };
+    gtGpuCheck(hipFree(p));
+  }
 };
+
+template <>
+struct gallocator<gt::space::hip_managed>
+{
+  template <typename T>
+  static T* allocate(size_t n)
+  {
+    T* p;
+    gtGpuCheck(hipMallocManaged(&p, sizeof(T) * n));
+    return p;
+  }
+
+  template <typename T>
+  static void deallocate(T* p)
+  {
+    gtGpuCheck(hipFree(p));
+  }
+};
+
+template <>
+struct gallocator<gt::space::hip_host>
+{
+  template <typename T>
+  static T* allocate(size_type n)
+  {
+    T* p;
+    gtGpuCheck(hipHostMalloc(&p, sizeof(T) * n));
+    return p;
+  }
+
+  template <typename T>
+  static void deallocate(T* p)
+  {
+    gtGpuCheck(hipHostFree(p));
+  }
+};
+
 } // namespace allocator_impl
 
 namespace hip

--- a/include/gtensor/backend_host.h
+++ b/include/gtensor/backend_host.h
@@ -27,7 +27,7 @@ inline void device_synchronize()
 namespace allocator_impl
 {
 template <typename T>
-struct selector<T, gt::space::host>
+struct selector<T, gt::space::host_only>
 {
   using type = std::allocator<T>;
 };

--- a/include/gtensor/backend_sycl.h
+++ b/include/gtensor/backend_sycl.h
@@ -107,27 +107,6 @@ inline void device_copy_async_dd(const T* src, T* dst, size_type count)
 
 } // namespace sycl
 
-namespace allocator_impl
-{
-
-template <typename T>
-struct selector<T, gt::space::sycl>
-{
-  using type =
-    wrap_allocator<T, gallocator<gt::space::sycl>::device, gt::space::sycl>;
-};
-
-#if 0
-template <typename T>
-struct selector<T, gt::space::host>
-{
-  using type =
-    wrap_allocator<T, gallocator<gt::space::sycl>::host, gt::space::sycl>;
-};
-#endif
-
-} // namespace allocator_impl
-
 namespace copy_impl
 {
 

--- a/include/gtensor/backend_sycl.h
+++ b/include/gtensor/backend_sycl.h
@@ -133,7 +133,7 @@ template <typename InputPtr, typename OutputPtr>
 inline void sycl_copy_n(InputPtr in, size_type count, OutputPtr out)
 {
   cl::sycl::queue& q = gt::backend::sycl::get_queue();
-  q.memcpy(backend::raw_pointer_cast(out), backend::raw_pointer_cast(in),
+  q.memcpy(gt::raw_pointer_cast(out), gt::raw_pointer_cast(in),
            sizeof(typename gt::pointer_traits<InputPtr>::element_type) * count);
   q.wait();
 }
@@ -178,11 +178,11 @@ inline void fill(gt::space::sycl tag, Ptr first, Ptr last, const T& value)
   using element_type = typename gt::pointer_traits<Ptr>::element_type;
   cl::sycl::queue& q = gt::backend::sycl::get_queue();
   if (element_type(value) == element_type()) {
-    q.memset(backend::raw_pointer_cast(first), 0,
+    q.memset(gt::raw_pointer_cast(first), 0,
              (last - first) * sizeof(element_type));
   } else {
     assert(sizeof(element_type) == 1);
-    q.memset(backend::raw_pointer_cast(first), value,
+    q.memset(gt::raw_pointer_cast(first), value,
              (last - first) * sizeof(element_type));
   }
 }

--- a/include/gtensor/backend_sycl.h
+++ b/include/gtensor/backend_sycl.h
@@ -20,74 +20,75 @@ namespace allocator_impl
 template <>
 struct gallocator<gt::space::sycl>
 {
-  struct device
+  template <typename T>
+  static T* allocate(size_type n)
   {
-    template <typename T>
-    static T* allocate(size_type n)
-    {
-      return cl::sycl::malloc_shared<T>(n, gt::backend::sycl::get_queue());
-    }
+    return cl::sycl::malloc_shared<T>(n, gt::backend::sycl::get_queue());
+  }
 
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      cl::sycl::free(p, gt::backend::sycl::get_queue());
-    }
-  };
-
-  struct managed
+  template <typename T>
+  static void deallocate(T* p)
   {
-    template <typename T>
-    static T* allocate(size_t n)
-    {
-      return cl::sycl::malloc_shared<T>(n, gt::backend::sycl::get_queue());
-    }
-
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      cl::sycl::free(p, gt::backend::sycl::get_queue());
-    }
-  };
-
-  // The host allocation type in SYCL allows device code to directly access
-  // the data. This is generally not necessary or effecient for gtensor, so
-  // we opt for the same implementation as for the HOST device below.
-
-  struct host
-  {
-    template <typename T>
-    static T* allocate(size_type n)
-    {
-      T* p = static_cast<T*>(malloc(sizeof(T) * n));
-      if (!p) {
-        std::cerr << "host allocate failed" << std::endl;
-        std::abort();
-      }
-      return p;
-    }
-
-    template <typename T>
-    static void deallocate(T* p)
-    {
-      free(p);
-    }
-  };
-
-  // template <typename T>
-  // struct host
-  // {
-  //   static T* allocate( : size_type count)
-  //   {
-  //     return cl::sycl::malloc_host<T>(count, gt::backend::sycl::get_queue());
-  //   }
-
-  //   static void deallocate(T* p)
-  //   {
-  //     cl::sycl::free(p, gt::backend::sycl::get_queue());
-  //   }
-  // };
+    cl::sycl::free(p, gt::backend::sycl::get_queue());
+  }
 };
+
+template <>
+struct gallocator<gt::space::sycl_managed>
+{
+  template <typename T>
+  static T* allocate(size_t n)
+  {
+    return cl::sycl::malloc_shared<T>(n, gt::backend::sycl::get_queue());
+  }
+
+  template <typename T>
+  static void deallocate(T* p)
+  {
+    cl::sycl::free(p, gt::backend::sycl::get_queue());
+  }
+}; // namespace allocator_impl
+
+// The host allocation type in SYCL allows device code to directly access
+// the data. This is generally not necessary or effecient for gtensor, so
+// we opt for the same implementation as for the HOST device below.
+
+template <>
+struct gallocator<gt::space::sycl_host>
+
+{
+  template <typename T>
+  static T* allocate(size_type n)
+  {
+    T* p = static_cast<T*>(malloc(sizeof(T) * n));
+    if (!p) {
+      std::cerr << "host allocate failed" << std::endl;
+      std::abort();
+    }
+    return p;
+  }
+
+  template <typename T>
+  static void deallocate(T* p)
+  {
+    free(p);
+  }
+};
+
+// template <typename T>
+// struct host
+// {
+//   static T* allocate( : size_type count)
+//   {
+//     return cl::sycl::malloc_host<T>(count, gt::backend::sycl::get_queue());
+//   }
+
+//   static void deallocate(T* p)
+//   {
+//     cl::sycl::free(p, gt::backend::sycl::get_queue());
+//   }
+// };
+
 } // namespace allocator_impl
 
 namespace sycl

--- a/include/gtensor/backend_thrust.h
+++ b/include/gtensor/backend_thrust.h
@@ -30,6 +30,12 @@ struct selector<T, gt::space::thrust>
   using type = ::thrust::device_allocator<T>;
 #endif
 };
+
+template <typename T>
+struct selector<T, gt::space::thrust_host>
+{
+  using type = std::allocator<T>;
+};
 } // namespace allocator_impl
 
 namespace copy_impl

--- a/include/gtensor/blas.h
+++ b/include/gtensor/blas.h
@@ -39,15 +39,15 @@ template <typename C, typename = std::enable_if_t<has_container_methods_v<C> &&
 inline void axpy(handle_t* h, typename C::value_type a, const C& x, C& y)
 {
   assert(x.size() == y.size());
-  axpy(h, x.size(), a, gt::backend::raw_pointer_cast(x.data()), 1,
-       gt::backend::raw_pointer_cast(y.data()), 1);
+  axpy(h, x.size(), a, gt::raw_pointer_cast(x.data()), 1,
+       gt::raw_pointer_cast(y.data()), 1);
 }
 
 template <typename C, typename = std::enable_if_t<has_container_methods_v<C> &&
                                                   has_space_type_device_v<C>>>
 inline void scal(handle_t* h, typename C::value_type fac, C& arr)
 {
-  scal(h, arr.size(), fac, gt::backend::raw_pointer_cast(arr.data()), 1);
+  scal(h, arr.size(), fac, gt::raw_pointer_cast(arr.data()), 1);
 }
 
 template <typename C, typename = std::enable_if_t<has_container_methods_v<C> &&
@@ -55,39 +55,39 @@ template <typename C, typename = std::enable_if_t<has_container_methods_v<C> &&
                                                   has_complex_value_type_v<C>>>
 inline void scal(handle_t* h, container_complex_subtype_t<C> fac, C& arr)
 {
-  scal(h, arr.size(), fac, gt::backend::raw_pointer_cast(arr.data()), 1);
+  scal(h, arr.size(), fac, gt::raw_pointer_cast(arr.data()), 1);
 }
 
 template <typename C, typename = std::enable_if_t<has_container_methods_v<C> &&
                                                   has_space_type_device_v<C>>>
 inline void copy(handle_t* h, C& src, C& dest)
 {
-  copy(h, src.size(), gt::backend::raw_pointer_cast(src.data()), 1,
-       gt::backend::raw_pointer_cast(dest.data()), 1);
+  copy(h, src.size(), gt::raw_pointer_cast(src.data()), 1,
+       gt::raw_pointer_cast(dest.data()), 1);
 }
 
 template <typename C, typename = std::enable_if_t<has_container_methods_v<C> &&
                                                   has_space_type_device_v<C>>>
 inline typename C::value_type dot(handle_t* h, const C& x, const C& y)
 {
-  return dot(h, x.size(), gt::backend::raw_pointer_cast(x.data()), 1,
-             gt::backend::raw_pointer_cast(y.data()), 1);
+  return dot(h, x.size(), gt::raw_pointer_cast(x.data()), 1,
+             gt::raw_pointer_cast(y.data()), 1);
 }
 
 template <typename C, typename = std::enable_if_t<has_container_methods_v<C> &&
                                                   has_space_type_device_v<C>>>
 inline typename C::value_type dotu(handle_t* h, const C& x, const C& y)
 {
-  return dotu(h, x.size(), gt::backend::raw_pointer_cast(x.data()), 1,
-              gt::backend::raw_pointer_cast(y.data()), 1);
+  return dotu(h, x.size(), gt::raw_pointer_cast(x.data()), 1,
+              gt::raw_pointer_cast(y.data()), 1);
 }
 
 template <typename C, typename = std::enable_if_t<has_container_methods_v<C> &&
                                                   has_space_type_device_v<C>>>
 inline typename C::value_type dotc(handle_t* h, const C& x, const C& y)
 {
-  return dotc(h, x.size(), gt::backend::raw_pointer_cast(x.data()), 1,
-              gt::backend::raw_pointer_cast(y.data()), 1);
+  return dotc(h, x.size(), gt::raw_pointer_cast(x.data()), 1,
+              gt::raw_pointer_cast(y.data()), 1);
 }
 
 template <typename M, typename V,
@@ -106,10 +106,9 @@ inline void gemv(handle_t* h, typename M::value_type alpha, M& A, V& x,
     "matrix and vectors must have same value type");
   assert(A.shape(1) == x.shape(0));
 
-  gemv(h, A.shape(0), A.shape(1), alpha,
-       gt::backend::raw_pointer_cast(A.data()), A.shape(0),
-       gt::backend::raw_pointer_cast(x.data()), 1, beta,
-       gt::backend::raw_pointer_cast(y.data()), 1);
+  gemv(h, A.shape(0), A.shape(1), alpha, gt::raw_pointer_cast(A.data()),
+       A.shape(0), gt::raw_pointer_cast(x.data()), 1, beta,
+       gt::raw_pointer_cast(y.data()), 1);
 }
 
 } // end namespace blas

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -86,8 +86,8 @@ GT_INLINE auto device_pointer_cast(T* p)
 
 namespace backend
 {
-
-// ======================================================================
+namespace allocator_impl
+{
 
 template <typename T, typename A, typename S>
 struct wrap_allocator
@@ -103,22 +103,26 @@ struct wrap_allocator
   }
 };
 
-namespace allocator_impl
-{
 template <typename S>
 struct gallocator;
 
 template <typename T, typename S>
-struct selector;
+struct selector
+{
+  using type = wrap_allocator<T, typename gallocator<S>::device, S>;
+};
+
 } // namespace allocator_impl
 
+#if 0 // host handled generically
+template <typename T>
+struct selector<T, gt::space::host>
+{
+  using type =
+    wrap_allocator<T, gallocator<gt::space::cuda>::host, gt::space::host>;
+};
+#endif
 } // namespace backend
-
-template <typename T, typename S = gt::space::device>
-using device_allocator = typename backend::allocator_impl::selector<T, S>::type;
-
-template <typename T, typename S = gt::space::host>
-using host_allocator = typename backend::allocator_impl::selector<T, S>::type;
 
 } // namespace gt
 
@@ -161,6 +165,12 @@ using namespace backend::host;
 } // namespace clib
 
 } // namespace backend
+
+template <typename T, typename S = gt::space::device>
+using device_allocator = typename backend::allocator_impl::selector<T, S>::type;
+
+template <typename T, typename S = gt::space::host>
+using host_allocator = typename backend::allocator_impl::selector<T, S>::type;
 
 // ======================================================================
 // fill

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -154,6 +154,11 @@ using namespace backend::host;
 #endif
 } // namespace clib
 
+} // namespace backend
+
+// ======================================================================
+// fill
+
 template <
   typename Ptr, typename T,
   std::enable_if_t<
@@ -161,11 +166,9 @@ template <
     int> = 0>
 void fill(Ptr first, Ptr last, const T& value)
 {
-  return fill_impl::fill(typename pointer_traits<Ptr>::space_type{}, first,
-                         last, value);
+  return backend::fill_impl::fill(typename pointer_traits<Ptr>::space_type{},
+                                  first, last, value);
 }
-
-} // namespace backend
 
 // ======================================================================
 // copy_n

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -105,9 +105,12 @@ struct wrap_allocator
 
 namespace allocator_impl
 {
+template <typename S>
+struct gallocator;
+
 template <typename T, typename S>
 struct selector;
-}
+} // namespace allocator_impl
 
 } // namespace backend
 
@@ -145,10 +148,13 @@ namespace clib
 {
 #if GTENSOR_DEVICE_CUDA
 using namespace backend::cuda;
+using gallocator = backend::allocator_impl::gallocator<gt::space::cuda>;
 #elif GTENSOR_DEVICE_HIP
 using namespace backend::hip;
+using gallocator = backend::allocator_impl::gallocator<gt::space::hip>;
 #elif GTENSOR_DEVICE_SYCL
 using namespace backend::sycl;
+using gallocator = backend::allocator_impl::gallocator<gt::space::sycl>;
 #else // just for device_synchronize()
 using namespace backend::host;
 #endif

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -109,13 +109,14 @@ template <typename T, typename S>
 struct selector;
 }
 
+} // namespace backend
+
 template <typename T, typename S = gt::space::device>
-using device_allocator = typename allocator_impl::selector<T, S>::type;
+using device_allocator = typename backend::allocator_impl::selector<T, S>::type;
 
 template <typename T, typename S = gt::space::host>
-using host_allocator = typename allocator_impl::selector<T, S>::type;
+using host_allocator = typename backend::allocator_impl::selector<T, S>::type;
 
-} // namespace backend
 } // namespace gt
 
 #include "backend_host.h"

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -109,19 +109,11 @@ struct gallocator;
 template <typename T, typename S>
 struct selector
 {
-  using type = wrap_allocator<T, typename gallocator<S>::device, S>;
+  using type = wrap_allocator<T, gallocator<S>, S>;
 };
 
 } // namespace allocator_impl
 
-#if 0 // host handled generically
-template <typename T>
-struct selector<T, gt::space::host>
-{
-  using type =
-    wrap_allocator<T, gallocator<gt::space::cuda>::host, gt::space::host>;
-};
-#endif
 } // namespace backend
 
 } // namespace gt
@@ -152,16 +144,16 @@ namespace clib
 {
 #if GTENSOR_DEVICE_CUDA
 using namespace backend::cuda;
-using gallocator = backend::allocator_impl::gallocator<gt::space::cuda>;
 #elif GTENSOR_DEVICE_HIP
 using namespace backend::hip;
-using gallocator = backend::allocator_impl::gallocator<gt::space::hip>;
 #elif GTENSOR_DEVICE_SYCL
 using namespace backend::sycl;
-using gallocator = backend::allocator_impl::gallocator<gt::space::sycl>;
 #else // just for device_synchronize()
 using namespace backend::host;
 #endif
+
+template <typename S>
+using gallocator = gt::backend::allocator_impl::gallocator<S>;
 } // namespace clib
 
 } // namespace backend

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -71,9 +71,6 @@ using device_ptr = space_pointer<T, S>;
 template <typename T, typename S = gt::space::host>
 using host_ptr = space_pointer<T, S>;
 
-namespace backend
-{
-
 template <typename P>
 GT_INLINE auto raw_pointer_cast(P p)
 {
@@ -86,6 +83,9 @@ GT_INLINE auto device_pointer_cast(T* p)
   using pointer = typename gt::device_ptr<T, gt::space::device>;
   return pointer(p);
 }
+
+namespace backend
+{
 
 // ======================================================================
 

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -51,13 +51,19 @@ struct space_traits<device>
   using pointer = ::thrust::device_ptr<T>;
 #else
   template <typename T>
-  using pointer = gt::device_ptr<T>;
+  using pointer = gt::backend::device_ptr<T>;
 #endif
 };
 
 #endif
 
 } // namespace space
+
+template <typename T, typename S = gt::space::device>
+using device_ptr = typename gt::space::space_traits<S>::template pointer<T>;
+
+template <typename T, typename S = gt::space::host>
+using host_ptr = typename gt::space::space_traits<S>::template pointer<T>;
 
 namespace backend
 {

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -59,11 +59,14 @@ struct space_traits<device>
 
 } // namespace space
 
+template <typename T, typename S>
+using space_pointer = typename gt::space::space_traits<S>::template pointer<T>;
+
 template <typename T, typename S = gt::space::device>
-using device_ptr = typename gt::space::space_traits<S>::template pointer<T>;
+using device_ptr = space_pointer<T, S>;
 
 template <typename T, typename S = gt::space::host>
-using host_ptr = typename gt::space::space_traits<S>::template pointer<T>;
+using host_ptr = space_pointer<T, S>;
 
 namespace backend
 {

--- a/include/gtensor/device_ptr.h
+++ b/include/gtensor/device_ptr.h
@@ -3,6 +3,7 @@
 
 #include "defs.h"
 #include "helper.h"
+#include "space_forward.h"
 
 namespace gt
 {
@@ -11,6 +12,13 @@ class device_ptr
 {
 public:
   using self_type = device_ptr<T>;
+
+  using element_type = T;
+  using difference_type = std::ptrdiff_t;
+  using space_type = gt::space::device;
+
+  template <typename U>
+  using rebind = device_ptr<U>;
 
   device_ptr() = default;
   device_ptr(std::nullptr_t){};
@@ -40,7 +48,7 @@ public:
     return self_type(get() - off);
   }
 
-  GT_INLINE std::ptrdiff_t operator-(const self_type& other) const
+  GT_INLINE difference_type operator-(const self_type& other) const
   {
     return get() - other.get();
   }

--- a/include/gtensor/device_ptr.h
+++ b/include/gtensor/device_ptr.h
@@ -7,6 +7,9 @@
 
 namespace gt
 {
+namespace backend
+{
+
 template <typename T>
 class device_ptr
 {
@@ -85,6 +88,7 @@ private:
   T* p_ = nullptr;
 };
 
+} // namespace backend
 } // namespace gt
 
 #endif

--- a/include/gtensor/gcontainer.h
+++ b/include/gtensor/gcontainer.h
@@ -94,7 +94,7 @@ template <typename D>
 inline void gcontainer<D>::fill(const value_type v)
 {
   if (v == value_type(0)) {
-    backend::fill(this->data(), this->data() + this->size(), 0);
+    gt::fill(this->data(), this->data() + this->size(), 0);
   } else {
     assign(derived(), scalar(v));
   }

--- a/include/gtensor/gtensor_span.h
+++ b/include/gtensor/gtensor_span.h
@@ -160,7 +160,7 @@ template <typename T, size_type N, typename S>
 inline void gtensor_span<T, N, S>::fill(const value_type v)
 {
   if (v == T(0)) {
-    backend::fill(this->data(), this->data() + this->size(), 0);
+    gt::fill(this->data(), this->data() + this->size(), 0);
   } else {
     assign(*this, scalar(v));
   }

--- a/include/gtensor/gtensor_span.h
+++ b/include/gtensor/gtensor_span.h
@@ -133,16 +133,14 @@ GT_INLINE gtensor_span<T, N, S>::gtensor_span(pointer data,
 #if defined(GTENSOR_DEVICE_CUDA) && !defined(__CUDACC__)
   if (std::is_same<S, space::device>::value) {
     cudaPointerAttributes attr;
-    gtGpuCheck(
-      cudaPointerGetAttributes(&attr, gt::backend::raw_pointer_cast(data)));
+    gtGpuCheck(cudaPointerGetAttributes(&attr, gt::raw_pointer_cast(data)));
     assert(attr.type == cudaMemoryTypeDevice ||
            attr.type == cudaMemoryTypeManaged);
   }
 #elif defined(GTENSOR_DEVICE_HIP)
   if (std::is_same<S, space::device>::value) {
     hipPointerAttribute_t attr;
-    gtGpuCheck(
-      hipPointerGetAttributes(&attr, gt::backend::raw_pointer_cast(data)));
+    gtGpuCheck(hipPointerGetAttributes(&attr, gt::raw_pointer_cast(data)));
     assert(attr.memoryType == hipMemoryTypeDevice || attr.isManaged);
   }
 #endif
@@ -221,8 +219,8 @@ template <size_type N, typename T>
 GT_INLINE gtensor_span<T, N, space::device> adapt_device(
   T* data, const shape_type<N>& shape)
 {
-  return gtensor_span<T, N, space::device>(
-    gt::backend::device_pointer_cast(data), shape, calc_strides(shape));
+  return gtensor_span<T, N, space::device>(gt::device_pointer_cast(data), shape,
+                                           calc_strides(shape));
 }
 
 template <size_type N, typename T>

--- a/include/gtensor/gtensor_span.h
+++ b/include/gtensor/gtensor_span.h
@@ -24,9 +24,7 @@ struct gtensor_inner_types<gtensor_span<T, N, S>>
   using space_type = S;
   constexpr static size_type dimension = N;
 
-  using storage_type =
-    typename gt::span<T,
-                      typename gt::space::space_traits<S>::template pointer<T>>;
+  using storage_type = typename gt::span<T, gt::space_pointer<T, S>>;
   using value_type = typename storage_type::value_type;
   using pointer = typename storage_type::pointer;
   using const_pointer = typename storage_type::const_pointer;

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -104,12 +104,12 @@ private:
 
 #ifdef GTENSOR_HAVE_DEVICE
 
-template <typename T, typename A = backend::device_allocator<T>>
+template <typename T, typename A = gt::device_allocator<T>>
 using device_storage = gtensor_storage<T, A, space::device>;
 
 #endif
 
-template <typename T, typename A = backend::host_allocator<T>>
+template <typename T, typename A = gt::host_allocator<T>>
 using host_storage = gtensor_storage<T, A, space::host>;
 
 template <typename T, typename A, typename O>

--- a/include/gtensor/pointer_traits.h
+++ b/include/gtensor/pointer_traits.h
@@ -32,17 +32,17 @@ struct pointer_traits<T*>
 };
 
 template <typename T>
-struct pointer_traits<gt::device_ptr<T>>
+struct pointer_traits<gt::backend::device_ptr<T>>
 {
   using element_type = T;
-  using pointer = gt::device_ptr<T>;
-  using const_pointer = gt::device_ptr<const T>;
+  using pointer = gt::backend::device_ptr<T>;
+  using const_pointer = gt::backend::device_ptr<const T>;
   using reference = T&;
   using const_reference = const T&;
-  using space_type = gt::space::device;
+  using space_type = typename pointer::space_type;
 
   template <typename U>
-  using rebind = gt::device_ptr<U>;
+  using rebind = gt::backend::device_ptr<U>;
 
   GT_INLINE static T* get(pointer p) { return p.get(); }
 };

--- a/include/gtensor/reductions.h
+++ b/include/gtensor/reductions.h
@@ -48,8 +48,8 @@ inline auto sum(const Container& a)
   // Not necessary in CUDA 11.2. For thrust backend and newer CUDA,
   // this only entails an extra device_ptr copy construct, so performance
   // impact will be minimal.
-  P begin(gt::backend::raw_pointer_cast(a.data()));
-  P end(gt::backend::raw_pointer_cast(a.data()) + a.size());
+  P begin(gt::raw_pointer_cast(a.data()));
+  P end(gt::raw_pointer_cast(a.data()) + a.size());
   return thrust::reduce(begin, end, 0., thrust::plus<T>());
 }
 
@@ -59,8 +59,8 @@ inline auto max(const Container& a)
 {
   using T = typename Container::value_type;
   using P = typename detail::thrust_const_pointer<Container>::type;
-  P begin(gt::backend::raw_pointer_cast(a.data()));
-  P end(gt::backend::raw_pointer_cast(a.data()) + a.size());
+  P begin(gt::raw_pointer_cast(a.data()));
+  P end(gt::raw_pointer_cast(a.data()) + a.size());
   return thrust::reduce(begin, end, 0., thrust::maximum<T>());
 }
 
@@ -70,8 +70,8 @@ inline auto min(const Container& a)
 {
   using T = typename Container::value_type;
   using P = typename detail::thrust_const_pointer<Container>::type;
-  P begin(gt::backend::raw_pointer_cast(a.data()));
-  P end(gt::backend::raw_pointer_cast(a.data()) + a.size());
+  P begin(gt::raw_pointer_cast(a.data()));
+  P end(gt::raw_pointer_cast(a.data()) + a.size());
   auto min_element = thrust::min_element(begin, end);
   return *min_element;
 }

--- a/include/gtensor/space.h
+++ b/include/gtensor/space.h
@@ -18,12 +18,12 @@
 #endif
 
 #ifndef GTENSOR_DEFAULT_HOST_ALLOCATOR
-#define GTENSOR_DEFAULT_HOST_ALLOCATOR(T) gt::backend::host_allocator<T>
+#define GTENSOR_DEFAULT_HOST_ALLOCATOR(T) gt::host_allocator<T>
 #endif
 
 #ifndef GTENSOR_DEFAULT_DEVICE_ALLOCATOR
 #define GTENSOR_DEFAULT_DEVICE_ALLOCATOR(T)                                    \
-  gt::allocator::caching_allocator<T, gt::backend::device_allocator<T>>
+  gt::allocator::caching_allocator<T, gt::device_allocator<T>>
 #endif
 
 namespace gt

--- a/include/gtensor/space_forward.h
+++ b/include/gtensor/space_forward.h
@@ -9,22 +9,40 @@ namespace gt
 namespace space
 {
 
-struct host
+struct host_only
 {};
+
 #ifdef GTENSOR_USE_THRUST
 struct thrust
 {};
+struct thrust_host
+{};
 #endif
+
 #ifdef GTENSOR_DEVICE_CUDA
 struct cuda
 {};
+struct cuda_managed
+{};
+struct cuda_host
+{};
 #endif
+
 #ifdef GTENSOR_DEVICE_HIP
 struct hip
 {};
+struct hip_managed
+{};
+struct hip_host
+{};
 #endif
+
 #ifdef GTENSOR_DEVICE_SYCL
 struct sycl
+{};
+struct sycl_managed
+{};
+struct sycl_host
 {};
 #endif
 
@@ -32,16 +50,35 @@ struct sycl
 
 #if GTENSOR_USE_THRUST
 using device = thrust;
+using host = thrust_host;
 #elif GTENSOR_DEVICE_CUDA
 using device = cuda;
+using host = cuda_host;
 #elif GTENSOR_DEVICE_HIP
 using device = hip;
+using host = hip_host;
 #elif GTENSOR_DEVICE_SYCL
 using device = sycl;
+using host = sycl_host;
+#endif
+
+#if GTENSOR_DEVICE_CUDA
+using clib_device = cuda;
+using clib_host = cuda_host;
+using clib_managed = cuda_managed;
+#elif GTENSOR_DEVICE_HIP
+using clib_device = hip;
+using clib_host = hip_host;
+using clib_managed = hip_managed;
+#elif GTENSOR_DEVICE_SYCL
+using clib_device = sycl;
+using clib_host = sycl_host;
+using clib_managed = sycl_managed;
 #endif
 
 #else // !  GTENSOR_HAVE_DEVICE
 
+using host = host_only;
 using device = host;
 
 #endif

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -73,8 +73,8 @@ void gt_backend_memcpy_hh(void* dst, const void* src, size_t nbytes)
 
 void gt_backend_memcpy_dd(void* dst, const void* src, size_t nbytes)
 {
-  gt::copy_n(gt::backend::device_pointer_cast((const uint8_t*)src), nbytes,
-             gt::backend::device_pointer_cast((uint8_t*)dst));
+  gt::copy_n(gt::device_pointer_cast((const uint8_t*)src), nbytes,
+             gt::device_pointer_cast((uint8_t*)dst));
 }
 
 void gt_backend_memcpy_async_dd(void* dst, const void* src, size_t nbytes)
@@ -85,14 +85,14 @@ void gt_backend_memcpy_async_dd(void* dst, const void* src, size_t nbytes)
 
 void gt_backend_memcpy_dh(void* dst, const void* src, size_t nbytes)
 {
-  gt::copy_n(gt::backend::device_pointer_cast((const uint8_t*)src), nbytes,
+  gt::copy_n(gt::device_pointer_cast((const uint8_t*)src), nbytes,
              (uint8_t*)dst);
 }
 
 void gt_backend_memcpy_hd(void* dst, const void* src, size_t nbytes)
 {
   gt::copy_n((const uint8_t*)src, nbytes,
-             gt::backend::device_pointer_cast((uint8_t*)dst));
+             gt::device_pointer_cast((uint8_t*)dst));
 }
 
 void gt_backend_memset(void* dst, int value, size_t nbytes)

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -36,34 +36,40 @@ uint32_t gt_backend_device_get_vendor_id(int device_id)
 
 void* gt_backend_host_allocate(size_t nbytes)
 {
-  return (void*)gt::backend::clib::gallocator::host::allocate<uint8_t>(nbytes);
+  return (void*)
+    gt::backend::clib::gallocator<gt::space::clib_host>::allocate<uint8_t>(
+      nbytes);
 }
 
 void* gt_backend_device_allocate(size_t nbytes)
 {
-  return (void*)gt::backend::clib::gallocator::device::allocate<uint8_t>(
-    nbytes);
+  return (void*)
+    gt::backend::clib::gallocator<gt::space::clib_device>::allocate<uint8_t>(
+      nbytes);
 }
 
 void* gt_backend_managed_allocate(size_t nbytes)
 {
-  return (void*)gt::backend::clib::gallocator::managed::allocate<uint8_t>(
-    nbytes);
+  return (void*)
+    gt::backend::clib::gallocator<gt::space::clib_managed>::allocate<uint8_t>(
+      nbytes);
 }
 
 void gt_backend_host_deallocate(void* p)
 {
-  gt::backend::clib::gallocator::host::deallocate((uint8_t*)p);
+  gt::backend::clib::gallocator<gt::space::clib_host>::deallocate((uint8_t*)p);
 }
 
 void gt_backend_device_deallocate(void* p)
 {
-  gt::backend::clib::gallocator::device::deallocate((uint8_t*)p);
+  gt::backend::clib::gallocator<gt::space::clib_device>::deallocate(
+    (uint8_t*)p);
 }
 
 void gt_backend_managed_deallocate(void* p)
 {
-  gt::backend::clib::gallocator::managed::deallocate((uint8_t*)p);
+  gt::backend::clib::gallocator<gt::space::clib_managed>::deallocate(
+    (uint8_t*)p);
 }
 
 void gt_backend_memcpy_hh(void* dst, const void* src, size_t nbytes)

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -97,9 +97,8 @@ void gt_backend_memcpy_hd(void* dst, const void* src, size_t nbytes)
 
 void gt_backend_memset(void* dst, int value, size_t nbytes)
 {
-  gt::backend::fill(gt::backend::device_pointer_cast((uint8_t*)dst),
-                    gt::backend::device_pointer_cast((uint8_t*)dst) + nbytes,
-                    value);
+  gt::fill(gt::device_pointer_cast((uint8_t*)dst),
+           gt::device_pointer_cast((uint8_t*)dst) + nbytes, value);
 }
 
 #endif

--- a/tests/test_adapt.cxx
+++ b/tests/test_adapt.cxx
@@ -34,8 +34,7 @@ TEST(adapt, adapt_device)
 {
   constexpr int N = 10;
   gt::backend::device_storage<int> a(N);
-  auto aview =
-    gt::adapt_device(gt::backend::raw_pointer_cast(a.data()), gt::shape(N));
+  auto aview = gt::adapt_device(gt::raw_pointer_cast(a.data()), gt::shape(N));
 
   aview = gt::scalar(7);
 

--- a/tests/test_blas.cxx
+++ b/tests/test_blas.cxx
@@ -31,8 +31,8 @@ void test_axpy_real()
 
   gt::blas::handle_t* h = gt::blas::create();
 
-  // gt::blas::axpy(h, N, &a, gt::backend::raw_pointer_cast(d_x.data()), 1,
-  //               gt::backend::raw_pointer_cast(d_y.data()), 1);
+  // gt::blas::axpy(h, N, &a, gt::raw_pointer_cast(d_x.data()), 1,
+  //               gt::raw_pointer_cast(d_y.data()), 1);
   gt::blas::axpy(h, a, d_x, d_y);
 
   gt::blas::destroy(h);
@@ -75,8 +75,8 @@ void test_axpy_complex()
 
   gt::blas::handle_t* h = gt::blas::create();
 
-  gt::blas::axpy(h, N, a, gt::backend::raw_pointer_cast(d_x.data()), 1,
-                 gt::backend::raw_pointer_cast(d_y.data()), 1);
+  gt::blas::axpy(h, N, a, gt::raw_pointer_cast(d_x.data()), 1,
+                 gt::raw_pointer_cast(d_y.data()), 1);
 
   gt::blas::destroy(h);
 
@@ -118,7 +118,7 @@ void test_scal_complex()
 
   gt::blas::handle_t* h = gt::blas::create();
 
-  // gt::blas::scal(h, N, a, gt::backend::raw_pointer_cast(d_x.data()), 1);
+  // gt::blas::scal(h, N, a, gt::raw_pointer_cast(d_x.data()), 1);
   gt::blas::scal(h, a, d_x);
   gt::blas::scal(h, b, d_y);
 
@@ -159,7 +159,7 @@ void test_scal_real()
 
   gt::blas::handle_t* h = gt::blas::create();
 
-  // gt::blas::scal(h, N, a, gt::backend::raw_pointer_cast(d_x.data()), 1);
+  // gt::blas::scal(h, N, a, gt::raw_pointer_cast(d_x.data()), 1);
   gt::blas::scal(h, a, d_x);
 
   gt::blas::destroy(h);
@@ -348,9 +348,9 @@ void test_gemv_real()
 
   gt::blas::handle_t* h = gt::blas::create();
 
-  // gt::blas::gemv(h, N, N, a, gt::backend::raw_pointer_cast(d_A.data()), N,
-  //                gt::backend::raw_pointer_cast(d_x.data()), 1, b,
-  //                gt::backend::raw_pointer_cast(d_y.data()), 1);
+  // gt::blas::gemv(h, N, N, a, gt::raw_pointer_cast(d_A.data()), N,
+  //                gt::raw_pointer_cast(d_x.data()), 1, b,
+  //                gt::raw_pointer_cast(d_y.data()), 1);
   gt::blas::gemv(h, a, d_A, d_x, b, d_y);
 
   gt::blas::destroy(h);
@@ -409,9 +409,9 @@ void test_gemv_complex()
 
   gt::blas::handle_t* h = gt::blas::create();
 
-  // gt::blas::gemv(h, N, N, a, gt::backend::raw_pointer_cast(d_mat.data()), N,
-  //                gt::backend::raw_pointer_cast(d_x.data()), 1, b,
-  //                gt::backend::raw_pointer_cast(d_y.data()), 1);
+  // gt::blas::gemv(h, N, N, a, gt::raw_pointer_cast(d_mat.data()), N,
+  //                gt::raw_pointer_cast(d_x.data()), 1, b,
+  //                gt::raw_pointer_cast(d_y.data()), 1);
   gt::blas::gemv(h, a, d_mat, d_x, b, d_y);
 
   gt::blas::destroy(h);

--- a/tests/test_cblas.cxx
+++ b/tests/test_cblas.cxx
@@ -24,8 +24,8 @@ void test_real_axpy(F&& f)
 
   gtblas_create();
 
-  f(N, &a, gt::backend::raw_pointer_cast(d_x.data()), 1,
-    gt::backend::raw_pointer_cast(d_y.data()), 1);
+  f(N, &a, gt::raw_pointer_cast(d_x.data()), 1,
+    gt::raw_pointer_cast(d_y.data()), 1);
 
   gtblas_destroy();
 
@@ -67,8 +67,8 @@ void test_complex_axpy(F&& f)
 
   gtblas_create();
 
-  f(N, &a, gt::backend::raw_pointer_cast(d_x.data()), 1,
-    gt::backend::raw_pointer_cast(d_y.data()), 1);
+  f(N, &a, gt::raw_pointer_cast(d_x.data()), 1,
+    gt::raw_pointer_cast(d_y.data()), 1);
 
   gtblas_destroy();
 
@@ -105,7 +105,7 @@ void test_real_scal(F&& f)
 
   gtblas_create();
 
-  f(N, &a, gt::backend::raw_pointer_cast(d_x.data()), 1);
+  f(N, &a, gt::raw_pointer_cast(d_x.data()), 1);
 
   gtblas_destroy();
 
@@ -147,8 +147,8 @@ void test_complex_scal(F&& f, F2&& f2)
 
   gtblas_create();
 
-  f(N, &a, gt::backend::raw_pointer_cast(d_x.data()), 1);
-  f2(N, &a2, gt::backend::raw_pointer_cast(d_y.data()), 1);
+  f(N, &a, gt::raw_pointer_cast(d_x.data()), 1);
+  f2(N, &a2, gt::raw_pointer_cast(d_y.data()), 1);
 
   gtblas_destroy();
 
@@ -218,9 +218,9 @@ void test_gemv_real(F&& f)
 
   gtblas_create();
 
-  f(N, N, &a, gt::backend::raw_pointer_cast(d_A.data()), N,
-    gt::backend::raw_pointer_cast(d_x.data()), 1, &b,
-    gt::backend::raw_pointer_cast(d_y.data()), 1);
+  f(N, N, &a, gt::raw_pointer_cast(d_A.data()), N,
+    gt::raw_pointer_cast(d_x.data()), 1, &b, gt::raw_pointer_cast(d_y.data()),
+    1);
 
   gtblas_destroy();
 
@@ -278,9 +278,9 @@ void test_gemv_complex(F&& f)
 
   gtblas_create();
 
-  f(N, N, &a, gt::backend::raw_pointer_cast(d_mat.data()), N,
-    gt::backend::raw_pointer_cast(d_x.data()), 1, &b,
-    gt::backend::raw_pointer_cast(d_y.data()), 1);
+  f(N, N, &a, gt::raw_pointer_cast(d_mat.data()), N,
+    gt::raw_pointer_cast(d_x.data()), 1, &b, gt::raw_pointer_cast(d_y.data()),
+    1);
 
   gtblas_destroy();
 

--- a/tests/test_device_backend.cxx
+++ b/tests/test_device_backend.cxx
@@ -36,7 +36,8 @@ TEST(device_backend, list_devices)
 #define N 10
 TEST(device_backend, managed_allocate)
 {
-  double* a = gt::backend::clib::gallocator::managed::allocate<double>(N);
+  using allocator = gt::backend::clib::gallocator<gt::space::clib_managed>;
+  double* a = allocator::allocate<double>(N);
   for (int i = 0; i < N; i++) {
     a[i] = ((double)i) / N;
   }
@@ -46,7 +47,7 @@ TEST(device_backend, managed_allocate)
   for (int i = 0; i < N; i++) {
     EXPECT_EQ(a[i], 1.0 + ((double)i) / N);
   }
-  gt::backend::clib::gallocator::managed::deallocate(a);
+  allocator::deallocate(a);
 }
 
 #endif

--- a/tests/test_device_ptr.cxx
+++ b/tests/test_device_ptr.cxx
@@ -70,7 +70,7 @@ TEST(device_ptr, deref)
   gt::backend::device_allocator<T> alloc;
 
   auto p = alloc.allocate(1);
-  gt::device_ptr<T> p1(gt::backend::raw_pointer_cast(p));
+  gt::device_ptr<T> p1(gt::raw_pointer_cast(p));
 
   device_ptr_deref(p1);
 
@@ -97,7 +97,7 @@ TEST(device_ptr, access)
   gt::backend::device_allocator<T> alloc;
 
   auto p = alloc.allocate(5);
-  gt::device_ptr<T> d_arr(gt::backend::raw_pointer_cast(p));
+  gt::device_ptr<T> d_arr(gt::raw_pointer_cast(p));
 
   device_ptr_access(d_arr, N);
 
@@ -127,7 +127,7 @@ TEST(device_ptr, arrow)
   gt::backend::device_allocator<T> alloc;
 
   auto p = alloc.allocate(1);
-  gt::device_ptr<T> p1(gt::backend::raw_pointer_cast(p));
+  gt::device_ptr<T> p1(gt::raw_pointer_cast(p));
 
   device_ptr_arrow(p1);
 

--- a/tests/test_fft.cxx
+++ b/tests/test_fft.cxx
@@ -51,8 +51,8 @@ void fft_r2c_1d()
   // but with fftw convention for real transforms, the last term is
   // conjugate of second and set to 0 to save storage / computation
   gt::fft::FFTPlanMany<gt::fft::Domain::REAL, E> plan({N}, batch_size);
-  // plan.exec_forward(gt::backend::raw_pointer_cast(d_A.data()),
-  //                  gt::backend::raw_pointer_cast(d_B.data()));
+  // plan.exec_forward(gt::raw_pointer_cast(d_A.data()),
+  //                  gt::raw_pointer_cast(d_B.data()));
   plan(d_A, d_B);
 
   // test roundtripping data
@@ -108,8 +108,8 @@ void fft_c2r_1d()
 
   // ifft(x) -> [8+0i 3+1i -6+0i 3-1i]
   gt::fft::FFTPlanMany<gt::fft::Domain::REAL, E> plan({N}, batch_size);
-  // plan.exec_inverse(gt::backend::raw_pointer_cast(d_B.data()),
-  //                  gt::backend::raw_pointer_cast(d_A.data()));
+  // plan.exec_inverse(gt::raw_pointer_cast(d_B.data()),
+  //                  gt::raw_pointer_cast(d_A.data()));
   plan.inverse(d_B, d_A);
 
   gt::copy(d_A, h_A);
@@ -167,8 +167,8 @@ void fft_c2c_1d_forward()
   gt::fft::FFTPlanMany<gt::fft::Domain::COMPLEX, E> plan({N}, batch_size);
 
   // ifft(x) -> [8+0i 3+1i -6+0i 3-1i]
-  // plan.exec_forward(gt::backend::raw_pointer_cast(d_A.data()),
-  //                  gt::backend::raw_pointer_cast(d_B.data()));
+  // plan.exec_forward(gt::raw_pointer_cast(d_A.data()),
+  //                  gt::raw_pointer_cast(d_B.data()));
   plan(d_A, d_B);
 
   gt::copy(d_B, h_B);
@@ -232,8 +232,8 @@ void fft_c2c_1d_inverse()
   gt::fft::FFTPlanMany<gt::fft::Domain::COMPLEX, E> plan({N}, batch_size);
 
   // ifft(x) -> [8+0i 3+1i -6+0i 3-1i]
-  // plan.exec_inverse(gt::backend::raw_pointer_cast(d_A.data()),
-  //                  gt::backend::raw_pointer_cast(d_B.data()));
+  // plan.exec_inverse(gt::raw_pointer_cast(d_A.data()),
+  //                  gt::raw_pointer_cast(d_B.data()));
   plan.inverse(d_A, d_B);
 
   gt::copy(d_B, h_B);

--- a/tests/test_fft.cxx
+++ b/tests/test_fft.cxx
@@ -43,7 +43,7 @@ void fft_r2c_1d()
 
   // zero output array, rocfft at least does not zero padding elements
   // for real to complex transform
-  gt::backend::fill(d_B.data(), d_B.data() + batch_size * Nout, 0);
+  gt::fill(d_B.data(), d_B.data() + batch_size * Nout, 0);
 
   gt::copy(h_A, d_A);
 
@@ -283,7 +283,7 @@ TEST(fft, move_only)
 
   // zero output array, rocfft at least does not zero padding elements
   // for real to complex transform
-  gt::backend::fill(d_B.data(), d_B.data() + batch_size * Nout, 0);
+  gt::fill(d_B.data(), d_B.data() + batch_size * Nout, 0);
 
   gt::copy(h_A, d_A);
 

--- a/tests/test_lapack.cxx
+++ b/tests/test_lapack.cxx
@@ -119,17 +119,16 @@ void test_getrf_batch_real()
   auto h_A0 = h_A.view(gt::all, gt::all, 0);
 
   set_A0(h_A0);
-  h_Aptr(0) = gt::backend::raw_pointer_cast(d_A.data());
+  h_Aptr(0) = gt::raw_pointer_cast(d_A.data());
 
   gt::copy(h_A, d_A);
   gt::copy(h_Aptr, d_Aptr);
 
   gt::blas::handle_t* h = gt::blas::create();
 
-  gt::blas::getrf_batched(h, N, gt::backend::raw_pointer_cast(d_Aptr.data()), N,
-                          gt::backend::raw_pointer_cast(d_p.data()),
-                          gt::backend::raw_pointer_cast(d_info.data()),
-                          batch_size);
+  gt::blas::getrf_batched(h, N, gt::raw_pointer_cast(d_Aptr.data()), N,
+                          gt::raw_pointer_cast(d_p.data()),
+                          gt::raw_pointer_cast(d_info.data()), batch_size);
 
   gt::blas::destroy(h);
 
@@ -195,7 +194,7 @@ void test_getrs_batch_real()
 
   // set up first (and only) batch
   set_A0_LU(h_A.view(gt::all, gt::all, 0));
-  h_Aptr(0) = gt::backend::raw_pointer_cast(d_A.data());
+  h_Aptr(0) = gt::raw_pointer_cast(d_A.data());
   set_A0_piv(h_p.view(gt::all, 0));
 
   // set up two col vectors to solve in first (and only) batch
@@ -207,7 +206,7 @@ void test_getrs_batch_real()
   h_B(0, 1, 0) = 73;
   h_B(1, 1, 0) = 78;
   h_B(2, 1, 0) = 154;
-  h_Bptr(0) = gt::backend::raw_pointer_cast(d_B.data());
+  h_Bptr(0) = gt::raw_pointer_cast(d_B.data());
 
   gt::copy(h_Aptr, d_Aptr);
   gt::copy(h_A, d_A);
@@ -217,10 +216,9 @@ void test_getrs_batch_real()
 
   gt::blas::handle_t* h = gt::blas::create();
 
-  gt::blas::getrs_batched(
-    h, N, NRHS, gt::backend::raw_pointer_cast(d_Aptr.data()), N,
-    gt::backend::raw_pointer_cast(d_p.data()),
-    gt::backend::raw_pointer_cast(d_Bptr.data()), N, batch_size);
+  gt::blas::getrs_batched(h, N, NRHS, gt::raw_pointer_cast(d_Aptr.data()), N,
+                          gt::raw_pointer_cast(d_p.data()),
+                          gt::raw_pointer_cast(d_Bptr.data()), N, batch_size);
 
   gt::blas::destroy(h);
 
@@ -264,7 +262,7 @@ void test_getrf_batch_complex()
 
   // setup first batch matrix input
   set_A0(h_A.view(gt::all, gt::all, 0));
-  h_Aptr(0) = gt::backend::raw_pointer_cast(d_A.data());
+  h_Aptr(0) = gt::raw_pointer_cast(d_A.data());
 
   // setup second batch matrix input
   set_A1_complex(h_A.view(gt::all, gt::all, 1));
@@ -277,10 +275,9 @@ void test_getrf_batch_complex()
 
   gt::blas::handle_t* h = gt::blas::create();
 
-  gt::blas::getrf_batched(h, N, gt::backend::raw_pointer_cast(d_Aptr.data()), N,
-                          gt::backend::raw_pointer_cast(d_p.data()),
-                          gt::backend::raw_pointer_cast(d_info.data()),
-                          batch_size);
+  gt::blas::getrf_batched(h, N, gt::raw_pointer_cast(d_Aptr.data()), N,
+                          gt::raw_pointer_cast(d_p.data()),
+                          gt::raw_pointer_cast(d_info.data()), batch_size);
 
   gt::blas::destroy(h);
 
@@ -369,7 +366,7 @@ void test_getrs_batch_complex()
 
   // setup input for first batch
   set_A0_LU(h_A.view(gt::all, gt::all, 0));
-  h_Aptr(0) = gt::backend::raw_pointer_cast(d_A.data());
+  h_Aptr(0) = gt::raw_pointer_cast(d_A.data());
   set_A0_piv(h_p.view(gt::all, 0));
 
   // setup input for second batch
@@ -394,7 +391,7 @@ void test_getrs_batch_complex()
   h_B(1, 1, 1) = T(90, -12);
   h_B(2, 1, 1) = T(112, 42);
 
-  h_Bptr(0) = gt::backend::raw_pointer_cast(d_B.data());
+  h_Bptr(0) = gt::raw_pointer_cast(d_B.data());
   h_Bptr(1) = h_Bptr(0) + N * NRHS;
 
   gt::copy(h_Aptr, d_Aptr);
@@ -406,10 +403,9 @@ void test_getrs_batch_complex()
 
   gt::blas::handle_t* h = gt::blas::create();
 
-  gt::blas::getrs_batched(
-    h, N, NRHS, gt::backend::raw_pointer_cast(d_Aptr.data()), N,
-    gt::backend::raw_pointer_cast(d_p.data()),
-    gt::backend::raw_pointer_cast(d_Bptr.data()), N, batch_size);
+  gt::blas::getrs_batched(h, N, NRHS, gt::raw_pointer_cast(d_Aptr.data()), N,
+                          gt::raw_pointer_cast(d_p.data()),
+                          gt::raw_pointer_cast(d_Bptr.data()), N, batch_size);
 
   gt::blas::destroy(h);
 

--- a/tests/test_span.cxx
+++ b/tests/test_span.cxx
@@ -57,8 +57,7 @@ TEST(span, type_aliases)
 namespace gt
 {
 template <typename T>
-using device_span = gt::span<
-  T, typename gt::space::space_traits<gt::space::device>::template pointer<T>>;
+using device_span = gt::span<T, gt::device_ptr<T>>;
 }
 
 TEST(span, device_convert_const)


### PR DESCRIPTION
Mostly some more cleanup, moving some stuff out of `backend::`, like `gt::fill` or `gt::raw_pointer_cast`, since these functions as such are now backend-independent (and then by means of the tagged pointer are dispatched to an actual backend).

This revamps the `gallocator` abstraction a bit by separately providing `gallocator` per space type, e.g., for `cuda`, `cuda_managed` and `cuda_host` rather than having them all three nested inside of a `cuda` namespace/struct.

`gallocator` unfortunately is another abstraction level that'd be nice to get rid of -- it's used to build both the C/Fortran API as well as to make regular C++ allocators. It would have been nicer to just make C++ allocators and use them for the C/Fortran API, but that's not really possible since `deallocate` would have to know the number of bytes allocated. 