### PR TITLE
First attempt to care for large launch dimensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ if ("hip" IN_LIST GTENSOR_BUILD_DEVICES)
     target_compile_definitions(gtensor_hip INTERFACE GTENSOR_USE_THRUST)
   endif()
 
-  if ($ENV{MACHINE} STREQUAL "crusher")
+  if ("$ENV{MACHINE}" STREQUAL "crusher")
      target_compile_definitions(gtensor_hip INTERFACE __HIP_ROCclr__ __HIP_ARCH_GFX90A__=1)
   endif()
   # Note: always link thrust, used for reductions even when the gtensor

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ option(GTENSOR_ENABLE_FFT  "Enable gtfft" OFF)
 set(HIP_GCC_TOOLCHAIN "" CACHE STRING "pass gcc-toolchain option to hipcc")
 set(ROCM_PATH "/opt/rocm" CACHE STRING "path to ROCm installation")
 set(HIP_PATH "/opt/rocm/hip" CACHE STRING "path to HIP installation")
-set(HIP_GPU_ARCHITECTURES "gfx803,gfx906,gfx908" CACHE
+set(HIP_GPU_ARCHITECTURES "gfx803,gfx906,gfx908,gfx90a" CACHE
     STRING "comma separated list of AMD gpu architectures to build for")
 
 # SYCL specific configuration
@@ -139,6 +139,9 @@ if ("hip" IN_LIST GTENSOR_BUILD_DEVICES)
     target_compile_definitions(gtensor_hip INTERFACE GTENSOR_USE_THRUST)
   endif()
 
+  if ($ENV{MACHINE} STREQUAL "crusher")
+     target_compile_definitions(gtensor_hip INTERFACE __HIP_ROCclr__ __HIP_ARCH_GFX90A__=1)
+  endif()
   # Note: always link thrust, used for reductions even when the gtensor
   # internal data backend is used instead of thrust::device_vector
   add_library(rocthrust INTERFACE IMPORTED)
@@ -170,6 +173,8 @@ if ("hip" IN_LIST GTENSOR_BUILD_DEVICES)
   target_link_libraries(gtensor_hip INTERFACE rocthrust)
   target_compile_options(gtensor_hip INTERFACE
     $<$<COMPILE_LANGUAGE:CXX>:--amdgpu-target=${HIP_GPU_ARCHITECTURES}>)
+  target_compile_options(gtensor_hip INTERFACE
+    $<$<COMPILE_LANGUAGE:CXX>:--offload-arch=${HIP_GPU_ARCHITECTURES}>)
   target_link_options(gtensor_hip INTERFACE
     $<$<LINK_LANGUAGE:CXX>:--amdgpu-target=${HIP_GPU_ARCHITECTURES}>)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,7 @@ if ("sycl" IN_LIST GTENSOR_BUILD_DEVICES)
       target_compile_options(gtensor_sycl INTERFACE
         $<$<COMPILE_LANGUAGE:CXX>:-fsycl-targets=spir64_gen
           -Xsycl-target-backend
-            "-device ${GTENSOR_DEVICE_SYCL_AOT_ARCHITECTURES}">)
+	     "-device ${GTENSOR_DEVICE_SYCL_AOT_ARCHITECTURES}" >)
     endif()
 
     add_library(oneapi_mkl_sycl INTERFACE IMPORTED)

--- a/include/gtensor/assign.h
+++ b/include/gtensor/assign.h
@@ -10,7 +10,7 @@ namespace gt
 constexpr const int BS_X = 16;
 constexpr const int BS_Y = 16;
 constexpr const int BS_LINEAR = 256;
-  constexpr const int MAXTHREADS_PER_BLOCK = 1024;
+constexpr const int MAXTHREADS_PER_BLOCK = 1024;
 
 // ======================================================================
 // assign
@@ -150,7 +150,7 @@ __global__ void kernel_assign_2(Elhs lhs, Erhs rhs)
   /*int i = threadIdx.x + blockIdx.x * BS_X;
   int j = threadIdx.y + blockIdx.y * BS_Y;
   */
