### PR TITLE
Pr/bandsolve invert

### DIFF
--- a/benchmarks/getrs.cxx
+++ b/benchmarks/getrs.cxx
@@ -212,9 +212,9 @@ void test(int n, int nrhs, int batch_size, int bw)
   total = 0.0;
   for (int i = 0; i < NRUNS; i++) {
     clock_gettime(CLOCK_MONOTONIC, &start);
-    gt::blas::solve_inverted_batched(
-      n, nrhs, gt::raw_pointer_cast(d_Ainvptr.data()), lda,
-      gt::raw_pointer_cast(d_Bptr.data()), ldb,
+    gt::blas::gemm_batched<CT>(
+      h, n, nrhs, n, 1.0, gt::raw_pointer_cast(d_Ainvptr.data()), lda,
+      gt::raw_pointer_cast(d_Bptr.data()), ldb, 0.0,
       gt::raw_pointer_cast(d_Cptr.data()), ldb, batch_size);
     gt::synchronize();
     clock_gettime(CLOCK_MONOTONIC, &end);

--- a/benchmarks/getrs.cxx
+++ b/benchmarks/getrs.cxx
@@ -80,14 +80,22 @@ void test(int n, int nrhs, int batch_size, int bw)
 #endif
 
   auto h_Aptr = gt::empty<CT*>({batch_size});
+  auto h_Ainvptr = gt::empty<CT*>({batch_size});
   auto h_Bptr = gt::empty<CT*>({batch_size});
+  auto h_Cptr = gt::empty<CT*>({batch_size});
   auto d_Aptr = gt::empty_device<CT*>({batch_size});
+  auto d_Ainvptr = gt::empty_device<CT*>({batch_size});
   auto d_Bptr = gt::empty_device<CT*>({batch_size});
+  auto d_Cptr = gt::empty_device<CT*>({batch_size});
 
   auto h_Adata = gt::zeros<CT>({n, n, batch_size});
+  auto h_Ainvdata = gt::zeros<CT>({n, n, batch_size});
   auto h_Bdata = gt::zeros<CT>({n, nrhs, batch_size});
+  auto h_Cdata = gt::zeros<CT>({n, nrhs, batch_size});
   auto d_Adata = gt::empty_device<CT>(h_Adata.shape());
+  auto d_Ainvdata = gt::empty_device<CT>(h_Adata.shape());
   auto d_Bdata = gt::empty_device<CT>(h_Bdata.shape());
+  auto d_Cdata = gt::empty_device<CT>(h_Cdata.shape());
 
   auto h_piv = gt::empty<gt::blas::index_t>({n, batch_size});
   auto d_piv = gt::empty_device<gt::blas::index_t>(h_piv.shape());
@@ -123,12 +131,16 @@ void test(int n, int nrhs, int batch_size, int bw)
 
   for (int i = 0; i < batch_size; i++) {
     h_Aptr(i) = gt::raw_pointer_cast(d_Adata.data()) + (n * n * i);
+    h_Ainvptr(i) = gt::raw_pointer_cast(d_Ainvdata.data()) + (n * n * i);
     h_Bptr(i) = gt::raw_pointer_cast(d_Bdata.data()) + (n * nrhs * i);
+    h_Cptr(i) = gt::raw_pointer_cast(d_Cdata.data()) + (n * nrhs * i);
   }
   gt::copy(h_Aptr, d_Aptr);
   gt::copy(h_Adata, d_Adata);
+  gt::copy(h_Ainvptr, d_Ainvptr);
   gt::copy(h_Bptr, d_Bptr);
   gt::copy(h_Bdata, d_Bdata);
+  gt::copy(h_Cptr, d_Cptr);
   gt::copy(h_piv, d_piv);
 
   std::cout << "INFO: memcpy to device done" << std::endl;
@@ -151,6 +163,11 @@ void test(int n, int nrhs, int batch_size, int bw)
   ss.str("");
   ss << bw2.lower << "_" << bw2.upper;
   bw_str = ss.str();
+
+  gt::blas::invert_banded_batched(n, gt::raw_pointer_cast(d_Aptr.data()), lda,
+                                  gt::raw_pointer_cast(d_piv.data()),
+                                  gt::raw_pointer_cast(d_Ainvptr.data()), lda,
+                                  batch_size, bw2.lower, bw2.upper);
 
   for (int i = 0; i < NRUNS; i++) {
     clock_gettime(CLOCK_MONOTONIC, &start);
@@ -191,6 +208,25 @@ void test(int n, int nrhs, int batch_size, int bw)
 
   std::cout << type_str << "\t" << size_str << "\t" << bw_str
             << "\tbanded_avg\t" << total / (NRUNS - 1) << std::endl;
+
+  total = 0.0;
+  for (int i = 0; i < NRUNS; i++) {
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    gt::blas::solve_inverted_batched(
+      n, nrhs, gt::raw_pointer_cast(d_Ainvptr.data()), lda,
+      gt::raw_pointer_cast(d_Bptr.data()), ldb,
+      gt::raw_pointer_cast(d_Cptr.data()), ldb, batch_size);
+    gt::synchronize();
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    elapsed =
+      (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) * 1.0e-9;
+    if (i > 0)
+      total += elapsed;
+    std::cout << "INFO: run invt [" << i << "]: " << elapsed << std::endl;
+  }
+
+  std::cout << type_str << "\t" << size_str << "\t" << bw_str
+            << "\tinverted_avg\t" << total / (NRUNS - 1) << std::endl;
 
 // needs update for change to use non-trivial input with specified bw
 #if 0

--- a/include/gt-blas/backend/cuda.h
+++ b/include/gt-blas/backend/cuda.h
@@ -321,6 +321,37 @@ CREATE_GETRF_NPVT_BATCHED(cublasCgetrfBatched, gt::complex<float>, cuComplex)
 
 #undef CREATE_GETRF_NPVT_BATCHED
 
+// ======================================================================
+// gemm batched
+
+template <typename T>
+inline void gemm_batched(handle_t* h, int m, int n, int k, T alpha,
+                         T** d_Aarray, int lda, T** d_Barray, int ldb, T beta,
+                         T** d_Carray, int ldc, int batchSize);
+
+#define CREATE_GEMM_BATCHED(METHOD, GTTYPE, BLASTYPE)                          \
+  template <>                                                                  \
+  inline void gemm_batched<GTTYPE>(handle_t * h, int m, int n, int k,          \
+                                   GTTYPE alpha, GTTYPE** d_Aarray, int lda,   \
+                                   GTTYPE** d_Barray, int ldb, GTTYPE beta,    \
+                                   GTTYPE** d_Carray, int ldc, int batchSize)  \
+  {                                                                            \
+    gtBlasCheck(METHOD(h->handle, CUBLAS_OP_N, CUBLAS_OP_N, m, n, k,           \
+                       reinterpret_cast<BLASTYPE*>(&alpha),                    \
+                       reinterpret_cast<BLASTYPE**>(d_Aarray), lda,            \
+                       reinterpret_cast<BLASTYPE**>(d_Barray), ldb,            \
+                       reinterpret_cast<BLASTYPE*>(&beta),                     \
+                       reinterpret_cast<BLASTYPE**>(d_Carray), ldc,            \
+                       batchSize));                                            \
+  }
+
+CREATE_GEMM_BATCHED(cublasZgemmBatched, gt::complex<double>, cuDoubleComplex)
+CREATE_GEMM_BATCHED(cublasCgemmBatched, gt::complex<float>, cuComplex)
+CREATE_GEMM_BATCHED(cublasDgemmBatched, double, double);
+CREATE_GEMM_BATCHED(cublasSgemmBatched, float, float);
+
+#undef CREATE_GEMM_BATCHED
+
 } // namespace blas
 
 } // namespace gt

--- a/include/gt-blas/backend/hip.h
+++ b/include/gt-blas/backend/hip.h
@@ -322,6 +322,39 @@ CREATE_GETRF_NPVT_BATCHED(rocsolver_cgetrf_npvt_batched, gt::complex<float>,
 
 #undef CREATE_GETRF_NPVT_BATCHED
 
+// ======================================================================
+// gemm batched
+
+template <typename T>
+inline void gemm_batched(handle_t* h, int m, int n, int k, T alpha,
+                         T** d_Aarray, int lda, T** d_Barray, int ldb, T beta,
+                         T** d_Carray, int ldc, int batchSize);
+
+#define CREATE_GEMM_BATCHED(METHOD, GTTYPE, BLASTYPE)                          \
+  template <>                                                                  \
+  inline void gemm_batched<GTTYPE>(handle_t * h, int m, int n, int k,          \
+                                   GTTYPE alpha, GTTYPE** d_Aarray, int lda,   \
+                                   GTTYPE** d_Barray, int ldb, GTTYPE beta,    \
+                                   GTTYPE** d_Carray, int ldc, int batchSize)  \
+  {                                                                            \
+    gtBlasCheck(                                                               \
+      METHOD(h->handle, rocblas_operation_none, rocblas_operation_none, m, n,  \
+             k, reinterpret_cast<BLASTYPE*>(&alpha),                           \
+             reinterpret_cast<BLASTYPE**>(d_Aarray), lda,                      \
+             reinterpret_cast<BLASTYPE**>(d_Barray), ldb,                      \
+             reinterpret_cast<BLASTYPE*>(&beta),                               \
+             reinterpret_cast<BLASTYPE**>(d_Carray), ldc, batchSize));         \
+  }
+
+CREATE_GEMM_BATCHED(rocblas_zgemm_batched, gt::complex<double>,
+                    rocblas_double_complex)
+CREATE_GEMM_BATCHED(rocblas_cgemm_batched, gt::complex<float>,
+                    rocblas_float_complex)
+CREATE_GEMM_BATCHED(rocblas_dgemm_batched, double, double);
+CREATE_GEMM_BATCHED(rocblas_sgemm_batched, float, float);
+
+#undef CREATE_GEMM_BATCHED
+
 } // namespace blas
 
 } // namespace gt

