### PR TITLE
cmake: use TARGET_DIRECTORY for source helper

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cxx: [ 'g++-11', 'clang++-11' ]
+        cxx: [ 'g++-10', 'clang++-11' ]
     name: tests-cpu-cxx20-${{ matrix.cxx }}
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,9 +286,13 @@ function(target_gtensor_sources TARGET)
   cmake_parse_arguments(target_gtensor_sources "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
   target_sources(${TARGET} PRIVATE ${target_gtensor_sources_PRIVATE})
   if ("${GTENSOR_DEVICE}" STREQUAL "cuda")
-    set_source_files_properties(${target_gtensor_sources_PRIVATE} PROPERTIES LANGUAGE CUDA)
+    set_source_files_properties(${target_gtensor_sources_PRIVATE}
+                                TARGET_DIRECTORY ${TARGET}
+                                PROPERTIES LANGUAGE CUDA)
   else()
-    set_source_files_properties(${target_gtensor_sources_PRIVATE} PROPERTIES LANGUAGE CXX)
+    set_source_files_properties(${target_gtensor_sources_PRIVATE}
+                                TARGET_DIRECTORY ${TARGET}
+                                PROPERTIES LANGUAGE CXX)
   endif()
 endfunction()
 


### PR DESCRIPTION
Fixes issue with CMakeLists.txt in multi-level add_subdirectory,
where target is defined in a different file.