-  long lind=blockIdx.x*blockDim.x + threadIdx.x;
+  long lind = blockIdx.x * blockDim.x + threadIdx.x;
   int i = lind % lhs.shape(0);
   int j = lind / lhs.shape(0);
 
@@ -166,11 +166,10 @@ __global__ void kernel_assign_3(Elhs lhs, Erhs rhs)
   int j = threadIdx.y + blockIdx.y * BS_Y;
   int b = blockIdx.z;
   */
-  long lind=blockIdx.x*blockDim.x + threadIdx.x;
+  long lind = blockIdx.x * blockDim.x + threadIdx.x;
   int i = lind % lhs.shape(0);
   int j = (lind / lhs.shape(0)) % lhs.shape(1);
-  int b = lind / (lhs.shape(0)*lhs.shape(1));
-
+  int b = lind / (lhs.shape(0) * lhs.shape(1));
 
   if (j < lhs.shape(1) && b < lhs.shape(2)) {
     lhs(i, j, b) = rhs(i, j, b);
@@ -248,16 +247,18 @@ struct assigner<1, space::device>
   }
 };
 
-static void get_launch_grid(int* shape, int dim, int& numThreads, int& numBlocks) {
-  long totalthreads=1;
-  for (int i=0; i<dim; ++i) {
+static void get_launch_grid(int* shape, int dim, int& numThreads,
+                            int& numBlocks)
+{
+  long totalthreads = 1;
+  for (int i = 0; i < dim; ++i) {
     totalthreads *= shape[i];
   }
-  numThreads = 2*MAXTHREADS_PER_BLOCK;
+  numThreads = 2 * MAXTHREADS_PER_BLOCK;
   do {
     numThreads /= 2;
-    numBlocks=(totalthreads+numThreads-1)/numThreads;
-  } while (numThreads>16 && numBlocks<32);
+    numBlocks = (totalthreads + numThreads - 1) / numThreads;
+  } while (numThreads > 16 && numBlocks < 32);
 }
 
 template <>
@@ -269,8 +270,9 @@ struct assigner<2, space::device>
     // printf("assigner<2, device>\n");
     int numThreads, numBlocks;
     int shape[2];
-    shape[0]=lhs.shape(0); shape[1]=lhs.shape(1);
-    get_launch_grid(shape,2,numThreads,numBlocks);
+    shape[0] = lhs.shape(0);
+    shape[1] = lhs.shape(1);
+    get_launch_grid(shape, 2, numThreads, numBlocks);
     /*dim3 numThreads(BS_X, BS_Y);
     dim3 numBlocks((lhs.shape(0) + BS_X - 1) / BS_X,
                    (lhs.shape(1) + BS_Y - 1) / BS_Y);
@@ -292,8 +294,10 @@ struct assigner<3, space::device>
     // printf("assigner<3, device>\n");
     int numThreads, numBlocks;
     int shape[3];
-    shape[0]=lhs.shape(0); shape[1]=lhs.shape(1); shape[2]=lhs.shape(2);
-    get_launch_grid(shape,3,numThreads,numBlocks);
+    shape[0] = lhs.shape(0);
+    shape[1] = lhs.shape(1);
+    shape[2] = lhs.shape(2);
+    get_launch_grid(shape, 3, numThreads, numBlocks);
     /*dim3 numThreads(BS_X, BS_Y);
     dim3 numBlocks((lhs.shape(0) + BS_X - 1) / BS_X,
                    (lhs.shape(1) + BS_Y - 1) / BS_Y, lhs.shape(2));


### PR DESCRIPTION
As I need it quite urgent, I implemented a simple `get_launch_grid` function which in the 2d and 3d assignment case computes a grid and threadblock size which does not fail. 

For assignments of higher dimension the implementation does not change anything, nor does it change the kernel launches of arbitrary kernels.