--- a/include/gt-blas/bandsolver.h
+++ b/include/gt-blas/bandsolver.h
@@ -15,6 +15,15 @@ struct matrix_bandwidth
   int upper;
 };
 
+/**
+ * Calculate max bandwidth in a batch of square matrices.
+ *
+ * @param n size of each A_i
+ * @param d_Aarray Array of device pointers to input [A_i]
+ * @param lda leading distance of each A_i, >=n
+ * @param batchSize number of matrices [A_i] and [B_i] in batch
+ * @return matrix_bandwidth struct containing max upper and lower bandwidth
+ */
 template <typename T>
 inline matrix_bandwidth get_max_bandwidth(int n, T** d_Aarray, int lda,
                                           int batch_size)
@@ -80,6 +89,23 @@ inline matrix_bandwidth get_max_bandwidth(int n, T** d_Aarray, int lda,
   return res;
 }
 
+/**
+ * Solve a batch of banded square LU factored matrices and RHS vectors.
+ *
+ * @see gt::blas::getrf_batch()
+ * @see gt::blas::get_max_bandwidth()
+ *
+ * @param n size of each A_i and number of rows of each B_i
+ * @param nrhs number of RHS column vectors in each B_i
+ * @param d_Aarray Array of device pointers to LU factored input [A_i]
+ * @param lda leading distance of each A_i, >=n
+ * @param d_PivtoArray Array of device pointers to each piv_i
+ * @param d_Barray Array of device pointers to each RHS/output [B_i]
+ * @param ldb leading distance of each B_i, >=n
+ * @param batchSize number of matrices [A_i] and [B_i] in batch
+ * @param lbw max lower bandwidth of all [A_i]
+ * @param ubw max upper bandwidth of all [A_i]
+ */
 template <typename T>
 inline void getrs_banded_batched(int n, int nrhs, T** d_Aarray, int lda,
                                  index_t* d_PivotArray, T** d_Barray, int ldb,
@@ -92,6 +118,81 @@ inline void getrs_banded_batched(int n, int nrhs, T** d_Aarray, int lda,
       T* B = d_Barray[batch] + ldb * rhs;
       index_t* piv = d_PivotArray + batch * n;
       T tmp;
+
+      for (int i = 0; i < n; i++) {
+        tmp = B[i];
+        B[i] = B[piv[i] - 1];
+        B[piv[i] - 1] = tmp;
+      }
+
+      // forward sub, unit diag
+      for (int i = 0; i < lbw; i++) {
+        tmp = B[i];
+        for (int j = 0; j < i; j++) {
+          tmp -= A[j * lda + i] * B[j];
+        }
+        B[i] = tmp;
+      }
+      for (int i = lbw; i < n; i++) {
+        tmp = B[i];
+        for (int j = i - lbw; j < i; j++) {
+          tmp -= A[j * lda + i] * B[j];
+        }
+        B[i] = tmp;
+      }
+
+      // backward sub
+      for (int i = n - 1; i > n - ubw - 1; i--) {
+        tmp = B[i];
+        for (int j = i + 1; j < n; j++) {
+          tmp -= A[j * lda + i] * B[j];
+        }
+        B[i] = tmp / A[i * lda + i];
+      }
+      for (int i = n - ubw - 1; i >= 0; i--) {
+        tmp = B[i];
+        for (int j = i + 1; j <= i + ubw; j++) {
+          tmp -= A[j * lda + i] * B[j];
+        }
+        B[i] = tmp / A[i * lda + i];
+      }
+    });
+}
+
+/**
+ * Invert a batch of square LU factored matrices.
+ *
+ * @see gt::blas::getrf_batch()
+ * @see gt::blas::get_max_bandwidth()
+ *
+ * @param n size of each A_i and B_i matrix in batch
+ * @param d_Aarray Array of device pointers to each input A_i
+ * @param lda leading distance of each A_i, >=n
+ * @param d_PivtoArray Array of device pointers to each piv_i
+ * @param d_Barray Array of device pointers to each output B_i
+ * @param ldb leading distance of each B_i, >=n
+ * @param batchSize number of matrices [A_i] and [B_i] in batch
+ * @param lbw max lower bandwidth of all [A_i]
+ * @param ubw max upper bandwidth of all [A_i]
+ */
+template <typename T>
+inline void invert_banded_batched(int n, T** d_Aarray, int lda,
+                                  index_t* d_PivotArray, T** d_Barray, int ldb,
+                                  int batchSize, int lbw, int ubw)
+{
+  int nrhs = n;
+  auto launch_shape = gt::shape(nrhs, batchSize);
+  gt::launch<2>(
+    launch_shape, GT_LAMBDA(int rhs, int batch) {
+      T* A = d_Aarray[batch];
+      T* B = d_Barray[batch] + ldb * rhs;
+      index_t* piv = d_PivotArray + batch * n;
+      T tmp;
+
+      for (int i = 0; i < n; i++) {
+        B[i] = 0;
+      }
+      B[rhs] = T(1);
 
       for (int i = 0; i < n; i++) {
         tmp = B[i];

--- a/include/gt-blas/cblas.h
+++ b/include/gt-blas/cblas.h
@@ -128,6 +128,42 @@ void gtblas_cget_max_bandwidth(int n, f2c_complex<float>** d_Aarray, int lda,
 void gtblas_zget_max_bandwidth(int n, f2c_complex<double>** d_Aarray, int lda,
                                int batchSize, int* lbw, int* ubw);
 
+void gtblas_sgemm_batched(int m, int n, int k, float* alpha, float** d_Aarray,
+                          int lda, float** d_Barray, int ldb, float* beta,
+                          float** d_Carray, int ldc, int batchSize);
+void gtblas_dgemm_batched(int m, int n, int k, double* alpha, double** d_Aarray,
+                          int lda, double** d_Barray, int ldb, double* beta,
+                          double** d_Carray, int ldc, int batchSize);
+void gtblas_cgemm_batched(int m, int n, int k, f2c_complex<float>* alpha,
+                          f2c_complex<float>** d_Aarray, int lda,
+                          f2c_complex<float>** d_Barray, int ldb,
+                          f2c_complex<float>* beta,
+                          f2c_complex<float>** d_Carray, int ldc,
+                          int batchSize);
+void gtblas_zgemm_batched(int m, int n, int k, f2c_complex<double>* alpha,
+                          f2c_complex<double>** d_Aarray, int lda,
+                          f2c_complex<double>** d_Barray, int ldb,
+                          f2c_complex<double>* beta,
+                          f2c_complex<double>** d_Carray, int ldc,
+                          int batchSize);
+
+void gtblas_sinvert_banded_batched(int n, float** d_Aarray, int lda,
+                                   gt::blas::index_t* d_PivotArray,
+                                   float** d_Barray, int ldb, int batchSize,
+                                   int lbw, int ubw);
+void gtblas_dinvert_banded_batched(int n, double** d_Aarray, int lda,
+                                   gt::blas::index_t* d_PivotArray,
+                                   double** d_Barray, int ldb, int batchSize,
+                                   int lbw, int ubw);
+void gtblas_cinvert_banded_batched(int n, f2c_complex<float>** d_Aarray,
+                                   int lda, gt::blas::index_t* d_PivotArray,
+                                   f2c_complex<float>** d_Barray, int ldb,
+                                   int batchSize, int lbw, int ubw);
+void gtblas_zinvert_banded_batched(int n, f2c_complex<double>** d_Aarray,
+                                   int lda, gt::blas::index_t* d_PivotArray,
+                                   f2c_complex<double>** d_Barray, int ldb,
+                                   int batchSize, int lbw, int ubw);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/gt-blas/cblas.h
+++ b/include/gt-blas/cblas.h
@@ -128,22 +128,24 @@ void gtblas_cget_max_bandwidth(int n, f2c_complex<float>** d_Aarray, int lda,
 void gtblas_zget_max_bandwidth(int n, f2c_complex<double>** d_Aarray, int lda,
                                int batchSize, int* lbw, int* ubw);
 
-void gtblas_sgemm_batched(int m, int n, int k, float* alpha, float** d_Aarray,
-                          int lda, float** d_Barray, int ldb, float* beta,
-                          float** d_Carray, int ldc, int batchSize);
-void gtblas_dgemm_batched(int m, int n, int k, double* alpha, double** d_Aarray,
-                          int lda, double** d_Barray, int ldb, double* beta,
-                          double** d_Carray, int ldc, int batchSize);
-void gtblas_cgemm_batched(int m, int n, int k, f2c_complex<float>* alpha,
+void gtblas_sgemm_batched(int m, int n, int k, const float* alpha,
+                          float** d_Aarray, int lda, float** d_Barray, int ldb,
+                          const float* beta, float** d_Carray, int ldc,
+                          int batchSize);
+void gtblas_dgemm_batched(int m, int n, int k, const double* alpha,
+                          double** d_Aarray, int lda, double** d_Barray,
+                          int ldb, const double* beta, double** d_Carray,
+                          int ldc, int batchSize);
+void gtblas_cgemm_batched(int m, int n, int k, const f2c_complex<float>* alpha,
                           f2c_complex<float>** d_Aarray, int lda,
                           f2c_complex<float>** d_Barray, int ldb,
-                          f2c_complex<float>* beta,
+                          const f2c_complex<float>* beta,
                           f2c_complex<float>** d_Carray, int ldc,
                           int batchSize);
-void gtblas_zgemm_batched(int m, int n, int k, f2c_complex<double>* alpha,
+void gtblas_zgemm_batched(int m, int n, int k, const f2c_complex<double>* alpha,
                           f2c_complex<double>** d_Aarray, int lda,
                           f2c_complex<double>** d_Barray, int ldb,
-                          f2c_complex<double>* beta,
+                          const f2c_complex<double>* beta,
                           f2c_complex<double>** d_Carray, int ldc,
                           int batchSize);
 

--- a/src/cgtblas.cxx
+++ b/src/cgtblas.cxx
@@ -308,3 +308,45 @@ CREATE_C_GETRF_NPVT_BATCHED(gtblas_cgetrf_npvt_batched, f2c_complex<float>)
 CREATE_C_GETRF_NPVT_BATCHED(gtblas_zgetrf_npvt_batched, f2c_complex<double>)
 
 #undef CREATE_C_GETRF_NPVT_BATCHED
+
+// ======================================================================
+// gtblas_Xgemm_batched
+#define CREATE_C_GEMM_BATCHED(CNAME, CPPTYPE)                                  \
+  void CNAME(int m, int n, int k, const CPPTYPE* alpha, CPPTYPE** d_Aarray,    \
+             int lda, CPPTYPE** d_Barray, int ldb, const CPPTYPE* beta,        \
+             CPPTYPE** d_Carray, int ldc, int batchSize)                       \
+  {                                                                            \
+    gt::blas::gemm_batched(g_handle, m, n, k, detail::fc2cpp_deref(alpha),     \
+                           detail::cast_aligned(d_Aarray), lda,                \
+                           detail::cast_aligned(d_Barray), ldb,                \
+                           detail::fc2cpp_deref(beta),                         \
+                           detail::cast_aligned(d_Carray), ldc, batchSize);    \
+  }
+
+CREATE_C_GEMM_BATCHED(gtblas_sgemm_batched, float)
+CREATE_C_GEMM_BATCHED(gtblas_dgemm_batched, double)
+CREATE_C_GEMM_BATCHED(gtblas_cgemm_batched, f2c_complex<float>)
+CREATE_C_GEMM_BATCHED(gtblas_zgemm_batched, f2c_complex<double>)
+
+#undef CREATE_C_GEMM_BATCHED
+
+// ======================================================================
+// gtblas_Xinvert_banded_batched
+#define CREATE_C_INVERT_BANDED_BATCHED(CNAME, CPPTYPE)                         \
+  void CNAME(int n, CPPTYPE** d_Aarray, int lda,                               \
+             gt::blas::index_t* d_PivotArray, CPPTYPE** d_Barray, int ldb,     \
+             int batchSize, int lbw, int ubw)                                  \
+  {                                                                            \
+    gt::blas::invert_banded_batched(                                           \
+      n, detail::cast_aligned(d_Aarray), lda, d_PivotArray,                    \
+      detail::cast_aligned(d_Barray), ldb, batchSize, lbw, ubw);               \
+  }
+
+CREATE_C_INVERT_BANDED_BATCHED(gtblas_sinvert_banded_batched, float)
+CREATE_C_INVERT_BANDED_BATCHED(gtblas_dinvert_banded_batched, double)
+CREATE_C_INVERT_BANDED_BATCHED(gtblas_cinvert_banded_batched,
+                               f2c_complex<float>)
+CREATE_C_INVERT_BANDED_BATCHED(gtblas_zinvert_banded_batched,
+                               f2c_complex<double>)
+
+#undef CREATE_C_INVERT_BANDED_BATCHED

--- a/tests/test_bandsolver.cxx
+++ b/tests/test_bandsolver.cxx
@@ -411,12 +411,12 @@ void test_invert_batch_complex()
   test::gtensor2<T*, 1, S> d_Aptr(batch_size);
   gt::gtensor<T, 3> h_A(gt::shape(N, N, batch_size));
   test::gtensor2<T, 3, S> d_A(gt::shape(N, N, batch_size));
-  gt::gtensor<T, 2> h_Ainv(gt::shape(N, N));
+  gt::gtensor<T, 2> h_Ainv_expected(gt::shape(N, N));
 
-  gt::gtensor<T*, 1> h_Bptr(batch_size);
-  test::gtensor2<T*, 1, S> d_Bptr(batch_size);
-  gt::gtensor<T, 3> h_B(gt::shape(N, N, batch_size));
-  test::gtensor2<T, 3, S> d_B(gt::shape(N, N, batch_size));
+  gt::gtensor<T*, 1> h_Ainvptr(batch_size);
+  test::gtensor2<T*, 1, S> d_Ainvptr(batch_size);
+  gt::gtensor<T, 3> h_Ainv(gt::shape(N, N, batch_size));
+  test::gtensor2<T, 3, S> d_Ainv(gt::shape(N, N, batch_size));
 
   gt::gtensor<gt::blas::index_t, 2> h_p(gt::shape(N, batch_size));
   test::gtensor2<gt::blas::index_t, 2, S> d_p(gt::shape(N, batch_size));
@@ -431,40 +431,40 @@ void test_invert_batch_complex()
   h_Aptr[1] = h_Aptr(0) + N * N;
   set_A1_piv(h_p.view(gt::all, 1));
 
-  h_Bptr(0) = gt::raw_pointer_cast(d_B.data());
-  h_Bptr(1) = h_Bptr(0) + N * NRHS;
+  h_Ainvptr(0) = gt::raw_pointer_cast(d_Ainv.data());
+  h_Ainvptr(1) = h_Ainvptr(0) + N * NRHS;
 
   gt::copy(h_Aptr, d_Aptr);
   gt::copy(h_A, d_A);
-  gt::copy(h_Bptr, d_Bptr);
-  gt::copy(h_B, d_B);
-  gt::copy(h_B, d_B);
+  gt::copy(h_Ainvptr, d_Ainvptr);
+  gt::copy(h_Ainv, d_Ainv);
+  gt::copy(h_Ainv, d_Ainv);
   gt::copy(h_p, d_p);
 
   gt::blas::invert_banded_batched(
     N, gt::raw_pointer_cast(d_Aptr.data()), N, gt::raw_pointer_cast(d_p.data()),
-    gt::raw_pointer_cast(d_Bptr.data()), N, batch_size, N - 1, N - 1);
+    gt::raw_pointer_cast(d_Ainvptr.data()), N, batch_size, N - 1, N - 1);
 
-  gt::copy(d_B, h_B);
+  gt::copy(d_Ainv, h_Ainv);
 
   // first batch, inverse
   // A^-1 = [ 1.0  1.0 -1.0
   //         -2.0 -1.0  1.5
   //          2.0  0.5 -1.0]
   // first col
-  h_Ainv(0, 0) = 1.0;
-  h_Ainv(1, 0) = -2.0;
-  h_Ainv(2, 0) = 2.0;
+  h_Ainv_expected(0, 0) = 1.0;
+  h_Ainv_expected(1, 0) = -2.0;
+  h_Ainv_expected(2, 0) = 2.0;
   // second col
-  h_Ainv(0, 1) = 1.0;
-  h_Ainv(1, 1) = -1.0;
-  h_Ainv(2, 1) = 0.5;
+  h_Ainv_expected(0, 1) = 1.0;
+  h_Ainv_expected(1, 1) = -1.0;
+  h_Ainv_expected(2, 1) = 0.5;
   // third col
-  h_Ainv(0, 2) = -1.0;
-  h_Ainv(1, 2) = 1.5;
-  h_Ainv(2, 2) = -1.0;
+  h_Ainv_expected(0, 2) = -1.0;
+  h_Ainv_expected(1, 2) = 1.5;
+  h_Ainv_expected(2, 2) = -1.0;
 
-  GT_EXPECT_NEAR_ARRAY(h_B.view(gt::all, gt::all, 0), h_Ainv);
+  GT_EXPECT_NEAR_ARRAY(h_Ainv.view(gt::all, gt::all, 0), h_Ainv_expected);
 
   // second batch, inverse
   // A =    [ 1+i  2-i   2
@@ -474,19 +474,19 @@ void test_invert_batch_complex()
   //           0.04+0.28i  0.016-0.088i  0.028-0.096i
   //           0.52-0.36i -0.092+0.256i  0.036+0.052i]
   // first col
-  h_Ainv(0, 0) = T(-0.1, 0.3);
-  h_Ainv(1, 0) = T(0.04, 0.28);
-  h_Ainv(2, 0) = T(0.52, -0.36);
+  h_Ainv_expected(0, 0) = T(-0.1, 0.3);
+  h_Ainv_expected(1, 0) = T(0.04, 0.28);
+  h_Ainv_expected(2, 0) = T(0.52, -0.36);
   // second col
-  h_Ainv(0, 1) = T(-0.04, -0.28);
-  h_Ainv(1, 1) = T(0.016, -0.088);
-  h_Ainv(2, 1) = T(-0.092, 0.256);
+  h_Ainv_expected(0, 1) = T(-0.04, -0.28);
+  h_Ainv_expected(1, 1) = T(0.016, -0.088);
+  h_Ainv_expected(2, 1) = T(-0.092, 0.256);
   // third col
-  h_Ainv(0, 2) = T(0.07, -0.01);
-  h_Ainv(1, 2) = T(-0.028, -0.096);
-  h_Ainv(2, 2) = T(0.036, 0.052);
+  h_Ainv_expected(0, 2) = T(0.07, -0.01);
+  h_Ainv_expected(1, 2) = T(-0.028, -0.096);
+  h_Ainv_expected(2, 2) = T(0.036, 0.052);
 
-  GT_EXPECT_NEAR_ARRAY(h_B.view(gt::all, gt::all, 1), h_Ainv);
+  GT_EXPECT_NEAR_ARRAY(h_Ainv.view(gt::all, gt::all, 1), h_Ainv_expected);
 }
 
 TEST(bandsolve, cinvert_batch)
@@ -497,4 +497,133 @@ TEST(bandsolve, cinvert_batch)
 TEST(bandsolve, zinvert_batch)
 {
   test_invert_batch_complex<double>();
+}
+
+template <typename R, typename S = gt::space::device>
+void test_solve_inverted_batch_complex()
+{
+  constexpr int N = 3;
+  constexpr int NRHS = 2;
+  constexpr int batch_size = 2;
+  using T = gt::complex<R>;
+
+  gt::gtensor<T*, 1> h_Ainvptr(batch_size);
+  test::gtensor2<T*, 1, S> d_Ainvptr(batch_size);
+  gt::gtensor<T, 3> h_Ainv(gt::shape(N, N, batch_size));
+  test::gtensor2<T, 3, S> d_Ainv(gt::shape(N, N, batch_size));
+
+  gt::gtensor<T*, 1> h_Bptr(batch_size);
+  test::gtensor2<T*, 1, S> d_Bptr(batch_size);
+  gt::gtensor<T, 3> h_B(gt::shape(N, NRHS, batch_size));
+  test::gtensor2<T, 3, S> d_B(gt::shape(N, NRHS, batch_size));
+
+  gt::gtensor<T*, 1> h_Cptr(batch_size);
+  test::gtensor2<T*, 1, S> d_Cptr(batch_size);
+  gt::gtensor<T, 3> h_C(gt::shape(N, NRHS, batch_size));
+  test::gtensor2<T, 3, S> d_C(gt::shape(N, NRHS, batch_size));
+
+  // first batch, inverse
+  // A^-1 = [ 1.0  1.0 -1.0
+  //         -2.0 -1.0  1.5
+  //          2.0  0.5 -1.0]
+  // first col
+  h_Ainv(0, 0, 0) = 1.0;
+  h_Ainv(1, 0, 0) = -2.0;
+  h_Ainv(2, 0, 0) = 2.0;
+  // second col
+  h_Ainv(0, 1, 0) = 1.0;
+  h_Ainv(1, 1, 0) = -1.0;
+  h_Ainv(2, 1, 0) = 0.5;
+  // third col
+  h_Ainv(0, 2, 0) = -1.0;
+  h_Ainv(1, 2, 0) = 1.5;
+  h_Ainv(2, 2, 0) = -1.0;
+
+  // second batch, inverse
+  // A =    [ 1+i  2-i   2
+  //           4i  4     2
+  //          4     6i   4]
+  // A^-1 = [ -0.1 +0.3i  -0.04 -0.28i   0.07 -0.01i
+  //           0.04+0.28i  0.016-0.088i  0.028-0.096i
+  //           0.52-0.36i -0.092+0.256i  0.036+0.052i]
+  // first col
+  h_Ainv(0, 0, 1) = T(-0.1, 0.3);
+  h_Ainv(1, 0, 1) = T(0.04, 0.28);
+  h_Ainv(2, 0, 1) = T(0.52, -0.36);
+  // second col
+  h_Ainv(0, 1, 1) = T(-0.04, -0.28);
+  h_Ainv(1, 1, 1) = T(0.016, -0.088);
+  h_Ainv(2, 1, 1) = T(-0.092, 0.256);
+  // third col
+  h_Ainv(0, 2, 1) = T(0.07, -0.01);
+  h_Ainv(1, 2, 1) = T(-0.028, -0.096);
+  h_Ainv(2, 2, 1) = T(0.036, 0.052);
+
+  h_Ainvptr(0) = gt::raw_pointer_cast(d_Ainv.data());
+  h_Ainvptr(1) = h_Ainvptr(0) + N * N;
+
+  gt::copy(h_Ainvptr, d_Ainvptr);
+  gt::copy(h_Ainv, d_Ainv);
+
+  // first batch, first rhs col vector   (11; 18; 28)
+  h_B(0, 0, 0) = 11;
+  h_B(1, 0, 0) = 18;
+  h_B(2, 0, 0) = 28;
+  // first batch, second rhs col vector  (73; 78; 154)
+  h_B(0, 1, 0) = 73;
+  h_B(1, 1, 0) = 78;
+  h_B(2, 1, 0) = 154;
+  // second batch, first rhs col vector  (73; 78; 154)
+  h_B(0, 0, 1) = T(11, -1);
+  h_B(1, 0, 1) = T(14, 4);
+  h_B(2, 0, 1) = T(16, 12);
+  // second batch, second rhs col vector (73-10i; 90-12i; 112 + 42i)
+  h_B(0, 1, 1) = T(73, -10);
+  h_B(1, 1, 1) = T(90, -12);
+  h_B(2, 1, 1) = T(112, 42);
+
+  h_Bptr(0) = gt::raw_pointer_cast(d_B.data());
+  h_Bptr(1) = h_Bptr(0) + N * NRHS;
+
+  gt::copy(h_Bptr, d_Bptr);
+  gt::copy(h_B, d_B);
+
+  h_Cptr(0) = gt::raw_pointer_cast(d_C.data());
+  h_Cptr(1) = h_Cptr(0) + N * NRHS;
+
+  gt::copy(h_Cptr, d_Cptr);
+
+  gt::blas::solve_inverted_batched(
+    N, NRHS, gt::raw_pointer_cast(d_Ainvptr.data()), N,
+    gt::raw_pointer_cast(d_Bptr.data()), N, gt::raw_pointer_cast(d_Cptr.data()),
+    N, batch_size);
+
+  gt::copy(d_C, h_C);
+
+  // first batch, first solution vector [1; 2; 3]
+  expect_complex_near(h_C(0, 0, 0), 1.0);
+  expect_complex_near(h_C(1, 0, 0), 2.0);
+  expect_complex_near(h_C(2, 0, 0), 3.0);
+  // first batch, second solution vector [-3; 7; 31]
+  expect_complex_near(h_C(0, 1, 0), -3.0);
+  expect_complex_near(h_C(1, 1, 0), 7.0);
+  expect_complex_near(h_C(2, 1, 0), 31.0);
+  // second batch, first solution vector [1; 2; 3]
+  expect_complex_near(h_C(0, 0, 1), 1.0);
+  expect_complex_near(h_C(1, 0, 1), 2.0);
+  expect_complex_near(h_C(2, 0, 1), 3.0);
+  // second batch, second solution vector [-3; 7; 31]
+  expect_complex_near(h_C(0, 1, 1), -3.0);
+  expect_complex_near(h_C(1, 1, 1), 7.0);
+  expect_complex_near(h_C(2, 1, 1), 31.0);
+}
+
+TEST(bandsolve, csolve_inverted_batch)
+{
+  test_solve_inverted_batch_complex<float>();
+}
+
+TEST(bandsolve, zsolve_inverted_batch)
+{
+  test_solve_inverted_batch_complex<double>();
 }

--- a/tests/test_complex.cxx
+++ b/tests/test_complex.cxx
@@ -103,7 +103,7 @@ TEST(complex, exp)
 {
   using namespace std::complex_literals;
   using T = gt::complex<double>;
-  T x = 1.i * M_PI / 2.;
+  T x = T(0.0, M_PI / 2.0);
 
   EXPECT_LT(gt::abs(gt::exp(x) - T(0., 1.)), 1e-14);
 }


### PR DESCRIPTION
Add routines for efficient batched linear solve using inverted matrices. Includes bandsolver routine for inverting a batch of LU factored matrices, and gpu gemm_batched wrappers around native CUDA/HIP/SYCL APIs. Note that the bandsolver routines will also work on non-banded routines - it will just behave like a normal dense solve, but not as efficient since it is serial per batch and rhs. The idea is to have alternatives to native getrs_batched routines, which have not been optimized yet on all GPU platforms for the sizes typically used by GENE.