### PR TITLE
don't enable GT_BOUNDSCHECK based on NDEBUG

### DIFF
--- a/include/gtensor/macros.h
+++ b/include/gtensor/macros.h
@@ -36,12 +36,6 @@
 
 #endif
 
-// Note: SYCL doesn't allow variadic function calls in kernel code, so the
-// bounds check implementation does not currently work.
-#if !defined(NDEBUG) && !defined(GTENSOR_DEVICE_SYCL)
-#define GT_BOUNDSCHECK
-#endif
-
 #ifdef GTENSOR_DEVICE_CUDA
 
 #define gtLaunchKernel(kernelName, numblocks, numthreads, memperblock,         \


### PR DESCRIPTION
This bounds checking is expensive, and one might want to build one's code
with asserts enabled, but without incurring the bounds checking overhead.