### PR TITLE
Pr/streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,3 +429,20 @@ auto k_a_const_copy = a_const_copy.to_kernel(); // gtensor_span<const int, 1>
 k_a_const_copy(0) = 10; // won't compile, type of LHS is const int&
 
 ```
+
+# Streams (experimental)
+
+To facilitate interoperability with existing libraries and allow
+experimentation with some advanced multi-stream use cases, there are classes
+`gt::stream` and `gt::stream_view`. The `gt::stream` will create a new stream
+in the default device backend and destroy the stream when the object is
+destructed. The `gt::stream_view` is constructed with an existing native stream
+object in the default backend (e.g. a `cudaStream\_t` for the CUDA backend).
+They can be used as optional arguments to `gt::launch` and `gt::assign`, in
+which case they will execute asynchronously with the default stream on device.
+Note that the equals operator form of assign does not work with alternate
+streams - it will always use the default stream. For the SYCL backend, the
+native stream object is a `sycl::queue`.
+
+See also `tests/test_stream.cxx`. Note that this API is likely to change; in
+particular, the stream objects will become templated on space type.

--- a/include/gtensor/assign.h
+++ b/include/gtensor/assign.h
@@ -445,13 +445,7 @@ struct assigner<N, space::device>
 } // namespace detail
 
 template <typename E1, typename E2>
-void assign(E1& lhs, const E2& rhs)
-{
-  assign(lhs, rhs, gt::stream_view());
-}
-
-template <typename E1, typename E2>
-void assign(E1& lhs, const E2& rhs, gt::stream_view stream)
+void assign(E1& lhs, const E2& rhs, gt::stream_view stream = gt::stream_view())
 {
   static_assert(expr_dimension<E1>() == expr_dimension<E2>(),
                 "cannot assign expressions of different dimension");
@@ -468,13 +462,8 @@ void assign(E1& lhs, const E2& rhs, gt::stream_view stream)
 }
 
 template <typename E1, typename T>
-void assign(E1& lhs, const gscalar<T>& val)
-{
-  assign(lhs, val, gt::stream_view());
-}
-
-template <typename E1, typename T>
-void assign(E1& lhs, const gscalar<T>& val, gt::stream_view stream)
+void assign(E1& lhs, const gscalar<T>& val,
+            gt::stream_view stream = gt::stream_view())
 {
   // FIXME, make more efficient
   detail::assigner<

--- a/include/gtensor/assign.h
+++ b/include/gtensor/assign.h
@@ -345,9 +345,9 @@ template <>
 struct assigner<1, space::device>
 {
   template <typename E1, typename E2>
-  static void run(E1& lhs, const E2& rhs)
+  static void run(E1& lhs, const E2& rhs, gt::stream_view stream)
   {
-    sycl::queue& q = gt::backend::sycl::get_queue();
+    sycl::queue q = stream.get_backend_stream();
     auto k_lhs = lhs.to_kernel();
     auto k_rhs = rhs.to_kernel();
     auto range = sycl::range<1>(lhs.shape(0));
@@ -368,9 +368,9 @@ template <>
 struct assigner<2, space::device>
 {
   template <typename E1, typename E2>
-  static void run(E1& lhs, const E2& rhs)
+  static void run(E1& lhs, const E2& rhs, gt::stream_view stream)
   {
-    sycl::queue& q = gt::backend::sycl::get_queue();
+    sycl::queue q = stream.get_backend_stream();
     auto k_lhs = lhs.to_kernel();
     auto k_rhs = rhs.to_kernel();
     auto range = sycl::range<2>(lhs.shape(0), lhs.shape(1));
@@ -392,9 +392,9 @@ template <>
 struct assigner<3, space::device>
 {
   template <typename E1, typename E2>
-  static void run(E1& lhs, const E2& rhs)
+  static void run(E1& lhs, const E2& rhs, gt::stream_view stream)
   {
-    sycl::queue& q = gt::backend::sycl::get_queue();
+    sycl::queue q = stream.get_backend_stream();
     auto k_lhs = lhs.to_kernel();
     auto k_rhs = rhs.to_kernel();
     auto range = sycl::range<3>(lhs.shape(0), lhs.shape(1), lhs.shape(2));
@@ -417,9 +417,9 @@ template <size_type N>
 struct assigner<N, space::device>
 {
   template <typename E1, typename E2>
-  static void run(E1& lhs, const E2& rhs)
+  static void run(E1& lhs, const E2& rhs, gt::stream_view stream)
   {
-    sycl::queue& q = gt::backend::sycl::get_queue();
+    sycl::queue q = stream.get_backend_stream();
     // use linear indexing for simplicity
     auto size = calc_size(lhs.shape());
     auto k_lhs = flatten(lhs).to_kernel();

--- a/include/gtensor/assign.h
+++ b/include/gtensor/assign.h
@@ -27,7 +27,7 @@ template <>
 struct assigner<1, space::host>
 {
   template <typename E1, typename E2>
-  static void run(E1& lhs, const E2& rhs)
+  static void run(E1& lhs, const E2& rhs, stream_view stream)
   {
     // printf("assigner<1, host>\n");
     for (int i = 0; i < lhs.shape(0); i++) {
@@ -40,7 +40,7 @@ template <>
 struct assigner<2, space::host>
 {
   template <typename E1, typename E2>
-  static void run(E1& lhs, const E2& rhs)
+  static void run(E1& lhs, const E2& rhs, stream_view stream)
   {
     // printf("assigner<2, host>\n");
     for (int j = 0; j < lhs.shape(1); j++) {
@@ -55,7 +55,7 @@ template <>
 struct assigner<3, space::host>
 {
   template <typename E1, typename E2>
-  static void run(E1& lhs, const E2& rhs)
+  static void run(E1& lhs, const E2& rhs, stream_view stream)
   {
     // printf("assigner<3, host>\n");
     for (int k = 0; k < lhs.shape(2); k++) {
@@ -72,7 +72,7 @@ template <>
 struct assigner<4, space::host>
 {
   template <typename E1, typename E2>
-  static void run(E1& lhs, const E2& rhs)
+  static void run(E1& lhs, const E2& rhs, stream_view stream)
   {
     // printf("assigner<4, host>\n");
     for (int l = 0; l < lhs.shape(3); l++) {
@@ -91,7 +91,7 @@ template <>
 struct assigner<5, space::host>
 {
   template <typename E1, typename E2>
-  static void run(E1& lhs, const E2& rhs)
+  static void run(E1& lhs, const E2& rhs, stream_view stream)
   {
     // printf("assigner<5, host>\n");
     for (int m = 0; m < lhs.shape(4); m++) {
@@ -112,7 +112,7 @@ template <>
 struct assigner<6, space::host>
 {
   template <typename E1, typename E2>
-  static void run(E1& lhs, const E2& rhs)
+  static void run(E1& lhs, const E2& rhs, stream_view stream)
   {
     // printf("assigner<6, host>\n");
     for (int n = 0; n < lhs.shape(5); n++) {
@@ -222,7 +222,7 @@ template <>
 struct assigner<1, space::device>
 {
   template <typename E1, typename E2>
-  static void run(E1& lhs, const E2& rhs)
+  static void run(E1& lhs, const E2& rhs, stream_view stream)
   {
     // printf("assigner<1, device>\n");
     const int BS_1D = 256;
@@ -230,8 +230,9 @@ struct assigner<1, space::device>
     dim3 numBlocks((lhs.shape(0) + BS_1D - 1) / BS_1D);
 
     gpuSyncIfEnabled();
-    gtLaunchKernel(kernel_assign_1, numBlocks, numThreads, 0, 0,
-                   lhs.to_kernel(), rhs.to_kernel());
+    gtLaunchKernel(kernel_assign_1, numBlocks, numThreads, 0,
+                   stream.get_backend_stream(), lhs.to_kernel(),
+                   rhs.to_kernel());
     gpuSyncIfEnabled();
   }
 };
@@ -240,7 +241,7 @@ template <>
 struct assigner<2, space::device>
 {
   template <typename E1, typename E2>
-  static void run(E1& lhs, const E2& rhs)
+  static void run(E1& lhs, const E2& rhs, stream_view stream)
   {
     // printf("assigner<2, device>\n");
     dim3 numThreads(BS_X, BS_Y);
@@ -248,8 +249,9 @@ struct assigner<2, space::device>
                    (lhs.shape(1) + BS_Y - 1) / BS_Y);
 
     gpuSyncIfEnabled();
-    gtLaunchKernel(kernel_assign_2, numBlocks, numThreads, 0, 0,
-                   lhs.to_kernel(), rhs.to_kernel());
+    gtLaunchKernel(kernel_assign_2, numBlocks, numThreads, 0,
+                   stream.get_backend_stream(), lhs.to_kernel(),
+                   rhs.to_kernel());
     gpuSyncIfEnabled();
   }
 };
@@ -258,7 +260,7 @@ template <>
 struct assigner<3, space::device>
 {
   template <typename E1, typename E2>
-  static void run(E1& lhs, const E2& rhs)
+  static void run(E1& lhs, const E2& rhs, stream_view stream)
   {
     // printf("assigner<3, device>\n");
     dim3 numThreads(BS_X, BS_Y);
@@ -269,8 +271,9 @@ struct assigner<3, space::device>
     /*std::cout << "rhs " << typeid(rhs.to_kernel()).name() << "\n";
     std::cout << "numBlocks="<<numBlocks.x<<" "<<numBlocks.y<<" "<<numBlocks.z<<
     ", numThreads="<<numThreads.x<<" "<<numThreads.y<<" "<<numThreads.z<<"\n";*/
-    gtLaunchKernel(kernel_assign_3, numBlocks, numThreads, 0, 0,
-                   lhs.to_kernel(), rhs.to_kernel());
+    gtLaunchKernel(kernel_assign_3, numBlocks, numThreads, 0,
+                   stream.get_backend_stream(), lhs.to_kernel(),
+                   rhs.to_kernel());
     gpuSyncIfEnabled();
   }
 };
@@ -279,7 +282,7 @@ template <>
 struct assigner<4, space::device>
 {
   template <typename E1, typename E2>
-  static void run(E1& lhs, const E2& rhs)
+  static void run(E1& lhs, const E2& rhs, stream_view stream)
   {
     // printf("assigner<4, device>\n");
     dim3 numThreads(256);
@@ -287,8 +290,9 @@ struct assigner<4, space::device>
 
     gpuSyncIfEnabled();
     // std::cout << "rhs " << typeid(rhs.to_kernel()).name() << "\n";
-    gtLaunchKernel(kernel_assign_4, numBlocks, numThreads, 0, 0,
-                   lhs.to_kernel(), rhs.to_kernel());
+    gtLaunchKernel(kernel_assign_4, numBlocks, numThreads, 0,
+                   stream.get_backend_stream(), lhs.to_kernel(),
+                   rhs.to_kernel());
     gpuSyncIfEnabled();
   }
 };
@@ -297,7 +301,7 @@ template <>
 struct assigner<5, space::device>
 {
   template <typename E1, typename E2>
-  static void run(E1& lhs, const E2& rhs)
+  static void run(E1& lhs, const E2& rhs, stream_view stream)
   {
     // printf("assigner<6, device>\n");
     dim3 numThreads(BS_X, BS_Y);
@@ -307,8 +311,9 @@ struct assigner<5, space::device>
 
     gpuSyncIfEnabled();
     // std::cout << "rhs " << typeid(rhs.to_kernel()).name() << "\n";
-    gtLaunchKernel(kernel_assign_5, numBlocks, numThreads, 0, 0,
-                   lhs.to_kernel(), rhs.to_kernel());
+    gtLaunchKernel(kernel_assign_5, numBlocks, numThreads, 0,
+                   stream.get_backend_stream(), lhs.to_kernel(),
+                   rhs.to_kernel());
     gpuSyncIfEnabled();
   }
 };
@@ -317,7 +322,7 @@ template <>
 struct assigner<6, space::device>
 {
   template <typename E1, typename E2>
-  static void run(E1& lhs, const E2& rhs)
+  static void run(E1& lhs, const E2& rhs, stream_view stream)
   {
     // printf("assigner<6, device>\n");
     dim3 numThreads(BS_X, BS_Y);
@@ -327,8 +332,9 @@ struct assigner<6, space::device>
 
     gpuSyncIfEnabled();
     // std::cout << "rhs " << typeid(rhs.to_kernel()).name() << "\n";
-    gtLaunchKernel(kernel_assign_6, numBlocks, numThreads, 0, 0,
-                   lhs.to_kernel(), rhs.to_kernel());
+    gtLaunchKernel(kernel_assign_6, numBlocks, numThreads, 0,
+                   stream.get_backend_stream(), lhs.to_kernel(),
+                   rhs.to_kernel());
     gpuSyncIfEnabled();
   }
 };
@@ -441,6 +447,12 @@ struct assigner<N, space::device>
 template <typename E1, typename E2>
 void assign(E1& lhs, const E2& rhs)
 {
+  assign(lhs, rhs, gt::stream_view());
+}
+
+template <typename E1, typename E2>
+void assign(E1& lhs, const E2& rhs, gt::stream_view stream)
+{
   static_assert(expr_dimension<E1>() == expr_dimension<E2>(),
                 "cannot assign expressions of different dimension");
   // FIXME, need to check for brodcasting
@@ -450,18 +462,25 @@ void assign(E1& lhs, const E2& rhs)
   }
   assert(lhs.shape() == rhs.shape());
 #endif
-  detail::assigner<expr_dimension<E1>(),
-                   space_t<expr_space_type<E1>, expr_space_type<E2>>>::run(lhs,
-                                                                           rhs);
+  detail::assigner<
+    expr_dimension<E1>(),
+    space_t<expr_space_type<E1>, expr_space_type<E2>>>::run(lhs, rhs, stream);
 }
 
 template <typename E1, typename T>
 void assign(E1& lhs, const gscalar<T>& val)
 {
+  assign(lhs, val, gt::stream_view());
+}
+
+template <typename E1, typename T>
+void assign(E1& lhs, const gscalar<T>& val, gt::stream_view stream)
+{
   // FIXME, make more efficient
   detail::assigner<
     expr_dimension<E1>(),
-    space_t<expr_space_type<E1>, expr_space_type<gscalar<T>>>>::run(lhs, val);
+    space_t<expr_space_type<E1>, expr_space_type<gscalar<T>>>>::run(lhs, val,
+                                                                    stream);
 }
 
 } // namespace gt

--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -206,12 +206,12 @@ private:
   cudaStream_t stream_;
 };
 
-class stream_wrapper
+class stream
 {
 public:
-  stream_wrapper() { gtGpuCheck(cudaStreamCreate(&stream_)); }
+  stream() { gtGpuCheck(cudaStreamCreate(&stream_)); }
 
-  ~stream_wrapper()
+  ~stream()
   {
     gtGpuCheck(cudaStreamSynchronize(stream_));
     gtGpuCheck(cudaStreamDestroy(stream_));

--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -2,6 +2,7 @@
 #ifndef GTENSOR_BACKEND_CUDA_H
 #define GTENSOR_BACKEND_CUDA_H
 
+#include "macros.h"
 #include "pointer_traits.h"
 
 #include <cuda_runtime_api.h>
@@ -188,6 +189,46 @@ inline void fill(gt::space::cuda tag, Ptr first, Ptr last, const T& value)
 } // namespace fill_impl
 
 } // namespace backend
+
+class stream_view
+{
+public:
+  stream_view() : stream_(nullptr) {}
+  stream_view(cudaStream_t s) : stream_(s) {}
+
+  auto get_backend_stream() { return stream_; }
+
+  bool is_default() { return stream_ == nullptr; }
+
+  void synchronize() { gtGpuCheck(cudaStreamSynchronize(stream_)); }
+
+private:
+  cudaStream_t stream_;
+};
+
+class stream_wrapper
+{
+public:
+  stream_wrapper() { gtGpuCheck(cudaStreamCreate(&stream_)); }
+
+  ~stream_wrapper()
+  {
+    gtGpuCheck(cudaStreamSynchronize(stream_));
+    gtGpuCheck(cudaStreamDestroy(stream_));
+  }
+
+  auto get_backend_stream() { return stream_; }
+
+  bool is_default() { return stream_ == nullptr; }
+
+  auto get_view() { return stream_view(this->stream_); }
+
+  void synchronize() { gtGpuCheck(cudaStreamSynchronize(stream_)); }
+
+private:
+  cudaStream_t stream_;
+};
+
 } // namespace gt
 
 #endif // GTENSOR_BACKEND_CUDA_H

--- a/include/gtensor/backend_hip.h
+++ b/include/gtensor/backend_hip.h
@@ -188,6 +188,46 @@ inline void fill(gt::space::hip tag, Ptr first, Ptr last, const T& value)
 } // namespace fill_impl
 
 } // namespace backend
+
+class stream_view
+{
+public:
+  stream_view() : stream_(nullptr) {}
+  stream_view(hipStream_t s) : stream_(s) {}
+
+  auto get_backend_stream() { return stream_; }
+
+  bool is_default() { return stream_ == nullptr; }
+
+  void synchronize() { gtGpuCheck(hipStreamSynchronize(stream_)); }
+
+private:
+  hipStream_t stream_;
+};
+
+class stream_wrapper
+{
+public:
+  stream_wrapper() { gtGpuCheck(hipStreamCreate(&stream_)); }
+
+  ~stream_wrapper()
+  {
+    gtGpuCheck(hipStreamSynchronize(stream_));
+    gtGpuCheck(hipStreamDestroy(stream_));
+  }
+
+  auto get_backend_stream() { return stream_; }
+
+  bool is_default() { return stream_ == nullptr; }
+
+  auto get_view() { return stream_view(this->stream_); }
+
+  void synchronize() { gtGpuCheck(hipStreamSynchronize(stream_)); }
+
+private:
+  hipStream_t stream_;
+};
+
 } // namespace gt
 
 #endif // GTENSOR_BACKEND_HIP_H

--- a/include/gtensor/backend_hip.h
+++ b/include/gtensor/backend_hip.h
@@ -205,12 +205,12 @@ private:
   hipStream_t stream_;
 };
 
-class stream_wrapper
+class stream
 {
 public:
-  stream_wrapper() { gtGpuCheck(hipStreamCreate(&stream_)); }
+  stream() { gtGpuCheck(hipStreamCreate(&stream_)); }
 
-  ~stream_wrapper()
+  ~stream()
   {
     gtGpuCheck(hipStreamSynchronize(stream_));
     gtGpuCheck(hipStreamDestroy(stream_));

--- a/include/gtensor/backend_host.h
+++ b/include/gtensor/backend_host.h
@@ -60,34 +60,27 @@ inline void fill(gt::space::host tag, Ptr first, Ptr last, const T& value)
 class stream_view
 {
 public:
-  stream_view() : stream_(nullptr) {}
-  stream_view(void* s) : stream_(s) {}
+  stream_view() {}
 
-  auto get_backend_stream() { return stream_; }
+  auto get_backend_stream() { return nullptr; }
 
-  bool is_default() { return stream_ == nullptr; }
+  bool is_default() { return true; }
 
   void synchronize() {}
-
-private:
-  void* stream_;
 };
 
-class stream_wrapper
+class stream
 {
 public:
-  stream_wrapper() : stream_(nullptr) {}
+  stream() {}
 
-  auto get_backend_stream() { return stream_; }
+  auto get_backend_stream() { return nullptr; }
 
-  bool is_default() { return stream_ == nullptr; }
+  bool is_default() { return true; }
 
-  auto get_view() { return stream_view(this->stream_); }
+  auto get_view() { return stream_view(); }
 
   void synchronize() {}
-
-private:
-  void* stream_;
 };
 
 #endif

--- a/include/gtensor/backend_host.h
+++ b/include/gtensor/backend_host.h
@@ -53,6 +53,45 @@ inline void fill(gt::space::host tag, Ptr first, Ptr last, const T& value)
 } // namespace fill_impl
 
 } // namespace backend
+
+#ifndef GTENSOR_HAVE_DEVICE
+
+// streams are no-op on host (could use threads in the future)
+class stream_view
+{
+public:
+  stream_view() : stream_(nullptr) {}
+  stream_view(void* s) : stream_(s) {}
+
+  auto get_backend_stream() { return stream_; }
+
+  bool is_default() { return stream_ == nullptr; }
+
+  void synchronize() {}
+
+private:
+  void* stream_;
+};
+
+class stream_wrapper
+{
+public:
+  stream_wrapper() : stream_(nullptr) {}
+
+  auto get_backend_stream() { return stream_; }
+
+  bool is_default() { return stream_ == nullptr; }
+
+  auto get_view() { return stream_view(this->stream_); }
+
+  void synchronize() {}
+
+private:
+  void* stream_;
+};
+
+#endif
+
 } // namespace gt
 
 #endif // GTENSOR_BACKEND_HOST_H

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -26,6 +26,9 @@
 namespace gt
 {
 
+class stream_view;
+class stream_wrapper;
+
 namespace backend
 {
 

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -596,37 +596,24 @@ struct launch<N, space::device>
 } // namespace detail
 
 template <int N, typename F>
-inline void launch_host(const gt::shape_type<N>& shape, F&& f)
+inline void launch_host(const gt::shape_type<N>& shape, F&& f,
+                        gt::stream_view stream = gt::stream_view{})
 {
-  detail::launch<N, space::host>::run(shape, std::forward<F>(f),
-                                      gt::stream_view{});
+  detail::launch<N, space::host>::run(shape, std::forward<F>(f), stream);
 }
 
 template <int N, typename F>
 inline void launch(const gt::shape_type<N>& shape, F&& f,
-                   gt::stream_view stream)
+                   gt::stream_view stream = gt::stream_view{})
 {
   detail::launch<N, space::device>::run(shape, std::forward<F>(f), stream);
 }
 
-template <int N, typename F>
-inline void launch(const gt::shape_type<N>& shape, F&& f)
-{
-  detail::launch<N, space::device>::run(shape, std::forward<F>(f),
-                                        gt::stream_view{});
-}
-
 template <int N, typename S, typename F>
 inline void launch(const gt::shape_type<N>& shape, F&& f,
-                   gt::stream_view stream)
+                   gt::stream_view stream = gt::stream_view{})
 {
   detail::launch<N, S>::run(shape, std::forward<F>(f), stream);
-}
-
-template <int N, typename S, typename F>
-inline void launch(const gt::shape_type<N>& shape, F&& f)
-{
-  detail::launch<N, S>::run(shape, std::forward<F>(f), gt::stream_view{});
 }
 
 // ======================================================================

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -308,7 +308,7 @@ template <>
 struct launch<1, space::host>
 {
   template <typename F>
-  static void run(const gt::shape_type<1>& shape, F&& f)
+  static void run(const gt::shape_type<1>& shape, F&& f, gt::stream_view stream)
   {
     for (int i = 0; i < shape[0]; i++) {
       std::forward<F>(f)(i);
@@ -320,7 +320,7 @@ template <>
 struct launch<2, space::host>
 {
   template <typename F>
-  static void run(const gt::shape_type<2>& shape, F&& f)
+  static void run(const gt::shape_type<2>& shape, F&& f, gt::stream_view stream)
   {
     for (int j = 0; j < shape[1]; j++) {
       for (int i = 0; i < shape[0]; i++) {
@@ -334,7 +334,7 @@ template <>
 struct launch<3, space::host>
 {
   template <typename F>
-  static void run(const gt::shape_type<3>& shape, F&& f)
+  static void run(const gt::shape_type<3>& shape, F&& f, gt::stream_view stream)
   {
     for (int k = 0; k < shape[2]; k++) {
       for (int j = 0; j < shape[1]; j++) {
@@ -350,7 +350,7 @@ template <>
 struct launch<4, space::host>
 {
   template <typename F>
-  static void run(const gt::shape_type<4>& shape, F&& f)
+  static void run(const gt::shape_type<4>& shape, F&& f, gt::stream_view stream)
   {
     for (int l = 0; l < shape[3]; l++) {
       for (int k = 0; k < shape[2]; k++) {
@@ -368,7 +368,7 @@ template <>
 struct launch<5, space::host>
 {
   template <typename F>
-  static void run(const gt::shape_type<5>& shape, F&& f)
+  static void run(const gt::shape_type<5>& shape, F&& f, gt::stream_view stream)
   {
     for (int m = 0; m < shape[4]; m++) {
       for (int l = 0; l < shape[3]; l++) {
@@ -388,7 +388,7 @@ template <>
 struct launch<6, space::host>
 {
   template <typename F>
-  static void run(const gt::shape_type<6>& shape, F&& f)
+  static void run(const gt::shape_type<6>& shape, F&& f, gt::stream_view stream)
   {
     for (int n = 0; n < shape[5]; n++) {
       for (int m = 0; m < shape[4]; m++) {
@@ -411,15 +411,15 @@ template <>
 struct launch<1, space::device>
 {
   template <typename F>
-  static void run(const gt::shape_type<1>& shape, F&& f)
+  static void run(const gt::shape_type<1>& shape, F&& f, gt::stream_view stream)
   {
     const int BS_1D = 256;
     dim3 numThreads(BS_1D);
     dim3 numBlocks((shape[0] + BS_1D - 1) / BS_1D);
 
     gpuSyncIfEnabled();
-    gtLaunchKernel(kernel_launch, numBlocks, numThreads, 0, 0, shape,
-                   std::forward<F>(f));
+    gtLaunchKernel(kernel_launch, numBlocks, numThreads, 0,
+                   stream.get_backend_stream(), shape, std::forward<F>(f));
     gpuSyncIfEnabled();
   }
 };
@@ -428,14 +428,14 @@ template <>
 struct launch<2, space::device>
 {
   template <typename F>
-  static void run(const gt::shape_type<2>& shape, F&& f)
+  static void run(const gt::shape_type<2>& shape, F&& f, gt::stream_view stream)
   {
     dim3 numThreads(BS_X, BS_Y);
     dim3 numBlocks((shape[0] + BS_X - 1) / BS_X, (shape[1] + BS_Y - 1) / BS_Y);
 
     gpuSyncIfEnabled();
-    gtLaunchKernel(kernel_launch, numBlocks, numThreads, 0, 0, shape,
-                   std::forward<F>(f));
+    gtLaunchKernel(kernel_launch, numBlocks, numThreads, 0,
+                   stream.get_backend_stream(), shape, std::forward<F>(f));
     gpuSyncIfEnabled();
   }
 };
@@ -444,15 +444,15 @@ template <>
 struct launch<3, space::device>
 {
   template <typename F>
-  static void run(const gt::shape_type<3>& shape, F&& f)
+  static void run(const gt::shape_type<3>& shape, F&& f, gt::stream_view stream)
   {
     dim3 numThreads(BS_X, BS_Y);
     dim3 numBlocks((shape[0] + BS_X - 1) / BS_X, (shape[1] + BS_Y - 1) / BS_Y,
                    shape[2]);
 
     gpuSyncIfEnabled();
-    gtLaunchKernel(kernel_launch, numBlocks, numThreads, 0, 0, shape,
-                   std::forward<F>(f));
+    gtLaunchKernel(kernel_launch, numBlocks, numThreads, 0,
+                   stream.get_backend_stream(), shape, std::forward<F>(f));
     gpuSyncIfEnabled();
   }
 };
@@ -461,15 +461,15 @@ template <>
 struct launch<4, space::device>
 {
   template <typename F>
-  static void run(const gt::shape_type<4>& shape, F&& f)
+  static void run(const gt::shape_type<4>& shape, F&& f, gt::stream_view stream)
   {
     dim3 numThreads(BS_X, BS_Y);
     dim3 numBlocks((shape[0] + BS_X - 1) / BS_X, (shape[1] + BS_Y - 1) / BS_Y,
                    shape[2] * shape[3]);
 
     gpuSyncIfEnabled();
-    gtLaunchKernel(kernel_launch, numBlocks, numThreads, 0, 0, shape,
-                   std::forward<F>(f));
+    gtLaunchKernel(kernel_launch, numBlocks, numThreads, 0,
+                   stream.get_backend_stream(), shape, std::forward<F>(f));
     gpuSyncIfEnabled();
   }
 };
@@ -478,14 +478,14 @@ template <>
 struct launch<5, space::device>
 {
   template <typename F>
-  static void run(const gt::shape_type<5>& shape, F&& f)
+  static void run(const gt::shape_type<5>& shape, F&& f, gt::stream_view stream)
   {
     dim3 numThreads(BS_X, BS_Y);
     dim3 numBlocks((shape[0] + BS_X - 1) / BS_X, (shape[1] + BS_Y - 1) / BS_Y,
                    shape[2] * shape[3] * shape[4]);
 
-    gtLaunchKernel(kernel_launch, numBlocks, numThreads, 0, 0, shape,
-                   std::forward<F>(f));
+    gtLaunchKernel(kernel_launch, numBlocks, numThreads, 0,
+                   stream.get_backend_stream(), shape, std::forward<F>(f));
   }
 };
 
@@ -493,14 +493,14 @@ template <>
 struct launch<6, space::device>
 {
   template <typename F>
-  static void run(const gt::shape_type<6>& shape, F&& f)
+  static void run(const gt::shape_type<6>& shape, F&& f, gt::stream_view stream)
   {
     dim3 numThreads(BS_X, BS_Y);
     dim3 numBlocks((shape[0] + BS_X - 1) / BS_X, (shape[1] + BS_Y - 1) / BS_Y,
                    shape[2] * shape[3] * shape[4] * shape[5]);
 
-    gtLaunchKernel(kernel_launch, numBlocks, numThreads, 0, 0, shape,
-                   std::forward<F>(f));
+    gtLaunchKernel(kernel_launch, numBlocks, numThreads, 0,
+                   stream.get_backend_stream(), shape, std::forward<F>(f));
   }
 };
 
@@ -598,19 +598,35 @@ struct launch<N, space::device>
 template <int N, typename F>
 inline void launch_host(const gt::shape_type<N>& shape, F&& f)
 {
-  detail::launch<N, space::host>::run(shape, std::forward<F>(f));
+  detail::launch<N, space::host>::run(shape, std::forward<F>(f),
+                                      gt::stream_view{});
+}
+
+template <int N, typename F>
+inline void launch(const gt::shape_type<N>& shape, F&& f,
+                   gt::stream_view stream)
+{
+  detail::launch<N, space::device>::run(shape, std::forward<F>(f), stream);
 }
 
 template <int N, typename F>
 inline void launch(const gt::shape_type<N>& shape, F&& f)
 {
-  detail::launch<N, space::device>::run(shape, std::forward<F>(f));
+  detail::launch<N, space::device>::run(shape, std::forward<F>(f),
+                                        gt::stream_view{});
+}
+
+template <int N, typename S, typename F>
+inline void launch(const gt::shape_type<N>& shape, F&& f,
+                   gt::stream_view stream)
+{
+  detail::launch<N, S>::run(shape, std::forward<F>(f), stream);
 }
 
 template <int N, typename S, typename F>
 inline void launch(const gt::shape_type<N>& shape, F&& f)
 {
-  detail::launch<N, S>::run(shape, std::forward<F>(f));
+  detail::launch<N, S>::run(shape, std::forward<F>(f), gt::stream_view{});
 }
 
 // ======================================================================

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -510,9 +510,9 @@ template <>
 struct launch<1, space::device>
 {
   template <typename F>
-  static void run(const gt::shape_type<1>& shape, F&& f)
+  static void run(const gt::shape_type<1>& shape, F&& f, gt::stream_view stream)
   {
-    sycl::queue& q = gt::backend::sycl::get_queue();
+    sycl::queue q = stream.get_backend_stream();
     auto range = sycl::range<1>(shape[0]);
     auto e = q.submit([&](sycl::handler& cgh) {
       // using kname = gt::backend::sycl::Launch1<decltype(f)>;
@@ -529,9 +529,9 @@ template <>
 struct launch<2, space::device>
 {
   template <typename F>
-  static void run(const gt::shape_type<2>& shape, F&& f)
+  static void run(const gt::shape_type<2>& shape, F&& f, gt::stream_view stream)
   {
-    sycl::queue& q = gt::backend::sycl::get_queue();
+    sycl::queue q = stream.get_backend_stream();
     auto range = sycl::range<2>(shape[0], shape[1]);
     auto e = q.submit([&](sycl::handler& cgh) {
       // using kname = gt::backend::sycl::Launch2<decltype(f)>;
@@ -549,9 +549,9 @@ template <>
 struct launch<3, space::device>
 {
   template <typename F>
-  static void run(const gt::shape_type<3>& shape, F&& f)
+  static void run(const gt::shape_type<3>& shape, F&& f, gt::stream_view stream)
   {
-    sycl::queue& q = gt::backend::sycl::get_queue();
+    sycl::queue q = stream.get_backend_stream();
     auto range = sycl::range<3>(shape[0], shape[1], shape[2]);
     auto e = q.submit([&](sycl::handler& cgh) {
       // using kname = gt::backend::sycl::Launch3<decltype(f)>;
@@ -570,9 +570,9 @@ template <size_type N>
 struct launch<N, space::device>
 {
   template <typename F>
-  static void run(const gt::shape_type<N>& shape, F&& f)
+  static void run(const gt::shape_type<N>& shape, F&& f, gt::stream_view stream)
   {
-    sycl::queue& q = gt::backend::sycl::get_queue();
+    sycl::queue q = stream.get_backend_stream();
     int size = calc_size(shape);
     // use linear indexing for simplicity
     auto block_size = std::min(size, BS_LINEAR);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ add_gtensor_test(test_reductions)
 add_gtensor_test(test_sarray)
 add_gtensor_test(test_assign)
 add_gtensor_test(test_space)
+add_gtensor_test(test_stream)
 
 if (GTENSOR_ENABLE_CLIB)
   add_executable(test_clib)

--- a/tests/test_stream.cxx
+++ b/tests/test_stream.cxx
@@ -9,7 +9,7 @@ TEST(stream, assign_gtensor_6d)
   gt::gtensor<int, 6> a(gt::shape(2, 3, 4, 5, 6, 7));
   gt::gtensor<int, 6> b(a.shape());
 
-  gt::stream_wrapper stream;
+  gt::stream stream;
 
   int* adata = a.data();
 
@@ -38,12 +38,12 @@ void device_double_add_2d_stream(gt::gtensor_device<double, 2>& a,
   gt::copy(b, out);
 }
 
-TEST(gtensor, device_launch_2d)
+TEST(stream, stream_device_launch_2d)
 {
   gt::gtensor_device<double, 2> a{{11., 12., 13.}, {21., 22., 23.}};
   gt::gtensor<double, 2> h_b(a.shape());
 
-  gt::stream_wrapper stream;
+  gt::stream stream;
 
   device_double_add_2d_stream(a, h_b, stream.get_view());
 

--- a/tests/test_stream.cxx
+++ b/tests/test_stream.cxx
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+
+#include "gtensor/gtensor.h"
+
+#include "test_debug.h"
+
+TEST(stream, assign_gtensor_6d)
+{
+  gt::gtensor<int, 6> a(gt::shape(2, 3, 4, 5, 6, 7));
+  gt::gtensor<int, 6> b(a.shape());
+
+  gt::stream_wrapper stream;
+
+  int* adata = a.data();
+
+  for (int i = 0; i < a.size(); i++) {
+    adata[i] = i;
+  }
+
+  EXPECT_NE(a, b);
+  gt::assign(b, a, stream.get_view());
+  stream.synchronize();
+  EXPECT_EQ(a, b);
+}
+
+void device_double_add_2d_stream(gt::gtensor_device<double, 2>& a,
+                                 gt::gtensor<double, 2>& out,
+                                 gt::stream_view stream)
+{
+  auto b = gt::empty_like(a);
+
+  auto k_a = a.to_kernel();
+  auto k_b = b.to_kernel();
+
+  gt::launch<2>(
+    a.shape(), GT_LAMBDA(int i, int j) { k_b(i, j) = k_a(i, j) + k_a(i, j); },
+    stream);
+  gt::copy(b, out);
+}
+
+TEST(gtensor, device_launch_2d)
+{
+  gt::gtensor_device<double, 2> a{{11., 12., 13.}, {21., 22., 23.}};
+  gt::gtensor<double, 2> h_b(a.shape());
+
+  gt::stream_wrapper stream;
+
+  device_double_add_2d_stream(a, h_b, stream.get_view());
+
+  EXPECT_EQ(h_b, (gt::gtensor<double, 2>{{22., 24., 26.}, {42., 44., 46.}}));
+}


### PR DESCRIPTION
Simple (not space templated) stream implementation for all backends, assign and launch. Does not provide a stream arg for async copy yet. Has a couple of unit tests in tests/test_streams.cxx.

Note that the SYCL approach to streams, queue objects, is arguably a better fit for a C++ library. However the main goal with the gtensor streams implementation is to allow interoperability with other libraries that already use stream directly, e.g. StarPU.