### PR TITLE
sycl gt-blas improvements

### DIFF
--- a/include/gt-blas/backend/sycl.h
+++ b/include/gt-blas/backend/sycl.h
@@ -209,8 +209,13 @@ inline void getrf_npvt_batched(handle_t* h, int n, T** d_Aarray, int lda,
     q, n, n, lda, n * n, batchSize);
   gt::backend::device_storage<T> scratch(scratch_count);
 
-  // TODO: hack until getrfnp group API is available, this won't work
-  // for non-contiguous batches
+  // NB: check that input is contiguous, until the group API is available
+  gt::backend::host_storage<T*> h_Aarray(batchSize);
+  gt::copy_n(d_Aarray, batchSize, h_Aarray.data());
+  for (int i = 0; i < batchSize - 1; i++) {
+    assert(h_Aarray[i + 1] == h_Aarray[i] + n * n);
+  }
+
   auto e = oneapi::mkl::lapack::getrfnp_batch(
     q, n, n, d_Aarray[0], lda, n * n, batchSize,
     gt::raw_pointer_cast(scratch.data()), scratch_count);

--- a/include/gt-blas/backend/sycl.h
+++ b/include/gt-blas/backend/sycl.h
@@ -206,13 +206,13 @@ inline void getrf_npvt_batched(handle_t* h, int n, T** d_Aarray, int lda,
   sycl::queue& q = *(h->handle);
 
   auto scratch_count = oneapi::mkl::lapack::getrfnp_batch_scratchpad_size<T>(
-    q, n, n, lda, 1, batchSize);
+    q, n, n, lda, n * n, batchSize);
   gt::backend::device_storage<T> scratch(scratch_count);
 
   // TODO: hack until getrfnp group API is available, this won't work
   // for non-contiguous batches
   auto e = oneapi::mkl::lapack::getrfnp_batch(
-    q, n, n, d_Aarray[0], lda, 1, batchSize,
+    q, n, n, d_Aarray[0], lda, n * n, batchSize,
     gt::raw_pointer_cast(scratch.data()), scratch_count);
   e.wait();
 

--- a/include/gt-blas/backend/sycl.h
+++ b/include/gt-blas/backend/sycl.h
@@ -85,13 +85,13 @@ inline T dot(handle_t* h, int n, const T* x, int incx, const T* y, int incy)
 {
   sycl::queue& q = *(h->handle);
 
-  T* d_rp = sycl::malloc_device<T>(1, q);
+  gt::backend::device_storage<T> d_rp(1);
   T result;
-  auto e = oneapi::mkl::blas::dot(*(h->handle), n, x, incx, y, incy, d_rp);
+  auto e = oneapi::mkl::blas::dot(*(h->handle), n, x, incx, y, incy,
+                                  gt::raw_pointer_cast(d_rp.data()));
   e.wait();
-  auto e2 = q.memcpy(&result, d_rp, sizeof(T));
+  auto e2 = q.memcpy(&result, gt::raw_pointer_cast(d_rp.data()), sizeof(T));
   e2.wait();
-  sycl::free(d_rp, q);
   return result;
 }
 
@@ -102,13 +102,13 @@ inline gt::complex<R> dotu(handle_t* h, int n, const gt::complex<R>* x,
   sycl::queue& q = *(h->handle);
   using T = gt::complex<R>;
 
-  T* d_rp = sycl::malloc_device<T>(1, q);
+  gt::backend::device_storage<T> d_rp(1);
   T result;
-  auto e = oneapi::mkl::blas::dotu(*(h->handle), n, x, incx, y, incy, d_rp);
+  auto e = oneapi::mkl::blas::dotu(*(h->handle), n, x, incx, y, incy,
+                                   gt::raw_pointer_cast(d_rp.data()));
   e.wait();
-  auto e2 = q.memcpy(&result, d_rp, sizeof(T));
+  auto e2 = q.memcpy(&result, gt::raw_pointer_cast(d_rp.data()), sizeof(T));
   e2.wait();
-  sycl::free(d_rp, q);
   return result;
 }
 
