### PR TITLE
Pr/test gene 6d

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ option(GTENSOR_ENABLE_FFT  "Enable gtfft" OFF)
 option(GTENSOR_PER_DIM_KERNELS
        "Enable per dim kernels (may break for large arrays)" OFF)
 
+option(GTENSOR_ALLOCATOR_CACHING "Enable naive caching allocators" ON)
+
 # HIP specific configuration
 set(HIP_GCC_TOOLCHAIN "" CACHE STRING "pass gcc-toolchain option to hipcc")
 set(ROCM_PATH "/opt/rocm" CACHE STRING "path to ROCm installation")
@@ -266,6 +268,14 @@ if (GTENSOR_PER_DIM_KERNELS)
                              INTERFACE GTENSOR_PER_DIM_KERNELS)
 else()
   message(STATUS "${PROJECT_NAME}: using N-d -> 1d assign/launch kernels")
+endif()
+
+if (GTENSOR_ALLOCATOR_CACHING)
+  message(STATUS "${PROJECT_NAME}: caching allocator enabled")
+else()
+  target_compile_definitions(gtensor_${GTENSOR_DEVICE}
+                             INTERFACE GTENSOR_ALLOCATOR_NO_CACHING)
+  message(STATUS "${PROJECT_NAME}: caching allocator disabled")
 endif()
 
 # define aliases for use in tests and examples subdirs

--- a/include/gtensor/assign.h
+++ b/include/gtensor/assign.h
@@ -460,7 +460,7 @@ struct assigner<3, space::device>
   }
 };
 
-#else // not defined GTENSOR_PER_DIM_KERNELS
+#endif // GTENSOR_PER_DIM_KERNELS
 
 template <size_type N>
 struct assigner<N, space::device>
@@ -505,8 +505,6 @@ struct assigner<N, space::device>
     gpuSyncIfEnabledStream(stream);
   }
 };
-
-#endif // GTENSOR_PER_DIM_KERNELS
 
 #endif // GTENSOR_DEVICE_SYCL
 

--- a/include/gtensor/assign.h
+++ b/include/gtensor/assign.h
@@ -517,13 +517,10 @@ void assign(E1& lhs, const E2& rhs, gt::stream_view stream = gt::stream_view())
 {
   static_assert(expr_dimension<E1>() == expr_dimension<E2>(),
                 "cannot assign expressions of different dimension");
-  // FIXME, need to check for brodcasting
-#if 0
   if (lhs.shape() != rhs.shape()) {
-    std::cout << "not the same shape! " << lhs.shape() << rhs.shape() << "\n";
+    throw std::runtime_error("cannot assign lhs = " + to_string(lhs.shape()) +
+                             " rhs = " + to_string(rhs.shape()) + "\n");
   }
-  assert(lhs.shape() == rhs.shape());
-#endif
   detail::assigner<
     expr_dimension<E1>(),
     space_t<expr_space_type<E1>, expr_space_type<E2>>>::run(lhs, rhs, stream);

--- a/include/gtensor/assign.h
+++ b/include/gtensor/assign.h
@@ -171,18 +171,14 @@ __global__ void kernel_assign_3(Elhs lhs, Erhs rhs)
 template <typename Elhs, typename Erhs>
 __global__ void kernel_assign_4(Elhs lhs, Erhs rhs)
 {
-  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int i = threadIdx.x + blockIdx.x * BS_X;
+  int j = threadIdx.y + blockIdx.y * BS_Y;
+  int b = blockIdx.z;
+  int l = b / lhs.shape(2);
+  b -= l * lhs.shape(2);
+  int k = b;
 
-  if (idx < lhs.size()) {
-    int rem = idx;
-    int i = rem % lhs.shape(0);
-    rem /= lhs.shape(0);
-    int j = rem % lhs.shape(1);
-    rem /= lhs.shape(1);
-    int k = rem % lhs.shape(2);
-    rem /= lhs.shape(2);
-    int l = rem;
-
+  if (i < lhs.shape(0) && j < lhs.shape(1)) {
     lhs(i, j, k, l) = rhs(i, j, k, l);
   }
 }
@@ -286,8 +282,10 @@ struct assigner<4, space::device>
   static void run(E1& lhs, const E2& rhs, stream_view stream)
   {
     // printf("assigner<4, device>\n");
-    dim3 numThreads(256);
-    dim3 numBlocks((lhs.size() + numThreads.x - 1) / numThreads.x);
+    dim3 numThreads(BS_X, BS_Y);
+    dim3 numBlocks((lhs.shape(0) + BS_X - 1) / BS_X,
+                   (lhs.shape(1) + BS_Y - 1) / BS_Y,
+                   lhs.shape(2) * lhs.shape(3));
 
     gpuSyncIfEnabledStream(stream);
     // std::cout << "rhs " << typeid(rhs.to_kernel()).name() << "\n";

--- a/include/gtensor/gfunction.h
+++ b/include/gtensor/gfunction.h
@@ -2,6 +2,8 @@
 #ifndef GTENSOR_GFUNCTION_H
 #define GTENSOR_GFUNCTION_H
 
+#include <cassert>
+
 #include "defs.h"
 #include "expression.h"
 #include "gscalar.h"
@@ -110,7 +112,8 @@ GT_INLINE void broadcast_shape(S& to, const S2& from)
     } else if (from[end_from - i] == 1) {
       // broadcasting, from, nothing to do
     } else {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) ||               \
+  defined(__SYCL_DEVICE_ONLY__)
       assert(false);
 #else
       throw std::runtime_error("cannot broadcast to = " + to_string(to) +
@@ -210,7 +213,11 @@ public:
 
   using shape_type = gt::shape_type<dimension()>;
 
-  gfunction(F&& f, E&& e) : f_(std::forward<F>(f)), e_(std::forward<E>(e)) {}
+  gfunction(F&& f, E&& e) : f_(std::forward<F>(f)), e_(std::forward<E>(e))
+  {
+    // force shape check on host
+    shape();
+  }
 
   GT_INLINE shape_type shape() const;
   GT_INLINE int shape(int i) const;
@@ -251,7 +258,10 @@ public:
     : f_(std::forward<F>(f)),
       e1_(std::forward<E1>(e1)),
       e2_(std::forward<E2>(e2))
-  {}
+  {
+    // force shape check on host
+    shape();
+  }
 
   GT_INLINE shape_type shape() const;
   GT_INLINE int shape(int i) const;

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -215,6 +215,8 @@ void copy(const gtensor_span<T, N, S_from>& from, gtensor_span<T, N, S_to>& to)
 
 #if defined(GTENSOR_DEVICE_CUDA) || defined(GTENSOR_DEVICE_HIP)
 
+#ifdef GTENSOR_PER_DIM_KERNELS
+
 template <typename F>
 __global__ void kernel_launch(gt::shape_type<1> shape, F f)
 {
@@ -298,6 +300,8 @@ __global__ void kernel_launch(gt::shape_type<6> shape, F f)
   }
 }
 
+#else // not GTENSOR_PER_DIM_KERNELS
+
 template <typename F, size_type N>
 __global__ void kernel_launch_N(F f, int size, gt::shape_type<N> strides)
 {
@@ -308,6 +312,8 @@ __global__ void kernel_launch_N(F f, int size, gt::shape_type<N> strides)
     index_expression(f, idx);
   }
 }
+
+#endif // GTENSOR_PER_DIM_KERNELS
 
 #endif // CUDA or HIP
 
@@ -519,7 +525,7 @@ struct launch<6, space::device>
   }
 };
 
