### PR TITLE
fix assign broadcast

### DIFF
--- a/include/gtensor/assign.h
+++ b/include/gtensor/assign.h
@@ -508,6 +508,18 @@ struct assigner<N, space::device>
 
 #endif // GTENSOR_DEVICE_SYCL
 
+template <typename S>
+inline void valid_assign_broadcast_or_throw(const S& lhs_shape,
+                                            const S& rhs_shape)
+{
+  for (int i = 0; i < lhs_shape.size(); i++) {
+    if (lhs_shape[i] != rhs_shape[i] && rhs_shape[i] != 1) {
+      throw std::runtime_error("cannot assign lhs = " + to_string(lhs_shape) +
+                               " rhs = " + to_string(rhs_shape) + "\n");
+    }
+  }
+}
+
 } // namespace detail
 
 template <typename E1, typename E2>
@@ -515,10 +527,7 @@ void assign(E1& lhs, const E2& rhs, gt::stream_view stream = gt::stream_view())
 {
   static_assert(expr_dimension<E1>() == expr_dimension<E2>(),
                 "cannot assign expressions of different dimension");
-  if (lhs.shape() != rhs.shape()) {
-    throw std::runtime_error("cannot assign lhs = " + to_string(lhs.shape()) +
-                             " rhs = " + to_string(rhs.shape()) + "\n");
-  }
+  detail::valid_assign_broadcast_or_throw(lhs.shape(), rhs.shape());
   detail::assigner<
     expr_dimension<E1>(),
     space_t<expr_space_type<E1>, expr_space_type<E2>>>::run(lhs, rhs, stream);

--- a/tests/test_assign.cxx
+++ b/tests/test_assign.cxx
@@ -65,6 +65,22 @@ TEST(assign, span_fill)
             (gt::gtensor<float, 2>{{9001, 9001}, {9001, 9001}, {9001, 9001}}));
 }
 
+TEST(assign, broadcast_6d)
+{
+  gt::gtensor<int, 6> a(gt::shape(8, 1, 2, 4, 1, 1), 0);
+  gt::gtensor<int, 6> b(gt::shape(8, 1, 2, 1, 1, 1), -7);
+
+  gt::assign(a, b);
+
+  for (int i = 0; i < a.shape(0); i++) {
+    for (int j = 0; j < a.shape(2); j++) {
+      for (int k = 0; k < a.shape(3); k++) {
+        EXPECT_EQ(a(i, 0, j, k, 0, 0), -7);
+      }
+    }
+  }
+}
+
 #ifdef GTENSOR_HAVE_DEVICE
 
 TEST(assign, device_gtensor_6d)
@@ -365,6 +381,26 @@ TEST(assign, device_gene_h_from_f)
 
   // spot check
   EXPECT_EQ(hdist, expected);
+}
+
+TEST(assign, device_broadcast_6d)
+{
+  gt::gtensor_device<int, 6> a(gt::shape(8, 1, 2, 4, 1, 1), 0);
+  gt::gtensor_device<int, 6> b(gt::shape(8, 1, 2, 1, 1, 1), -7);
+
+  gt::gtensor<int, 6> h_a(a.shape());
+
+  gt::assign(a, b);
+
+  gt::copy(a, h_a);
+
+  for (int i = 0; i < h_a.shape(0); i++) {
+    for (int j = 0; j < h_a.shape(2); j++) {
+      for (int k = 0; k < h_a.shape(3); k++) {
+        EXPECT_EQ(h_a(i, 0, j, k, 0, 0), -7);
+      }
+    }
+  }
 }
 
 #endif // GTENSOR_HAVE_DEVICE


### PR DESCRIPTION
Assign check is too strict, can broadcast if RHS has 1 in any
dimension. See calc_index in strides.h.