### PR TITLE
Pr/sycl 2021 04

### DIFF
--- a/.github/workflows/sycl.yml
+++ b/.github/workflows/sycl.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test-sycl:
     runs-on: ubuntu-latest
-    container: ghcr.io/wdmapp/oneapi-dpcpp-ubuntu-20.04:latest
+    container: ghcr.io/wdmapp/oneapi-dpcpp-ubuntu-20.04:20211004
     env:
       CXX: /opt/intel/oneapi/compiler/latest/linux/bin/dpcpp
       DPCPP_ROOT: /opt/intel/oneapi

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -515,8 +515,8 @@ struct launch<1, space::device>
     sycl::queue& q = gt::backend::sycl::get_queue();
     auto range = sycl::range<1>(shape[0]);
     auto e = q.submit([&](sycl::handler& cgh) {
-      using kname = gt::backend::sycl::Launch1<decltype(f)>;
-      cgh.parallel_for<kname>(range, [=](sycl::item<1> item) {
+      // using kname = gt::backend::sycl::Launch1<decltype(f)>;
+      cgh.parallel_for(range, [=](sycl::item<1> item) {
         int i = item.get_id(0);
         f(i);
       });
@@ -534,8 +534,8 @@ struct launch<2, space::device>
     sycl::queue& q = gt::backend::sycl::get_queue();
     auto range = sycl::range<2>(shape[0], shape[1]);
     auto e = q.submit([&](sycl::handler& cgh) {
-      using kname = gt::backend::sycl::Launch2<decltype(f)>;
-      cgh.parallel_for<kname>(range, [=](sycl::item<2> item) {
+      // using kname = gt::backend::sycl::Launch2<decltype(f)>;
+      cgh.parallel_for(range, [=](sycl::item<2> item) {
         int i = item.get_id(0);
         int j = item.get_id(1);
         f(i, j);
@@ -554,8 +554,8 @@ struct launch<3, space::device>
     sycl::queue& q = gt::backend::sycl::get_queue();
     auto range = sycl::range<3>(shape[0], shape[1], shape[2]);
     auto e = q.submit([&](sycl::handler& cgh) {
-      using kname = gt::backend::sycl::Launch3<decltype(f)>;
-      cgh.parallel_for<kname>(range, [=](sycl::item<3> item) {
+      // using kname = gt::backend::sycl::Launch3<decltype(f)>;
+      cgh.parallel_for(range, [=](sycl::item<3> item) {
         int i = item.get_id(0);
         int j = item.get_id(1);
         int k = item.get_id(2);
@@ -580,8 +580,8 @@ struct launch<N, space::device>
     auto range =
       sycl::nd_range<1>(sycl::range<1>(size), sycl::range<1>(block_size));
     auto e = q.submit([&](sycl::handler& cgh) {
-      using kname = gt::backend::sycl::LaunchN<decltype(f)>;
-      cgh.parallel_for<kname>(range, [=](sycl::nd_item<1> item) {
+      // using kname = gt::backend::sycl::LaunchN<decltype(f)>;
+      cgh.parallel_for(range, [=](sycl::nd_item<1> item) {
         int i = item.get_global_id(0);
         auto idx = unravel(i, strides);
         index_expression(f, idx);

--- a/include/gtensor/reductions.h
+++ b/include/gtensor/reductions.h
@@ -105,7 +105,7 @@ inline auto sum(const Container& a)
       auto sum_acc =
         sum_buf.template get_access<sycl::access::mode::read_write>(cgh);
       auto sum_reducer =
-        sycl::ONEAPI::reduction(sum_acc, sycl::ONEAPI::plus<T>{});
+        sycl::ext::oneapi::reduction(sum_acc, sycl::ext::oneapi::plus<T>{});
       using kname = gt::backend::sycl::Sum<Container>;
       cgh.parallel_for<kname>(range, sum_reducer,
                               [=](sycl::nd_item<1> item, auto& sum) {
@@ -138,7 +138,7 @@ inline auto max(const Container& a)
       auto max_acc =
         max_buf.template get_access<sycl::access::mode::read_write>(cgh);
       auto max_reducer =
-        sycl::ONEAPI::reduction(max_acc, sycl::ONEAPI::maximum<T>{});
+        sycl::ext::oneapi::reduction(max_acc, sycl::ext::oneapi::maximum<T>{});
       using kname = gt::backend::sycl::Max<Container>;
       cgh.parallel_for<kname>(range, max_reducer,
                               [=](sycl::nd_item<1> item, auto& max) {
@@ -177,7 +177,7 @@ inline auto min(const Container& a)
       auto min_acc =
         min_buf.template get_access<sycl::access::mode::read_write>(cgh);
       auto min_reducer =
-        sycl::ONEAPI::reduction(min_acc, sycl::ONEAPI::minimum<T>{});
+        sycl::ext::oneapi::reduction(min_acc, sycl::ext::oneapi::minimum<T>{});
       using kname = gt::backend::sycl::Min<Container>;
       cgh.parallel_for<kname>(range, min_reducer,
                               [=](sycl::nd_item<1> item, auto& min) {


### PR DESCRIPTION
Note that this is not backwards compatible with older versions of oneapi, because of the reduction API namespace change.