-#endif
+#else // not GTENSOR_PER_DIM_KERNELS
 
 template <int N>
 struct launch<N, space::device>
@@ -541,6 +547,8 @@ struct launch<N, space::device>
     gpuSyncIfEnabledStream(stream);
   }
 };
+
+#endif // GTENSOR_PER_DIM_KERNELS
 
 #elif defined(GTENSOR_DEVICE_SYCL)
 

--- a/include/gtensor/space.h
+++ b/include/gtensor/space.h
@@ -21,13 +21,21 @@
 #endif
 
 #ifndef GTENSOR_DEFAULT_DEVICE_ALLOCATOR
+#ifdef GTENSOR_ALLOCATOR_NO_CACHING
+#define GTENSOR_DEFAULT_DEVICE_ALLOCATOR(T) gt::device_allocator<T>
+#else
 #define GTENSOR_DEFAULT_DEVICE_ALLOCATOR(T)                                    \
   gt::allocator::caching_allocator<T, gt::device_allocator<T>>
+#endif // GTENSOR_ALLOCATOR_NO_CACHING
 #endif
 
 #ifndef GTENSOR_DEFAULT_MANAGED_ALLOCATOR
+#ifdef GTENSOR_ALLOCATOR_NO_CACHING
+#define GTENSOR_DEFAULT_MANAGED_ALLOCATOR(T) gt::managed_allocator<T>
+#else
 #define GTENSOR_DEFAULT_MANAGED_ALLOCATOR(T)                                   \
   gt::allocator::caching_allocator<T, gt::managed_allocator<T>>
+#endif // GTENSOR_ALLOCATOR_NO_CACHING
 #endif
 
 namespace gt

--- a/tests/test_assign.cxx
+++ b/tests/test_assign.cxx
@@ -166,17 +166,17 @@ TEST(assign, device_view_noncontiguous_6d)
 {
   using T = gt::complex<double>;
 
-  int nzb = 1;
+  int nzb = 2;
   int nvb = 2;
-  int nwb = 3;
-
-  // ijklmn, ghost in z, v, w
-  auto f_shape = gt::shape(5, 7, 9, 11, 13, 2);
+  int nwb = 2;
 
   // ijklmn, no ghost
-  auto g_shape =
-    gt::shape(f_shape[0], f_shape[1], f_shape[2] - 2 * nzb,
-              f_shape[3] - 2 * nvb, f_shape[4] - 2 * nwb, f_shape[5]);
+  auto g_shape = gt::shape(32, 4, 48, 40, 30, 2);
+
+  // ijklmn, ghost in z, v, w
+  auto f_shape =
+    gt::shape(g_shape[0], g_shape[1], g_shape[2] + 2 * nzb,
+              g_shape[3] + 2 * nvb, g_shape[4] + 2 * nwb, g_shape[5]);
   // i klmn, no ghost
   auto papbar_shape =
     gt::shape(g_shape[0], g_shape[2], g_shape[3], g_shape[4], g_shape[5]);


### PR DESCRIPTION
Add tests for non-contiguous view assignment, and attempt to improve error handling on dimension mismatch. This is to aid in debugging the 0x2b errors on crusher.