### PR TITLE
sycl: fix parameter size limit in assign

### DIFF
--- a/include/gtensor/assign.h
+++ b/include/gtensor/assign.h
@@ -468,14 +468,20 @@ struct assigner<N, space::device>
       sycl::nd_range<1>(sycl::range<1>(size), sycl::range<1>(block_size));
     auto k_lhs = lhs.to_kernel();
     auto k_rhs = rhs.to_kernel();
+    using ltype = decltype(k_lhs);
+    using rtype = decltype(k_rhs);
+
+    // Note: handle RHS that may be greater than 2k parameter limit
+    gt::backend::device_storage<rtype> d_rhs(1);
+    decltype(auto) d_rhs_p = gt::raw_pointer_cast(d_rhs.data());
+    q.copy(&k_rhs, d_rhs_p, 1).wait();
+
     auto e = q.submit([&](sycl::handler& cgh) {
-      using ltype = decltype(k_lhs);
-      using rtype = decltype(k_rhs);
       using kname = gt::backend::sycl::AssignN<E1, E2, ltype, rtype>;
       cgh.parallel_for<kname>(range, [=](sycl::nd_item<1> item) {
         int i = item.get_global_id(0);
         auto idx = unravel(i, strides);
-        index_expression(k_lhs, idx) = index_expression(k_rhs, idx);
+        index_expression(k_lhs, idx) = index_expression(*d_rhs_p, idx);
       });
     });
     e.wait();


### PR DESCRIPTION
Fixes issue when RHS is a very complex expession and ends up being
bigger than 2k limit when passed as a SYCL kernel parameter.