### PR TITLE
storage: fix memory leak on move assignment

### DIFF
--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -74,6 +74,9 @@ public:
 
   gtensor_storage& operator=(gtensor_storage&& dv)
   {
+    if (capacity_ > 0) {
+      allocator_.deallocate(data_, capacity_);
+    }
     data_ = dv.data_;
     size_ = dv.size_;
     capacity_ = dv.capacity_;


### PR DESCRIPTION
For non thrust backend, anything that does a move assignment of an owning gtensor object will result in move assignment of the underlying gtensor_storage, which was not correctly deallocating the existing destination data and resulting in memory leaks.