### PR TITLE
add tests for gt::cos, gt::exp (incl complex)

### DIFF
--- a/include/gtensor/complex_ops.h
+++ b/include/gtensor/complex_ops.h
@@ -45,6 +45,15 @@ GT_INLINE complex<T> conj(thrust::device_reference<complex<T>> a)
   return thrust::conj(thrust::raw_reference_cast(a));
 }
 
+using std::exp;
+using thrust::exp;
+
+template <typename T>
+GT_INLINE complex<T> exp(thrust::device_reference<const thrust::complex<T>> a)
+{
+  return thrust::exp(thrust::raw_reference_cast(a));
+}
+
 #else // not CUDA and GTENSOR_USE_THRUST not defined
 
 template <typename T>
@@ -64,6 +73,8 @@ GT_INLINE complex<T> conj(const complex<T>& a)
 {
   return std::conj(a);
 }
+
+using std::exp;
 
 #endif
 

--- a/include/gtensor/complex_ops.h
+++ b/include/gtensor/complex_ops.h
@@ -16,12 +16,6 @@ GT_INLINE T norm(const complex<T>& a)
 }
 
 template <typename T>
-GT_INLINE T abs(const complex<T>& a)
-{
-  return thrust::abs(a);
-}
-
-template <typename T>
 GT_INLINE complex<T> conj(const complex<T>& a)
 {
   return thrust::conj(a);
@@ -32,6 +26,9 @@ GT_INLINE T norm(thrust::device_reference<complex<T>> a)
 {
   return thrust::norm(thrust::raw_reference_cast(a));
 }
+
+using std::abs;
+using thrust::abs;
 
 template <typename T>
 GT_INLINE T abs(thrust::device_reference<complex<T>> a)
@@ -62,11 +59,7 @@ GT_INLINE T norm(const complex<T>& a)
   return std::norm(a);
 }
 
-template <typename T>
-GT_INLINE T abs(const complex<T>& a)
-{
-  return std::abs(a);
-}
+using std::abs;
 
 template <typename T>
 GT_INLINE complex<T> conj(const complex<T>& a)

--- a/include/gtensor/complex_ops.h
+++ b/include/gtensor/complex_ops.h
@@ -46,6 +46,12 @@ using std::exp;
 using thrust::exp;
 
 template <typename T>
+GT_INLINE complex<T> exp(thrust::device_reference<thrust::complex<T>> a)
+{
+  return thrust::exp(thrust::raw_reference_cast(a));
+}
+
+template <typename T>
 GT_INLINE complex<T> exp(thrust::device_reference<const thrust::complex<T>> a)
 {
   return thrust::exp(thrust::raw_reference_cast(a));

--- a/include/gtensor/gfunction.h
+++ b/include/gtensor/gfunction.h
@@ -418,11 +418,11 @@ MAKE_BINARY_OP(divide, /)
     return function(funcs::NAME{}, std::forward<E>(e));                        \
   }
 
-MAKE_UNARY_FUNC(abs, std::abs)
+MAKE_UNARY_FUNC(abs, gt::abs)
 MAKE_UNARY_FUNC(sin, std::sin)
 MAKE_UNARY_FUNC(cos, std::cos)
 MAKE_UNARY_FUNC(tan, std::tan)
-MAKE_UNARY_FUNC(exp, std::exp)
+MAKE_UNARY_FUNC(exp, gt::exp)
 
 #undef MAKE_UNARY_FUNC
 

--- a/tests/test_expression.cxx
+++ b/tests/test_expression.cxx
@@ -213,12 +213,64 @@ TEST(expression, abs_complex)
 
 TEST(expression, sin)
 {
-  gt::gtensor<double, 1> t1({0., M_PI / 2., M_PI, 3 * M_PI / 2.});
+  gt::gtensor<double, 1> t({0., M_PI / 2., M_PI, 3 * M_PI / 2.});
   gt::gtensor<double, 1> ref({0., 1., 0., -1.});
-  auto e1 = gt::sin(t1);
 
-  EXPECT_LT(gt::norm_linf(gt::sin(t1) - ref), 1e-14);
+  EXPECT_LT(gt::norm_linf(gt::sin(t) - ref), 1e-14);
 }
