### PR TITLE
support thrust backend storage even if not used as default

### DIFF
--- a/include/gtensor/allocator.h
+++ b/include/gtensor/allocator.h
@@ -6,7 +6,7 @@
 #include <memory>
 #include <utility>
 
-#ifdef GTENSOR_USE_THRUST
+#ifdef GTENSOR_HAVE_THRUST
 #include <thrust/device_ptr.h>
 #endif
 
@@ -26,7 +26,7 @@ bool is_valid(P p)
   return bool(p);
 }
 
-#ifdef GTENSOR_USE_THRUST
+#ifdef GTENSOR_HAVE_THRUST
 template <typename T>
 bool is_valid(::thrust::device_ptr<T> p)
 {

--- a/include/gtensor/defs.h
+++ b/include/gtensor/defs.h
@@ -4,6 +4,12 @@
 
 #include <cstddef>
 
+// This really should be defined by the build system, but it'll cause
+// compatibility issues with plain old make, so let's be cautious.
+#if defined(GTENSOR_DEVICE_CUDA) || defined(GTENSOR_DEVICE_HIP)
+#define GTENSOR_HAVE_THRUST
+#endif
+
 namespace gt
 {
 

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -8,12 +8,9 @@
 
 #ifdef GTENSOR_HAVE_DEVICE
 
-#ifdef GTENSOR_USE_THRUST
-#include <thrust/device_vector.h>
-#endif
-
-#if defined(GTENSOR_DEVICE_CUDA) || defined(GTENSOR_USE_THRUST)
+#ifdef GTENSOR_HAVE_THRUST
 #include "thrust_ext.h"
+#include <thrust/device_vector.h>
 #endif
 
 #endif // GTENSOR_HAVE_DEVICE
@@ -51,7 +48,7 @@ struct selector<gt::space::host>
   using pointer = T*;
 };
 
-#ifdef GTENSOR_USE_THRUST
+#ifdef GTENSOR_HAVE_THRUST
 template <>
 struct selector<gt::space::thrust>
 {
@@ -131,7 +128,7 @@ struct selector
 #ifdef GTENSOR_DEVICE_SYCL
 #include "backend_sycl.h"
 #endif
-#ifdef GTENSOR_USE_THRUST
+#ifdef GTENSOR_HAVE_THRUST
 #include "backend_thrust.h"
 #endif
 

--- a/include/gtensor/gtensor_forward.h
+++ b/include/gtensor/gtensor_forward.h
@@ -26,10 +26,6 @@ struct space_traits2<device>
 {
   template <typename T>
   using storage_type = device_vector<T>;
-#ifdef GTENSOR_USE_THRUST
-  template <typename T>
-  using pointer = ::thrust::device_ptr<T>;
-#endif
 };
 #endif
 } // namespace space

--- a/include/gtensor/pointer_traits.h
+++ b/include/gtensor/pointer_traits.h
@@ -5,7 +5,7 @@
 #include "device_ptr.h"
 #include "space_forward.h"
 
-#ifdef GTENSOR_USE_THRUST
+#ifdef GTENSOR_HAVE_THRUST
 #include <thrust/device_ptr.h>
 #endif
 
@@ -47,7 +47,7 @@ struct pointer_traits<gt::backend::device_ptr<T>>
   GT_INLINE static T* get(pointer p) { return p.get(); }
 };
 
-#ifdef GTENSOR_USE_THRUST
+#ifdef GTENSOR_HAVE_THRUST
 
 template <typename T>
 struct pointer_traits<::thrust::device_ptr<T>>

--- a/include/gtensor/space.h
+++ b/include/gtensor/space.h
@@ -11,8 +11,7 @@
 
 #include <vector>
 
-#ifdef GTENSOR_USE_THRUST
-#include <thrust/device_allocator.h>
+#ifdef GTENSOR_HAVE_THRUST
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 #endif
@@ -95,7 +94,7 @@ struct storage_traits<gt::backend::device_storage<T, A>>
 
 #endif
 
-#ifdef GTENSOR_USE_THRUST
+#ifdef GTENSOR_HAVE_THRUST
 
 template <typename T, typename A>
 struct storage_traits<::thrust::host_vector<T, A>>

--- a/include/gtensor/space_forward.h
+++ b/include/gtensor/space_forward.h
@@ -12,7 +12,7 @@ namespace space
 struct host_only
 {};
 
-#ifdef GTENSOR_USE_THRUST
+#ifdef GTENSOR_HAVE_THRUST
 struct thrust
 {};
 struct thrust_managed


### PR DESCRIPTION
The change away from thrust as default backend actually caused me quite some breakage, and life gets easier if thrust backend storage is still supported even though when it's not used by default.