@@ -119,13 +119,13 @@ inline gt::complex<R> dotc(handle_t* h, int n, const gt::complex<R>* x,
   sycl::queue& q = *(h->handle);
   using T = gt::complex<R>;
 
-  T* d_rp = sycl::malloc_device<T>(1, q);
+  gt::backend::device_storage<T> d_rp(1);
   T result;
-  auto e = oneapi::mkl::blas::dotc(*(h->handle), n, x, incx, y, incy, d_rp);
+  auto e = oneapi::mkl::blas::dotc(*(h->handle), n, x, incx, y, incy,
+                                   gt::raw_pointer_cast(d_rp.data()));
   e.wait();
-  auto e2 = q.memcpy(&result, d_rp, sizeof(T));
+  auto e2 = q.memcpy(&result, gt::raw_pointer_cast(d_rp.data()), sizeof(T));
   e2.wait();
-  sycl::free(d_rp, q);
   return result;
 }
 
@@ -145,6 +145,19 @@ inline void gemv(handle_t* h, int m, int n, T alpha, const T* A, int lda,
 // ======================================================================
 // getrf/getrs batched
 
+/*
+namespace detail
+{
+template <typename T, typename S = space::sycl_managed>
+using managed_allocator =
+  typename backend::allocator_impl::selector<T, S>::type;
+
+template <typename T>
+using managed_storage =
+  backend::gtensor_storage<T, managed_allocator<T>, space::sycl_managed>;
+} // end namespace detail
+*/
+
 template <typename T>
 inline void getrf_batched(handle_t* h, int n, T** d_Aarray, int lda,
                           gt::blas::index_t* d_PivotArray, int* d_infoArray,
@@ -158,28 +171,57 @@ inline void getrf_batched(handle_t* h, int n, T** d_Aarray, int lda,
 
   // unlike cuBLAS/rocBLAS, the pivot array to getrf is expected to be
   // an array of pointer, just like d_Aarray.
-  auto d_PivotPtr = sycl::malloc_shared<index_t*>(batchSize, q);
+  /*
+  using pivot_alloc_shared_t =
+    sycl::usm_allocator<index_t*, sycl::usm::alloc::shared>;
+  pivot_alloc_shared_t pivot_alloc(q);
+  std::vector<index_t*, pivot_alloc_shared_t> d_PivotPtr(batchSize,
+                                                         pivot_alloc);
+                                                         */
+  gt::backend::managed_storage<index_t*> d_PivotPtr(batchSize);
   for (int i = 0; i < batchSize; i++) {
     d_PivotPtr[i] = d_PivotArray + (i * n);
   }
 
   auto scratch_count = oneapi::mkl::lapack::getrf_batch_scratchpad_size<T>(
     q, &n64, &n64, &lda64, 1, &batchSize64);
+  gt::backend::device_storage<T> scratch(scratch_count);
 
-  auto scratch = sycl::malloc_device<T>(scratch_count, q);
+  auto e = oneapi::mkl::lapack::getrf_batch(
+    q, &n64, &n64, d_Aarray, &lda64, gt::raw_pointer_cast(d_PivotPtr.data()), 1,
+    &batchSize64, gt::raw_pointer_cast(scratch.data()), scratch_count);
+  e.wait();
 
-  auto e = oneapi::mkl::lapack::getrf_batch(q, &n64, &n64, d_Aarray, &lda64,
-                                            d_PivotPtr, 1, &batchSize64,
-                                            scratch, scratch_count);
   // set zero to indicate no errors, which is true if we get here without
   // an exception being thrown
   // TODO: translate exceptions to info error codes?
   auto e2 = q.memset(d_infoArray, 0, sizeof(int) * batchSize);
-  e.wait();
   e2.wait();
+}
 
-  sycl::free(scratch, q);
-  sycl::free(d_PivotPtr, q);
+template <typename T>
+inline void getrf_npvt_batched(handle_t* h, int n, T** d_Aarray, int lda,
+                               int* d_infoArray, int batchSize)
+{
+  sycl::queue& q = *(h->handle);
+
+  auto scratch_count =
+    oneapi::mkl::lapack::getrfnp_batch_strided_scratchpad_size<T>(q, n, n, lda,
+                                                                  1, batchSize);
+  gt::backend::device_storage<T> scratch(scratch_count);
+
+  // TODO: hack until getrfnp group API is available, this won't work
+  // for non-contiguous batches
+  auto e = oneapi::mkl::lapack::getrfnp_batch_strided(
+    q, n, n, d_Aarray[0], lda, 1, batchSize,
+    gt::raw_pointer_cast(scratch.data()), scratch_count);
+  e.wait();
+
+  // set zero to indicate no errors, which is true if we get here without
+  // an exception being thrown
+  // TODO: translate exceptions to info error codes?
+  auto e2 = q.memset(d_infoArray, 0, sizeof(int) * batchSize);
+  e2.wait();
 }
 
 template <typename T>
@@ -197,7 +239,15 @@ inline void getrs_batched(handle_t* h, int n, int nrhs, T** d_Aarray, int lda,
 
   // unlike cuBLAS/rocBLAS, the pivot array to getrf is expected to be
   // an array of pointer, just like d_Aarray.
-  auto d_PivotPtr = sycl::malloc_shared<index_t*>(batchSize, q);
+  /*
+  using pivot_alloc_shared_t =
+    sycl::usm_allocator<index_t*, sycl::usm::alloc::shared>;
+  pivot_alloc_shared_t pivot_alloc(q);
+  std::vector<index_t*, pivot_alloc_shared_t> d_PivotPtr(batchSize,
+                                                         pivot_alloc);
+  */
+
+  gt::backend::managed_storage<index_t*> d_PivotPtr(batchSize);
   for (int i = 0; i < batchSize; i++) {
     d_PivotPtr[i] = d_PivotArray + (i * n);
   }
@@ -205,15 +255,13 @@ inline void getrs_batched(handle_t* h, int n, int nrhs, T** d_Aarray, int lda,
   auto trans_op = oneapi::mkl::transpose::nontrans;
   auto scratch_count = oneapi::mkl::lapack::getrs_batch_scratchpad_size<T>(
     q, &trans_op, &n64, &nrhs64, &lda64, &ldb64, 1, &batchSize64);
-  auto scratch = sycl::malloc_device<T>(scratch_count, q);
+  gt::backend::device_storage<T> scratch(scratch_count);
 
   auto e = oneapi::mkl::lapack::getrs_batch(
-    q, &trans_op, &n64, &nrhs64, d_Aarray, &lda64, d_PivotPtr, d_Barray, &ldb64,
-    1, &batchSize64, scratch, scratch_count);
+    q, &trans_op, &n64, &nrhs64, d_Aarray, &lda64,
+    gt::raw_pointer_cast(d_PivotPtr.data()), d_Barray, &ldb64, 1, &batchSize64,
+    gt::raw_pointer_cast(scratch.data()), scratch_count);
   e.wait();
-
-  sycl::free(scratch, q);
-  sycl::free(d_PivotPtr, q);
 }
 
 } // namespace blas

--- a/include/gt-blas/backend/sycl.h
+++ b/include/gt-blas/backend/sycl.h
@@ -205,14 +205,13 @@ inline void getrf_npvt_batched(handle_t* h, int n, T** d_Aarray, int lda,
 {
   sycl::queue& q = *(h->handle);
 
-  auto scratch_count =
-    oneapi::mkl::lapack::getrfnp_batch_strided_scratchpad_size<T>(q, n, n, lda,
-                                                                  1, batchSize);
+  auto scratch_count = oneapi::mkl::lapack::getrfnp_batch_scratchpad_size<T>(
+    q, n, n, lda, 1, batchSize);
   gt::backend::device_storage<T> scratch(scratch_count);
 
   // TODO: hack until getrfnp group API is available, this won't work
   // for non-contiguous batches
-  auto e = oneapi::mkl::lapack::getrfnp_batch_strided(
+  auto e = oneapi::mkl::lapack::getrfnp_batch(
     q, n, n, d_Aarray[0], lda, 1, batchSize,
     gt::raw_pointer_cast(scratch.data()), scratch_count);
   e.wait();

--- a/include/gtensor/backend_sycl_device.h
+++ b/include/gtensor/backend_sycl_device.h
@@ -77,7 +77,7 @@ inline uint32_t get_unique_device_id<cl::sycl::backend::opencl>(
   int device_index, const cl::sycl::device& d)
 {
   uint32_t unique_id = 0;
-  cl_device_id cl_dev = d.get_native<cl::sycl::backend::opencl>();
+  cl_device_id cl_dev = cl::sycl::get_native<cl::sycl::backend::opencl>(d);
   cl_device_pci_bus_info_khr pci_info;
   cl_int rval = clGetDeviceInfo(cl_dev, CL_DEVICE_PCI_BUS_INFO_KHR,
                                 sizeof(pci_info), &pci_info, NULL);
@@ -97,12 +97,13 @@ inline uint32_t get_unique_device_id<cl::sycl::backend::opencl>(
 
 #ifdef GTENSOR_DEVICE_SYCL_L0
 template <>
-inline uint32_t get_unique_device_id<cl::sycl::backend::level_zero>(
+inline uint32_t get_unique_device_id<cl::sycl::backend::ext_oneapi_level_zero>(
   int device_index, const cl::sycl::device& d)
 {
   uint32_t unique_id = 0;
 
-  ze_device_handle_t ze_dev = d.get_native<cl::sycl::backend::level_zero>();
+  ze_device_handle_t ze_dev =
+    cl::sycl::get_native<cl::sycl::backend::ext_oneapi_level_zero>(d);
   ze_device_properties_t ze_prop;
   zeDeviceGetProperties(ze_dev, &ze_prop);
 
@@ -200,8 +201,8 @@ public:
     if (false) {
 #ifdef GTENSOR_DEVICE_SYCL_L0
     } else if (p_name.find("Level-Zero") != std::string::npos) {
-      return get_unique_device_id<cl::sycl::backend::level_zero>(device_id,
-                                                                 sycl_dev);
+      return get_unique_device_id<cl::sycl::backend::ext_oneapi_level_zero>(
+        device_id, sycl_dev);
 #endif
 #ifdef GTENSOR_DEVICE_SYCL_OPENCL
     } else if (p_name.find("OpenCL") != std::string::npos) {

--- a/include/gtensor/backend_thrust.h
+++ b/include/gtensor/backend_thrust.h
@@ -3,6 +3,7 @@
 #define GTENSOR_BACKEND_THRUST_H
 
 #include "pointer_traits.h"
+#include "thrust_ext.h"
 
 #include <thrust/copy.h>
 #include <thrust/device_allocator.h>
@@ -36,6 +37,13 @@ struct selector<T, gt::space::thrust_host>
 {
   using type = std::allocator<T>;
 };
+
+template <typename T>
+struct selector<T, gt::space::thrust_managed>
+{
+  using type = thrust::ext::managed_allocator<T>;
+};
+
 } // namespace allocator_impl
 
 namespace copy_impl

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -167,6 +167,10 @@ using device_allocator = typename backend::allocator_impl::selector<T, S>::type;
 template <typename T, typename S = gt::space::host>
 using host_allocator = typename backend::allocator_impl::selector<T, S>::type;
 
+template <typename T, typename S = gt::space::managed>
+using managed_allocator =
+  typename backend::allocator_impl::selector<T, S>::type;
+
 // ======================================================================
 // fill
 

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -107,6 +107,9 @@ private:
 template <typename T, typename A = gt::device_allocator<T>>
 using device_storage = gtensor_storage<T, A, space::device>;
 
+template <typename T, typename A = gt::managed_allocator<T>>
+using managed_storage = gtensor_storage<T, A, space::managed>;
+
 #endif
 
 template <typename T, typename A = gt::host_allocator<T>>

--- a/include/gtensor/space_forward.h
+++ b/include/gtensor/space_forward.h
@@ -15,6 +15,8 @@ struct host_only
 #ifdef GTENSOR_USE_THRUST
 struct thrust
 {};
+struct thrust_managed
+{};
 struct thrust_host
 {};
 #endif
@@ -52,7 +54,7 @@ struct sycl_host
 using device = thrust;
 using host = thrust_host;
 #if GTENSOR_DEVICE_CUDA
-using managed = cuda_managed;
+using managed = thrust_managed;
 #else
 using managed = hip_managed;
 #endif

--- a/include/gtensor/space_forward.h
+++ b/include/gtensor/space_forward.h
@@ -88,6 +88,7 @@ using clib_managed = sycl_managed;
 
 using host = host_only;
 using device = host;
+using managed = host;
 
 #endif
 

--- a/include/gtensor/space_forward.h
+++ b/include/gtensor/space_forward.h
@@ -51,15 +51,23 @@ struct sycl_host
 #if GTENSOR_USE_THRUST
 using device = thrust;
 using host = thrust_host;
+#if GTENSOR_DEVICE_CUDA
+using managed = cuda_managed;
+#else
+using managed = hip_managed;
+#endif
 #elif GTENSOR_DEVICE_CUDA
 using device = cuda;
 using host = cuda_host;
+using managed = cuda_managed;
 #elif GTENSOR_DEVICE_HIP
 using device = hip;
 using host = hip_host;
+using managed = hip_managed;
 #elif GTENSOR_DEVICE_SYCL
 using device = sycl;
 using host = sycl_host;
+using managed = sycl_managed;
 #endif
 
 #if GTENSOR_DEVICE_CUDA

--- a/include/gtensor/space_forward.h
+++ b/include/gtensor/space_forward.h
@@ -53,11 +53,7 @@ struct sycl_host
 #if GTENSOR_USE_THRUST
 using device = thrust;
 using host = thrust_host;
-#if GTENSOR_DEVICE_CUDA
 using managed = thrust_managed;
-#else
-using managed = hip_managed;
-#endif
 #elif GTENSOR_DEVICE_CUDA
 using device = cuda;
 using host = cuda_host;

--- a/include/gtensor/thrust_ext.h
+++ b/include/gtensor/thrust_ext.h
@@ -194,7 +194,6 @@ GT_INLINE auto operator/(T a, U b)
          ext::remove_device_reference_t<U>(b);
 }
 
-
 } // namespace thrust
 
 #endif

--- a/include/gtensor/thrust_ext.h
+++ b/include/gtensor/thrust_ext.h
@@ -15,6 +15,7 @@
 #include "gtl.h"
 #include "macros.h"
 
+#include <thrust/device_allocator.h>
 #include <thrust/device_ptr.h>
 #include <thrust/system_error.h>
 
@@ -70,19 +71,8 @@ using remove_device_reference_t =
 
 #include <thrust/system/cuda/error.h>
 
-namespace detail
-{
-#if THRUST_VERSION <= 100903
-template <typename T>
-using device_allocator = ::thrust::device_malloc_allocator<T>;
-#else
-template <typename T>
-using device_allocator = ::thrust::device_allocator<T>;
-#endif
-} // end namespace detail
-
 template <class T>
-class managed_allocator : public detail::device_allocator<T>
+class managed_allocator : public ::thrust::device_allocator<T>
 {
 public:
   using value_type = T;

--- a/tests/test_gtensor_storage.cxx
+++ b/tests/test_gtensor_storage.cxx
@@ -346,4 +346,37 @@ TEST(gtensor_storage, device_resize_shrink)
   }
 }
 
+template <typename GS>
+void test_raii(int size, int ntrials)
+{
+  for (int i = 0; i < ntrials; i++) {
+    {
+      GS storage(size);
+      gt::fill(storage.data(), storage.data() + size, 0);
+    }
+  }
+}
+
+TEST(gtensor_storage, host_raii)
+{
+  test_raii<gt::backend::host_storage<double>>(100, 100);
+  test_raii<gt::backend::host_storage<gt::complex<float>>>(100, 100);
+}
+
+#ifdef GTENSOR_HAVE_DEVICE
+
+TEST(gtensor_storage, device_raii)
+{
+  test_raii<gt::backend::device_storage<double>>(100, 100);
+  test_raii<gt::backend::device_storage<gt::complex<float>>>(100, 100);
+}
+
+TEST(gtensor_storage, managed_raii)
+{
+  test_raii<gt::backend::managed_storage<double>>(100, 100);
+  test_raii<gt::backend::managed_storage<gt::complex<float>>>(100, 100);
+}
+
+#endif
+
 #endif // GTENSOR_HAVE_DEVICE

--- a/tests/test_lapack.cxx
+++ b/tests/test_lapack.cxx
@@ -387,7 +387,6 @@ TEST(lapack, zgetrf_batch)
   test_getrf_batch_complex<double>();
 }
 
-#ifndef GTENSOR_DEVICE_SYCL
 template <typename R>
 void test_getrf_npvt_batch_complex()
 {
@@ -468,7 +467,6 @@ TEST(lapack, zgetrf_npvt_batch)
 {
   test_getrf_npvt_batch_complex<double>();
 }
-#endif
 
 template <typename R>
 void test_getrs_batch_complex()


### PR DESCRIPTION
Uses gtensor RAII classes for temp memory, so things are cleaned up in case of failures, and so the memory pool can be used. Also adds a limited getrf_npvt API, which has a limitation that it requires contiguous matrices in input.