+
+TEST(expression, cos)
+{
+  gt::gtensor<double, 1> t({0., M_PI / 2., M_PI, 3 * M_PI / 2.});
+  gt::gtensor<double, 1> ref({1., 0., -1., 0.});
+
+  EXPECT_LT(gt::norm_linf(gt::cos(t) - ref), 1e-14);
+}
+
+TEST(expression, exp)
+{
+  gt::gtensor<double, 1> t({0., 1.});
+  gt::gtensor<double, 1> ref({1., std::exp(1.)});
+
+  EXPECT_LT(gt::norm_linf(gt::exp(t) - ref), 1e-14);
+}
+
+TEST(expression, exp_complex)
+{
+  using namespace std::complex_literals;
+
+  gt::gtensor<double, 1> t({0., M_PI / 2., M_PI, 3 * M_PI / 2.});
+  gt::gtensor<std::complex<double>, 1> ref({1., 1.i, -1., -1.i});
+
+  EXPECT_LT(gt::norm_linf(gt::exp(1.i * t) - ref), 1e-14);
+}
+
+#ifdef GTENSOR_HAVE_DEVICE
+TEST(expression, device_exp_complex)
+{
+  using namespace std::complex_literals;
+  // gt::complex<double> I(0., 1.);
+
+  gt::gtensor_device<gt::complex<double>, 1> t(gt::shape(4));
+  gt::gtensor<gt::complex<double>, 1> h_t(gt::shape(4));
+  h_t(0) = 1.i * 0. * M_PI / 2.;
+  h_t(1) = 1.i * 1. * M_PI / 2.;
+  h_t(2) = 1.i * 2. * M_PI / 2.;
+  h_t(3) = 1.i * 3. * M_PI / 2.;
+  copy(h_t, t);
+
+  gt::gtensor_device<gt::complex<double>, 1> ref(gt::shape(4));
+  gt::gtensor<gt::complex<double>, 1> h_ref(gt::shape(4));
+  h_ref(0) = 1.;
+  h_ref(1) = 1.i;
+  h_ref(2) = -1.;
+  h_ref(3) = -1.i;
+  copy(h_ref, ref);
+
+  gt::gtensor_device<gt::complex<double>, 1> res = gt::exp(t);
+  EXPECT_LT(gt::norm_linf(res - ref), 1e-14);
+}
+#endif
 
 TEST(shape, broadcast_same)
 {

--- a/tests/test_expression.cxx
+++ b/tests/test_expression.cxx
@@ -238,26 +238,26 @@ TEST(expression, exp)
 TEST(expression, exp_complex)
 {
   using namespace std::complex_literals;
+  gt::complex<double> I(0., 1.);
 
   gt::gtensor<double, 1> t({0., M_PI / 2., M_PI, 3 * M_PI / 2.});
-  gt::gtensor<std::complex<double>, 1> ref({1., 1.i, -1., -1.i});
 
-  EXPECT_LT(gt::norm_linf(gt::exp(1.i * t) - ref), 1e-14);
+  gt::gtensor<gt::complex<double>, 1> ref(t.shape());
+  ref(0) = 1.;
+  ref(1) = 1.i;
+  ref(2) = -1.;
+  ref(3) = -1.i;
+
+  EXPECT_LT(gt::norm_linf(gt::exp(I * t) - ref), 1e-14);
 }
 
 #ifdef GTENSOR_HAVE_DEVICE
 TEST(expression, device_exp_complex)
 {
   using namespace std::complex_literals;
-  // gt::complex<double> I(0., 1.);
+  gt::complex<double> I(0., 1.);
 
-  gt::gtensor_device<gt::complex<double>, 1> t(gt::shape(4));
-  gt::gtensor<gt::complex<double>, 1> h_t(gt::shape(4));
-  h_t(0) = 1.i * 0. * M_PI / 2.;
-  h_t(1) = 1.i * 1. * M_PI / 2.;
-  h_t(2) = 1.i * 2. * M_PI / 2.;
-  h_t(3) = 1.i * 3. * M_PI / 2.;
-  copy(h_t, t);
+  gt::gtensor_device<double, 1> t({0., M_PI / 2., M_PI, 3 * M_PI / 2.});
 
   gt::gtensor_device<gt::complex<double>, 1> ref(gt::shape(4));
   gt::gtensor<gt::complex<double>, 1> h_ref(gt::shape(4));
@@ -267,8 +267,7 @@ TEST(expression, device_exp_complex)
   h_ref(3) = -1.i;
   copy(h_ref, ref);
 
-  gt::gtensor_device<gt::complex<double>, 1> res = gt::exp(t);
-  EXPECT_LT(gt::norm_linf(res - ref), 1e-14);
+  EXPECT_LT(gt::norm_linf(gt::exp(I * t) - ref), 1e-14);
 }
 #endif
 


### PR DESCRIPTION
Fixes #110. (Actually, `gt::exp` already exists -- this just adds tests for it.)
