### PR TITLE
Pr/blas getri

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -11,6 +11,10 @@ if (GTENSOR_ENABLE_BLAS)
   add_executable(bench_getrf)
   target_gtensor_sources(bench_getrf PRIVATE bench_getrf.cxx)
   target_link_libraries(bench_getrf gtensor::gtensor gtensor::blas benchmark::benchmark)
+
+  add_executable(bench_getri)
+  target_gtensor_sources(bench_getri PRIVATE bench_getri.cxx)
+  target_link_libraries(bench_getri gtensor::gtensor gtensor::blas benchmark::benchmark)
 endif()
 
 add_executable(bench_assign)

--- a/benchmarks/bench_getrf.cxx
+++ b/benchmarks/bench_getrf.cxx
@@ -12,21 +12,13 @@
 
 using namespace gt::placeholders;
 
-//#define BENCH_GETRF_DEBUG
+// #define BENCH_GETRF_DEBUG
 
 template <typename Matrix>
 void debug_print_matrix(const char* name, Matrix&& M)
 {
 #ifdef BENCH_GETRF_DEBUG
-  int n = M.shape(0);
-  std::cerr << name << "\n";
-  for (int j = 0; j < n; j++) {
-    for (int i = 0; i < n; i++) {
-      std::cerr << M(i, j) << " ";
-    }
-    std::cerr << "\n";
-  }
-  std::cerr << std::endl;
+  std::cerr << name << "\n" << M << std::endl;
 #endif
 }
 
@@ -34,12 +26,7 @@ template <typename Vector>
 void debug_print_vector(const char* name, Vector&& V)
 {
 #ifdef BENCH_GETRF_DEBUG
-  int n = V.shape(0);
-  std::cerr << name << "\n";
-  for (int i = 0; i < n; i++) {
-    std::cerr << V(i) << " ";
-  }
-  std::cerr << std::endl;
+  std::cerr << name << "\n" << V << std::endl;
 #endif
 }
 

--- a/benchmarks/bench_getrf.cxx
+++ b/benchmarks/bench_getrf.cxx
@@ -203,7 +203,7 @@ static void BM_getrf(benchmark::State& state)
   gt::copy(h_Aptr, d_Aptr);
   gt::synchronize();
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   auto fn = [&]() {
     if (PIVOT) {
@@ -235,8 +235,6 @@ static void BM_getrf(benchmark::State& state)
   for (auto _ : state) {
     fn();
   }
-
-  gt::blas::destroy(h);
 }
 
 // RealType, N, NBATCH, Pivot

--- a/benchmarks/bench_getri.cxx
+++ b/benchmarks/bench_getri.cxx
@@ -119,7 +119,7 @@ static void BM_getri(benchmark::State& state)
   gt::copy(h_AAinvptr, d_AAinvptr);
   gt::synchronize();
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   gt::blas::getrf_batched(h, N, gt::raw_pointer_cast(d_Aptr.data()), N,
                           gt::raw_pointer_cast(d_piv.data()),
@@ -155,8 +155,6 @@ static void BM_getri(benchmark::State& state)
   for (auto _ : state) {
     fn();
   }
-
-  gt::blas::destroy(h);
 }
 
 // RealType, N, NBATC

--- a/benchmarks/bench_getri.cxx
+++ b/benchmarks/bench_getri.cxx
@@ -12,36 +12,7 @@
 
 using namespace gt::placeholders;
 
-//#define BENCH_GETRI_DEBUG
-
-template <typename Matrix>
-void debug_print_matrix(const char* name, Matrix&& M)
-{
-#ifdef BENCH_GETRI_DEBUG
-  int n = M.shape(0);
-  std::cerr << name << "\n";
-  for (int j = 0; j < n; j++) {
-    for (int i = 0; i < n; i++) {
-      std::cerr << M(i, j) << " ";
-    }
-    std::cerr << "\n";
-  }
-  std::cerr << std::endl;
-#endif
-}
-
-template <typename Vector>
-void debug_print_vector(const char* name, Vector&& V)
-{
-#ifdef BENCH_GETRI_DEBUG
-  int n = V.shape(0);
-  std::cerr << name << "\n";
-  for (int i = 0; i < n; i++) {
-    std::cerr << V(i) << " ";
-  }
-  std::cerr << std::endl;
-#endif
-}
+// #define BENCH_GETRI_DEBUG
 
 template <typename CT>
 auto make_test_matrix(int n, int bw, int batch_size, bool needs_pivot)
@@ -177,7 +148,7 @@ static void BM_getri(benchmark::State& state)
   check_close_identity_batch<R>(h_AAinv);
 
   for (int b = 0; b < NBATCH; b++) {
-    debug_print_matrix("A*Ainv", h_AAinv.view(_all, _all, b));
+    std::cout << b << " A*Ainv\n" << h_AAinv.view(_all, _all, b) << std::endl;
   }
 #endif
 

--- a/benchmarks/bench_getri.cxx
+++ b/benchmarks/bench_getri.cxx
@@ -1,0 +1,210 @@
+#include <iostream>
+#include <numeric>
+#include <string>
+
+#include <benchmark/benchmark.h>
+
+#include <gtensor/gtensor.h>
+
+#include <gt-blas/blas.h>
+
+#include "gt-bm.h"
+
+using namespace gt::placeholders;
+
+//#define BENCH_GETRI_DEBUG
+
+template <typename Matrix>
+void debug_print_matrix(const char* name, Matrix&& M)
+{
+#ifdef BENCH_GETRI_DEBUG
+  int n = M.shape(0);
+  std::cerr << name << "\n";
+  for (int j = 0; j < n; j++) {
+    for (int i = 0; i < n; i++) {
+      std::cerr << M(i, j) << " ";
+    }
+    std::cerr << "\n";
+  }
+  std::cerr << std::endl;
+#endif
+}
+
+template <typename Vector>
+void debug_print_vector(const char* name, Vector&& V)
+{
+#ifdef BENCH_GETRI_DEBUG
+  int n = V.shape(0);
+  std::cerr << name << "\n";
+  for (int i = 0; i < n; i++) {
+    std::cerr << V(i) << " ";
+  }
+  std::cerr << std::endl;
+#endif
+}
+
+template <typename CT>
+auto make_test_matrix(int n, int bw, int batch_size, bool needs_pivot)
+{
+  auto h_Adata = gt::zeros<CT>({n, n, batch_size});
+  for (int b = 0; b < batch_size; b++) {
+    for (int i = 0; i < n; i++) {
+      h_Adata(i, i, b) = CT(bw + 1.0, 0.0);
+      // set upper / lower diags at bw diagonal
+      for (int d = 1; d <= bw; d++) {
+        if (i + d < n) {
+          h_Adata(i, i + d, b) = CT(-1.0, 0.0);
+          h_Adata(i + d, i, b) = CT(0.0, -1.0);
+        }
+      }
+    }
+    if (needs_pivot) {
+      h_Adata(0, 0, b) = CT(n / 64.0, 0);
+    }
+  }
+  return h_Adata;
+}
+
+template <typename T, typename CT = gt::complex<T>>
+bool check_close_identity_batch(gt::gtensor<CT, 3>& h_A)
+{
+  int n = h_A.shape(0);
+  int nbatch = h_A.shape(2);
+  constexpr T tol = 100.0 * std::numeric_limits<T>::epsilon();
+
+  // should be identity matrix in every batch
+  T max_err = T(0);
+  T err;
+  for (int b = 0; b < nbatch; b++) {
+    for (int j = 0; j < n; j++) {
+      for (int i = 0; i < n; i++) {
+        if (i == j) {
+          err = gt::norm(h_A(i, j, b) - CT(1.0));
+        } else {
+          err = gt::norm(h_A(i, j, b));
+        }
+        if (err > max_err) {
+          max_err = err;
+        }
+      }
+    }
+  }
+
+  if (max_err > tol) {
+    std::cerr << "ERR: max absolute error " << max_err << " > " << tol
+              << std::endl;
+    return false;
+  }
+  return true;
+}
+
+// ======================================================================
+// BM_getri
+//
+
+template <typename R, int N, int NBATCH>
+static void BM_getri(benchmark::State& state)
+{
+  using CT = gt::complex<R>;
+
+  auto h_A = make_test_matrix<CT>(N, N - 1, NBATCH, true);
+  auto h_Acopy = gt::empty_like(h_A);
+  gt::gtensor_device<CT, 3> d_A(h_A.shape());
+  gt::gtensor_device<CT, 3> d_Acopy(h_A.shape());
+
+  gt::gtensor<CT, 3> h_AAinv(h_A.shape());
+  gt::gtensor_device<CT, 3> d_AAinv(h_A.shape());
+
+  auto h_C = gt::empty_like(h_A);
+  gt::gtensor_device<CT, 3> d_C(h_A.shape());
+
+  gt::gtensor<CT*, 1> h_Aptr(NBATCH);
+  gt::gtensor_device<CT*, 1> d_Aptr(NBATCH);
+
+  gt::gtensor<CT*, 1> h_Cptr(NBATCH);
+  gt::gtensor_device<CT*, 1> d_Cptr(NBATCH);
+
+  gt::gtensor<CT*, 1> h_AAinvptr(NBATCH);
+  gt::gtensor_device<CT*, 1> d_AAinvptr(NBATCH);
+
+  gt::gtensor<gt::blas::index_t, 2> h_piv(gt::shape(N, NBATCH));
+  gt::gtensor_device<gt::blas::index_t, 2> d_piv(gt::shape(N, NBATCH));
+  gt::gtensor_device<int, 1> d_info(NBATCH);
+
+  h_Aptr(0) = gt::raw_pointer_cast(d_A.data());
+  h_Cptr(0) = gt::raw_pointer_cast(d_C.data());
+  h_AAinvptr(0) = gt::raw_pointer_cast(d_AAinv.data());
+  for (int b = 1; b < NBATCH; b++) {
+    h_Aptr(b) = h_Aptr(0) + (N * N * b);
+    h_Cptr(b) = h_Cptr(0) + (N * N * b);
+    h_AAinvptr(b) = h_AAinvptr(0) + (N * N * b);
+  }
+
+  h_Acopy = h_A;
+  gt::copy(h_A, d_A);
+  gt::copy(d_A, d_Acopy);
+  gt::copy(h_Aptr, d_Aptr);
+  gt::copy(h_Cptr, d_Cptr);
+  gt::copy(h_AAinvptr, d_AAinvptr);
+  gt::synchronize();
+
+  gt::blas::handle_t* h = gt::blas::create();
+
+  gt::blas::getrf_batched(h, N, gt::raw_pointer_cast(d_Aptr.data()), N,
+                          gt::raw_pointer_cast(d_piv.data()),
+                          gt::raw_pointer_cast(d_info.data()), NBATCH);
+
+  auto fn = [&]() {
+    gt::blas::getri_batched(h, N, gt::raw_pointer_cast(d_Aptr.data()), N,
+                            gt::raw_pointer_cast(d_piv.data()),
+                            gt::raw_pointer_cast(d_Cptr.data()), N,
+                            gt::raw_pointer_cast(d_info.data()), NBATCH);
+    gt::synchronize();
+  };
+
+  // warm up, device compile, check
+  fn();
+
+#ifdef BENCH_GETRI_DEBUG
+  gt::copy(d_A, h_A);     // now contains Alu
+  gt::copy(h_Acopy, d_A); // copy original A back to d_A
+  CT a = CT(1.0);
+  CT b = CT(0.0);
+  gt::blas::gemm_batched(h, N, N, N, a, gt::raw_pointer_cast(d_Aptr.data()), N,
+                         gt::raw_pointer_cast(d_Cptr.data()), N, b,
+                         gt::raw_pointer_cast(d_AAinvptr.data()), N, NBATCH);
+  gt::copy(d_AAinv, h_AAinv);
+  check_close_identity_batch<R>(h_AAinv);
+
+  for (int b = 0; b < NBATCH; b++) {
+    debug_print_matrix("A*Ainv", h_AAinv.view(_all, _all, b));
+  }
+#endif
+
+  for (auto _ : state) {
+    fn();
+  }
+
+  gt::blas::destroy(h);
+}
+
+// RealType, N, NBATC
+BENCHMARK(BM_getri<float, 512, 64>)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_getri<double, 512, 64>)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_getri<float, 512, 64>)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_getri<double, 512, 64>)->Unit(benchmark::kMillisecond);
+
+BENCHMARK(BM_getri<float, 210, 256>)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_getri<double, 210, 256>)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_getri<float, 210, 256>)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_getri<double, 210, 256>)->Unit(benchmark::kMillisecond);
+
+// small cases for debugging
+/*
+BENCHMARK(BM_getri<double, 5, 2>)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_getri<double, 5, 2>)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_getri<float, 5, 2>)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_getri<float, 5, 2>)->Unit(benchmark::kMillisecond);
+*/
+
+BENCHMARK_MAIN();

--- a/benchmarks/bench_getri.cxx
+++ b/benchmarks/bench_getri.cxx
@@ -191,19 +191,13 @@ static void BM_getri(benchmark::State& state)
 // RealType, N, NBATC
 BENCHMARK(BM_getri<float, 512, 64>)->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_getri<double, 512, 64>)->Unit(benchmark::kMillisecond);
-BENCHMARK(BM_getri<float, 512, 64>)->Unit(benchmark::kMillisecond);
-BENCHMARK(BM_getri<double, 512, 64>)->Unit(benchmark::kMillisecond);
 
-BENCHMARK(BM_getri<float, 210, 256>)->Unit(benchmark::kMillisecond);
-BENCHMARK(BM_getri<double, 210, 256>)->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_getri<float, 210, 256>)->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_getri<double, 210, 256>)->Unit(benchmark::kMillisecond);
 
 // small cases for debugging
 /*
 BENCHMARK(BM_getri<double, 5, 2>)->Unit(benchmark::kMillisecond);
-BENCHMARK(BM_getri<double, 5, 2>)->Unit(benchmark::kMillisecond);
-BENCHMARK(BM_getri<float, 5, 2>)->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_getri<float, 5, 2>)->Unit(benchmark::kMillisecond);
 */
 

--- a/benchmarks/getrs.cxx
+++ b/benchmarks/getrs.cxx
@@ -225,8 +225,8 @@ void test(test_problem<CT> tp, int known_bw = 0)
 
   gt::blas::handle_t* h = gt::blas::create();
 
-  auto bw2 = gt::blas::get_max_bandwidth(n, gt::raw_pointer_cast(d_Aptr.data()),
-                                         lda, batch_size);
+  auto bw2 = gt::blas::get_max_bandwidth(
+    h, n, gt::raw_pointer_cast(d_Aptr.data()), lda, batch_size);
   if (known_bw > 0) {
     if (bw2.lower != known_bw || bw2.upper != known_bw) {
       std::cerr << "ERR: construct matrix bandwidth mismatch, expected "
@@ -239,8 +239,8 @@ void test(test_problem<CT> tp, int known_bw = 0)
   ss << bw2.lower << "_" << bw2.upper;
   bw_str = ss.str();
 
-  gt::blas::invert_banded_batched(n, gt::raw_pointer_cast(d_Aptr.data()), lda,
-                                  gt::raw_pointer_cast(d_piv.data()),
+  gt::blas::invert_banded_batched(h, n, gt::raw_pointer_cast(d_Aptr.data()),
+                                  lda, gt::raw_pointer_cast(d_piv.data()),
                                   gt::raw_pointer_cast(d_Ainvptr.data()), lda,
                                   batch_size, bw2.lower, bw2.upper);
 
@@ -251,10 +251,10 @@ void test(test_problem<CT> tp, int known_bw = 0)
                             batch_size);
   };
   auto const test_banded = [&]() {
-    gt::blas::getrs_banded_batched(n, nrhs, gt::raw_pointer_cast(d_Aptr.data()),
-                                   lda, gt::raw_pointer_cast(d_piv.data()),
-                                   gt::raw_pointer_cast(d_Bptr.data()), ldb,
-                                   batch_size, bw2.lower, bw2.upper);
+    gt::blas::getrs_banded_batched(
+      h, n, nrhs, gt::raw_pointer_cast(d_Aptr.data()), lda,
+      gt::raw_pointer_cast(d_piv.data()), gt::raw_pointer_cast(d_Bptr.data()),
+      ldb, batch_size, bw2.lower, bw2.upper);
   };
   auto const test_inverted = [&]() {
     gt::blas::gemm_batched<CT>(

--- a/benchmarks/getrs.cxx
+++ b/benchmarks/getrs.cxx
@@ -223,7 +223,7 @@ void test(test_problem<CT> tp, int known_bw = 0)
 
   std::cout << "INFO: memcpy to device done" << std::endl;
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   auto bw2 = gt::blas::get_max_bandwidth(
     h, n, gt::raw_pointer_cast(d_Aptr.data()), lda, batch_size);
@@ -279,10 +279,6 @@ void test(test_problem<CT> tp, int known_bw = 0)
   check_and_measure(test_blas, "blas");
   check_and_measure(test_banded, "banded");
   check_and_measure(test_inverted, "inverted");
-
-  gt::blas::destroy(h);
-
-  std::cout << "INFO: destroy done" << std::endl;
 }
 
 int main(int argc, char** argv)

--- a/benchmarks/gt-bm.h
+++ b/benchmarks/gt-bm.h
@@ -13,11 +13,15 @@ struct gthelper
   using gtensor = gt::gtensor<T, N, S>;
 };
 
+#ifdef GTENSOR_HAVE_DEVICE
+
 template <typename T, gt::size_type N>
 struct gthelper<T, N, gt::space::managed>
 {
   using gtensor = gt::gtensor_container<gt::space::managed_vector<T>, N>;
 };
+
+#endif
 
 template <typename T, gt::size_type N, typename S = gt::space::device>
 using gtensor2 = typename gthelper<T, N, S>::gtensor;

--- a/examples/src/snippets.cxx
+++ b/examples/src/snippets.cxx
@@ -59,7 +59,7 @@ void launch()
 
 void blas()
 {
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
   gt::gtensor_device<double, 1> x = gt::arange<double>(1, 11);
   gt::gtensor_device<double, 1> y = gt::arange<double>(1, 11);
   gt::blas::axpy(h, 2.0, x, y);

--- a/include/gt-blas/backend/cuda.h
+++ b/include/gt-blas/backend/cuda.h
@@ -299,7 +299,7 @@ CREATE_GETRS_BATCHED(cublasSgetrsBatched, float, float)
 #undef CREATE_GETRS_BATCHED
 
 // ======================================================================
-// getrf/getrs batched
+// getrf_npvt batched
 
 template <typename T>
 inline void getrf_npvt_batched(handle_t* h, int n, T** d_Aarray, int lda,

--- a/include/gt-blas/backend/cuda.h
+++ b/include/gt-blas/backend/cuda.h
@@ -324,6 +324,34 @@ CREATE_GETRF_NPVT_BATCHED(cublasCgetrfBatched, gt::complex<float>, cuComplex)
 #undef CREATE_GETRF_NPVT_BATCHED
 
 // ======================================================================
+// getri batched
+
+template <typename T>
+inline void getri_batched(handle_t* h, int n, T* const* d_Aarray, int lda,
+                          gt::blas::index_t* devIpiv, T** d_Carray, int ldc,
+                          int* d_infoArray, int batchSize);
+
+#define CREATE_GETRI_BATCHED(METHOD, GTTYPE, BLASTYPE)                         \
+  template <>                                                                  \
+  inline void getri_batched<GTTYPE>(                                           \
+    handle_t * h, int n, GTTYPE* const* d_Aarray, int lda,                     \
+    gt::blas::index_t* devIpiv, GTTYPE** d_Carray, int ldc, int* d_infoArray,  \
+    int batchSize)                                                             \
+  {                                                                            \
+    gtBlasCheck(METHOD(h->handle, n,                                           \
+                       reinterpret_cast<BLASTYPE* const*>(d_Aarray), lda,      \
+                       devIpiv, reinterpret_cast<BLASTYPE**>(d_Carray), ldc,   \
+                       d_infoArray, batchSize));                               \
+  }
+
+CREATE_GETRI_BATCHED(cublasZgetriBatched, gt::complex<double>, cuDoubleComplex)
+CREATE_GETRI_BATCHED(cublasCgetriBatched, gt::complex<float>, cuComplex)
+CREATE_GETRI_BATCHED(cublasDgetriBatched, double, double)
+CREATE_GETRI_BATCHED(cublasSgetriBatched, float, float)
+
+#undef CREATE_GETRI_BATCHED
+
+// ======================================================================
 // gemm batched
 
 template <typename T>

--- a/include/gt-blas/backend/cuda.h
+++ b/include/gt-blas/backend/cuda.h
@@ -54,14 +54,16 @@ inline void destroy(handle_t* h)
   delete h;
 }
 
-inline void set_stream(handle_t* h, stream_t stream_id)
+inline void set_stream(handle_t* h, gt::stream_view sview)
 {
-  gtBlasCheck(cublasSetStream(h->handle, stream_id));
+  gtBlasCheck(cublasSetStream(h->handle, sview.get_backend_stream()));
 }
 
-inline void get_stream(handle_t* h, stream_t* stream_id)
+inline gt::stream_view get_stream(handle_t* h)
 {
-  gtBlasCheck(cublasGetStream(h->handle, stream_id));
+  stream_t s;
+  gtBlasCheck(cublasGetStream(h->handle, &s));
+  return gt::stream_view{s};
 }
 
 // ======================================================================

--- a/include/gt-blas/backend/hip.h
+++ b/include/gt-blas/backend/hip.h
@@ -54,14 +54,16 @@ inline void destroy(handle_t* h)
   delete h;
 }
 
-inline void set_stream(handle_t* h, stream_t stream_id)
+inline void set_stream(handle_t* h, gt::stream_view sview)
 {
-  gtBlasCheck(rocblas_set_stream(h->handle, stream_id));
+  gtBlasCheck(rocblas_set_stream(h->handle, sview.get_backend_stream()));
 }
 
-inline void get_stream(handle_t* h, stream_t* stream_id)
+inline gt::stream_view get_stream(handle_t* h)
 {
-  gtBlasCheck(rocblas_get_stream(h->handle, stream_id));
+  stream_t s;
+  gtBlasCheck(rocblas_get_stream(h->handle, &s));
+  return gt::stream_view{s};
 }
 
 // ======================================================================

--- a/include/gt-blas/backend/hip.h
+++ b/include/gt-blas/backend/hip.h
@@ -325,6 +325,36 @@ CREATE_GETRF_NPVT_BATCHED(rocsolver_cgetrf_npvt_batched, gt::complex<float>,
 #undef CREATE_GETRF_NPVT_BATCHED
 
 // ======================================================================
+// getri batched
+
+template <typename T>
+inline void getri_batched(handle_t* h, int n, T* const* d_Aarray, int lda,
+                          gt::blas::index_t* devIpiv, T** d_Carray, int ldc,
+                          int* d_infoArray, int batchSize);
+
+#define CREATE_GETRI_BATCHED(METHOD, GTTYPE, BLASTYPE)                         \
+  template <>                                                                  \
+  inline void getri_batched<GTTYPE>(                                           \
+    handle_t * h, int n, GTTYPE* const* d_Aarray, int lda,                     \
+    gt::blas::index_t* devIpiv, GTTYPE** d_Carray, int ldc, int* d_infoArray,  \
+    int batchSize)                                                             \
+  {                                                                            \
+    gtBlasCheck(                                                               \
+      METHOD(h->handle, n, reinterpret_cast<BLASTYPE* const*>(d_Aarray), lda,  \
+             devIpiv, n, reinterpret_cast<BLASTYPE**>(d_Carray), ldc,          \
+             reinterpret_cast<rocblas_int*>(d_infoArray), batchSize));         \
+  }
+
+CREATE_GETRI_BATCHED(rocsolver_zgetri_outofplace_batched, gt::complex<double>,
+                     rocblas_double_complex)
+CREATE_GETRI_BATCHED(rocsolver_cgetri_outofplace_batched, gt::complex<float>,
+                     rocblas_float_complex)
+CREATE_GETRI_BATCHED(rocsolver_dgetri_outofplace_batched, double, double)
+CREATE_GETRI_BATCHED(rocsolver_sgetri_outofplace_batched, float, float)
+
+#undef CREATE_GETRI_BATCHED
+
+// ======================================================================
 // gemm batched
 
 template <typename T>

--- a/include/gt-blas/backend/sycl.h
+++ b/include/gt-blas/backend/sycl.h
@@ -10,11 +10,6 @@ namespace gt
 namespace blas
 {
 
-struct handle_t
-{
-  cl::sycl::queue handle;
-};
-
 // ======================================================================
 // types aliases
 
@@ -24,37 +19,29 @@ using index_t = std::int64_t;
 // ======================================================================
 // handle and stream management
 
-inline handle_t* create()
+class handle_sycl : public detail::handle_base<handle_sycl, cl::sycl::queue>
 {
-  handle_t* h = new handle_t();
-  h->handle = gt::backend::sycl::get_queue();
-  return h;
-}
+public:
+  handle_sycl() { handle_ = gt::backend::sycl::get_queue(); }
 
-inline void destroy(handle_t* h)
-{
-  delete h;
-}
+  void set_stream(gt::stream_view sview)
+  {
+    handle_ = sview.get_backend_stream();
+  }
 
-inline void set_stream(handle_t* h, gt::stream_view sview)
-{
-  // Note: SYCL queue objects have reference semantics, so
-  // a copy will behave the same as the original
-  h->handle = sview.get_backend_stream();
-}
+  gt::stream_view get_stream() { return gt::stream_view{handle_}; }
+};
 
-inline gt::stream_view get_stream(handle_t* h)
-{
-  return gt::stream_view(h->handle);
-}
+using handle_t = handle_sycl;
 
 // ======================================================================
 // axpy
 
 template <typename T>
-inline void axpy(handle_t* h, int n, T a, const T* x, int incx, T* y, int incy)
+inline void axpy(handle_t& h, int n, T a, const T* x, int incx, T* y, int incy)
 {
-  auto e = oneapi::mkl::blas::axpy(h->handle, n, a, x, incx, y, incy);
+  auto e =
+    oneapi::mkl::blas::axpy(h.get_backend_handle(), n, a, x, incx, y, incy);
   e.wait();
 }
 
@@ -62,9 +49,9 @@ inline void axpy(handle_t* h, int n, T a, const T* x, int incx, T* y, int incy)
 // scal
 
 template <typename S, typename T>
-inline void scal(handle_t* h, int n, S a, T* x, const int incx)
+inline void scal(handle_t& h, int n, S a, T* x, const int incx)
 {
-  auto e = oneapi::mkl::blas::scal(h->handle, n, a, x, incx);
+  auto e = oneapi::mkl::blas::scal(h.get_backend_handle(), n, a, x, incx);
   e.wait();
 }
 
@@ -72,9 +59,9 @@ inline void scal(handle_t* h, int n, S a, T* x, const int incx)
 // copy
 
 template <typename T>
-inline void copy(handle_t* h, int n, const T* x, int incx, T* y, int incy)
+inline void copy(handle_t& h, int n, const T* x, int incx, T* y, int incy)
 {
-  auto e = oneapi::mkl::blas::copy(h->handle, n, x, incx, y, incy);
+  auto e = oneapi::mkl::blas::copy(h.get_backend_handle(), n, x, incx, y, incy);
   e.wait();
 }
 
@@ -82,9 +69,9 @@ inline void copy(handle_t* h, int n, const T* x, int incx, T* y, int incy)
 // dot, dotc (conjugate)
 
 template <typename T>
-inline T dot(handle_t* h, int n, const T* x, int incx, const T* y, int incy)
+inline T dot(handle_t& h, int n, const T* x, int incx, const T* y, int incy)
 {
-  sycl::queue& q = h->handle;
+  sycl::queue& q = h.get_backend_handle();
 
   gt::space::device_vector<T> d_rp(1);
   T result;
@@ -97,10 +84,10 @@ inline T dot(handle_t* h, int n, const T* x, int incx, const T* y, int incy)
 }
 
 template <typename R>
-inline gt::complex<R> dotu(handle_t* h, int n, const gt::complex<R>* x,
+inline gt::complex<R> dotu(handle_t& h, int n, const gt::complex<R>* x,
                            int incx, const gt::complex<R>* y, int incy)
 {
-  sycl::queue& q = h->handle;
+  sycl::queue& q = h.get_backend_handle();
   using T = gt::complex<R>;
 
   gt::space::device_vector<T> d_rp(1);
@@ -114,10 +101,10 @@ inline gt::complex<R> dotu(handle_t* h, int n, const gt::complex<R>* x,
 }
 
 template <typename R>
-inline gt::complex<R> dotc(handle_t* h, int n, const gt::complex<R>* x,
+inline gt::complex<R> dotc(handle_t& h, int n, const gt::complex<R>* x,
                            int incx, const gt::complex<R>* y, int incy)
 {
-  sycl::queue& q = h->handle;
+  sycl::queue& q = h.get_backend_handle();
   using T = gt::complex<R>;
 
   gt::space::device_vector<T> d_rp(1);
@@ -134,11 +121,12 @@ inline gt::complex<R> dotc(handle_t* h, int n, const gt::complex<R>* x,
 // gemv
 
 template <typename T>
-inline void gemv(handle_t* h, int m, int n, T alpha, const T* A, int lda,
+inline void gemv(handle_t& h, int m, int n, T alpha, const T* A, int lda,
                  const T* x, int incx, T beta, T* y, int incy)
 {
-  auto e = oneapi::mkl::blas::gemv(h->handle, oneapi::mkl::transpose::nontrans,
-                                   m, n, alpha, A, lda, x, incx, beta, y, incy);
+  auto e = oneapi::mkl::blas::gemv(h.get_backend_handle(),
+                                   oneapi::mkl::transpose::nontrans, m, n,
+                                   alpha, A, lda, x, incx, beta, y, incy);
   e.wait();
 }
 
@@ -146,11 +134,11 @@ inline void gemv(handle_t* h, int m, int n, T alpha, const T* A, int lda,
 // getrf/getrs batched
 
 template <typename T>
-inline void getrf_batched(handle_t* h, int n, T** d_Aarray, int lda,
+inline void getrf_batched(handle_t& h, int n, T** d_Aarray, int lda,
                           gt::blas::index_t* d_PivotArray, int* d_infoArray,
                           int batchSize)
 {
-  sycl::queue& q = h->handle;
+  sycl::queue& q = h.get_backend_handle();
 
   index_t n64 = n;
   index_t lda64 = lda;
@@ -180,10 +168,10 @@ inline void getrf_batched(handle_t* h, int n, T** d_Aarray, int lda,
 }
 
 template <typename T>
-inline void getrf_npvt_batched(handle_t* h, int n, T** d_Aarray, int lda,
+inline void getrf_npvt_batched(handle_t& h, int n, T** d_Aarray, int lda,
                                int* d_infoArray, int batchSize)
 {
-  sycl::queue& q = h->handle;
+  sycl::queue& q = h.get_backend_handle();
 
   // TODO: This uses the strides batch API, which only works when batch
   // data is contiguous. Replace when group batch API is available in oneMKL
@@ -212,11 +200,11 @@ inline void getrf_npvt_batched(handle_t* h, int n, T** d_Aarray, int lda,
 }
 
 template <typename T>
-inline void getrs_batched(handle_t* h, int n, int nrhs, T** d_Aarray, int lda,
+inline void getrs_batched(handle_t& h, int n, int nrhs, T** d_Aarray, int lda,
                           gt::blas::index_t* d_PivotArray, T** d_Barray,
                           int ldb, int batchSize)
 {
-  sycl::queue& q = h->handle;
+  sycl::queue& q = h.get_backend_handle();
 
   index_t n64 = n;
   index_t nrhs64 = nrhs;
@@ -244,11 +232,11 @@ inline void getrs_batched(handle_t* h, int n, int nrhs, T** d_Aarray, int lda,
 }
 
 template <typename T>
-inline void getri_batched(handle_t* h, int n, T** d_Aarray, int lda,
+inline void getri_batched(handle_t& h, int n, T** d_Aarray, int lda,
                           gt::blas::index_t* d_PivotArray, T** d_Carray,
                           int ldc, int* d_infoArray, int batchSize)
 {
-  sycl::queue& q = h->handle;
+  sycl::queue& q = h.get_backend_handle();
 
   index_t n64 = n;
   index_t lda64 = lda;
@@ -289,11 +277,11 @@ inline void getri_batched(handle_t* h, int n, T** d_Aarray, int lda,
 }
 
 template <typename T>
-inline void gemm_batched(handle_t* h, int m, int n, int k, T alpha,
+inline void gemm_batched(handle_t& h, int m, int n, int k, T alpha,
                          T** d_Aarray, int lda, T** d_Barray, int ldb, T beta,
                          T* d_Carray[], int ldc, int batchSize)
 {
-  sycl::queue& q = h->handle;
+  sycl::queue& q = h.get_backend_handle();
 
   index_t m64 = m;
   index_t n64 = n;

--- a/include/gt-blas/bandsolver.h
+++ b/include/gt-blas/bandsolver.h
@@ -29,7 +29,7 @@ struct matrix_bandwidth
  * @return matrix_bandwidth struct containing max upper and lower bandwidth
  */
 template <typename T>
-inline matrix_bandwidth get_max_bandwidth(handle_t* h, int n, T** d_Aarray,
+inline matrix_bandwidth get_max_bandwidth(handle_t& h, int n, T** d_Aarray,
                                           int lda, int batch_size)
 {
   matrix_bandwidth res;
@@ -41,7 +41,7 @@ inline matrix_bandwidth get_max_bandwidth(handle_t* h, int n, T** d_Aarray,
   auto k_batch_lbw = d_batch_lbw.to_kernel();
   auto k_batch_ubw = d_batch_ubw.to_kernel();
 
-  auto stream = gt::blas::get_stream(h);
+  auto stream = h.get_stream();
 
   gt::launch<1>(
     launch_shape,
@@ -117,11 +117,11 @@ inline matrix_bandwidth get_max_bandwidth(handle_t* h, int n, T** d_Aarray,
  * @param ubw max upper bandwidth of all [A_i]
  */
 template <typename T>
-inline void getrs_banded_batched(handle_t* h, int n, int nrhs, T** d_Aarray,
+inline void getrs_banded_batched(handle_t& h, int n, int nrhs, T** d_Aarray,
                                  int lda, index_t* d_PivotArray, T** d_Barray,
                                  int ldb, int batchSize, int lbw, int ubw)
 {
-  auto stream = gt::blas::get_stream(h);
+  auto stream = h.get_stream();
   auto launch_shape = gt::shape(nrhs, batchSize);
   gt::launch<2>(
     launch_shape,
@@ -190,12 +190,12 @@ inline void getrs_banded_batched(handle_t* h, int n, int nrhs, T** d_Aarray,
  * @param ubw max upper bandwidth of all [A_i]
  */
 template <typename T>
-inline void invert_banded_batched(handle_t* h, int n, T** d_Aarray, int lda,
+inline void invert_banded_batched(handle_t& h, int n, T** d_Aarray, int lda,
                                   index_t* d_PivotArray, T** d_Barray, int ldb,
                                   int batchSize, int lbw, int ubw)
 {
   int nrhs = n;
-  auto stream = gt::blas::get_stream(h);
+  auto stream = h.get_stream();
   auto launch_shape = gt::shape(nrhs, batchSize);
   gt::launch<2>(
     launch_shape,
@@ -274,12 +274,12 @@ inline void invert_banded_batched(handle_t* h, int n, T** d_Aarray, int lda,
  * @param batchSize number of matrices [A^-1_i], [B_i], [C_i] in batch
  */
 template <typename T>
-inline void solve_inverted_batched(handle_t* h, int n, int nrhs, T** d_Aarray,
+inline void solve_inverted_batched(handle_t& h, int n, int nrhs, T** d_Aarray,
                                    int lda, T** d_Barray, int ldb, T** d_Carray,
                                    int ldc, int batchSize)
 {
   auto launch_shape = gt::shape(nrhs, batchSize);
-  auto stream = gt::blas::get_stream(h);
+  auto stream = h.get_stream();
   gt::launch<2>(
     launch_shape,
     GT_LAMBDA(int rhs, int batch) {

--- a/include/gt-blas/bandsolver.h
+++ b/include/gt-blas/bandsolver.h
@@ -4,6 +4,8 @@
 #include "gtensor/complex.h"
 #include "gtensor/reductions.h"
 
+#include "gt-blas/blas.h"
+
 namespace gt
 {
 
@@ -19,6 +21,7 @@ struct matrix_bandwidth
 /**
  * Calculate max bandwidth in a batch of square matrices.
  *
+ * @param h gt::blas::handle_t object
  * @param n size of each A_i
  * @param d_Aarray Array of device pointers to input [A_i]
  * @param lda leading distance of each A_i, >=n
@@ -26,8 +29,8 @@ struct matrix_bandwidth
  * @return matrix_bandwidth struct containing max upper and lower bandwidth
  */
 template <typename T>
-inline matrix_bandwidth get_max_bandwidth(int n, T** d_Aarray, int lda,
-                                          int batch_size)
+inline matrix_bandwidth get_max_bandwidth(handle_t* h, int n, T** d_Aarray,
+                                          int lda, int batch_size)
 {
   matrix_bandwidth res;
 
@@ -37,8 +40,12 @@ inline matrix_bandwidth get_max_bandwidth(int n, T** d_Aarray, int lda,
   auto launch_shape = gt::shape(batch_size);
   auto k_batch_lbw = d_batch_lbw.to_kernel();
   auto k_batch_ubw = d_batch_ubw.to_kernel();
+
+  auto stream = gt::blas::get_stream(h);
+
   gt::launch<1>(
-    launch_shape, GT_LAMBDA(int batch) {
+    launch_shape,
+    GT_LAMBDA(int batch) {
       int lbw = n - 1;
       int ubw = n - 1;
       int i, j;
@@ -82,10 +89,11 @@ inline matrix_bandwidth get_max_bandwidth(int n, T** d_Aarray, int lda,
 
       k_batch_lbw(batch) = lbw;
       k_batch_ubw(batch) = ubw;
-    });
+    },
+    stream);
 
-  res.lower = gt::max(d_batch_lbw);
-  res.upper = gt::max(d_batch_ubw);
+  res.lower = gt::max(d_batch_lbw, stream);
+  res.upper = gt::max(d_batch_ubw, stream);
 
   return res;
 }
@@ -96,6 +104,7 @@ inline matrix_bandwidth get_max_bandwidth(int n, T** d_Aarray, int lda,
  * @see gt::blas::getrf_batched()
  * @see gt::blas::get_max_bandwidth()
  *
+ * @param h gt::blas::handle_t object
  * @param n size of each A_i and number of rows of each B_i
  * @param nrhs number of RHS column vectors in each B_i
  * @param d_Aarray Array of device pointers to LU factored input [A_i]
@@ -108,13 +117,15 @@ inline matrix_bandwidth get_max_bandwidth(int n, T** d_Aarray, int lda,
  * @param ubw max upper bandwidth of all [A_i]
  */
 template <typename T>
-inline void getrs_banded_batched(int n, int nrhs, T** d_Aarray, int lda,
-                                 index_t* d_PivotArray, T** d_Barray, int ldb,
-                                 int batchSize, int lbw, int ubw)
+inline void getrs_banded_batched(handle_t* h, int n, int nrhs, T** d_Aarray,
+                                 int lda, index_t* d_PivotArray, T** d_Barray,
+                                 int ldb, int batchSize, int lbw, int ubw)
 {
+  auto stream = gt::blas::get_stream(h);
   auto launch_shape = gt::shape(nrhs, batchSize);
   gt::launch<2>(
-    launch_shape, GT_LAMBDA(int rhs, int batch) {
+    launch_shape,
+    GT_LAMBDA(int rhs, int batch) {
       T* A = d_Aarray[batch];
       T* B = d_Barray[batch] + ldb * rhs;
       index_t* piv = d_PivotArray + batch * n;
@@ -157,7 +168,8 @@ inline void getrs_banded_batched(int n, int nrhs, T** d_Aarray, int lda,
         }
         B[i] = tmp / A[i * lda + i];
       }
-    });
+    },
+    stream);
 }
 
 /**
@@ -166,6 +178,7 @@ inline void getrs_banded_batched(int n, int nrhs, T** d_Aarray, int lda,
  * @see gt::blas::getrf_batched()
  * @see gt::blas::get_max_bandwidth()
  *
+ * @param h gt::blas::handle_t object
  * @param n size of each A_i and B_i matrix in batch
  * @param d_Aarray Array of device pointers to each input A_i
  * @param lda leading distance of each A_i, >=n
@@ -177,14 +190,16 @@ inline void getrs_banded_batched(int n, int nrhs, T** d_Aarray, int lda,
  * @param ubw max upper bandwidth of all [A_i]
  */
 template <typename T>
-inline void invert_banded_batched(int n, T** d_Aarray, int lda,
+inline void invert_banded_batched(handle_t* h, int n, T** d_Aarray, int lda,
                                   index_t* d_PivotArray, T** d_Barray, int ldb,
                                   int batchSize, int lbw, int ubw)
 {
   int nrhs = n;
+  auto stream = gt::blas::get_stream(h);
   auto launch_shape = gt::shape(nrhs, batchSize);
   gt::launch<2>(
-    launch_shape, GT_LAMBDA(int rhs, int batch) {
+    launch_shape,
+    GT_LAMBDA(int rhs, int batch) {
       T* A = d_Aarray[batch];
       T* B = d_Barray[batch] + ldb * rhs;
       index_t* piv = d_PivotArray + batch * n;
@@ -232,11 +247,14 @@ inline void invert_banded_batched(int n, T** d_Aarray, int lda,
         }
         B[i] = tmp / A[i * lda + i];
       }
-    });
+    },
+    stream);
 }
 
 /**
  * Naive batched matrix multiply for solving with inverted matrices C = A^-1 * B
+ *
+ * DEPRECATED
  *
  * All matrices must be col-major
  *
@@ -244,6 +262,7 @@ inline void invert_banded_batched(int n, T** d_Aarray, int lda,
  * @see gt::blas::getrf_batched()
  * @see gt::blas::invert_banded_batched()
  *
+ * @param h gt::blas::handle_t object
  * @param n size of each A^-1_i and rows of each B_i and C_i
  * @param nrhs number of RHS column vectors in each B_i and C_i
  * @param d_Aarray Array of device pointers to each inverted input A_i
@@ -255,13 +274,15 @@ inline void invert_banded_batched(int n, T** d_Aarray, int lda,
  * @param batchSize number of matrices [A^-1_i], [B_i], [C_i] in batch
  */
 template <typename T>
-inline void solve_inverted_batched(int n, int nrhs, T** d_Aarray, int lda,
-                                   T** d_Barray, int ldb, T** d_Carray, int ldc,
-                                   int batchSize)
+inline void solve_inverted_batched(handle_t* h, int n, int nrhs, T** d_Aarray,
+                                   int lda, T** d_Barray, int ldb, T** d_Carray,
+                                   int ldc, int batchSize)
 {
   auto launch_shape = gt::shape(nrhs, batchSize);
+  auto stream = gt::blas::get_stream(h);
   gt::launch<2>(
-    launch_shape, GT_LAMBDA(int rhs, int batch) {
+    launch_shape,
+    GT_LAMBDA(int rhs, int batch) {
       T* A = d_Aarray[batch];
       T* b = d_Barray[batch] + ldb * rhs;
       T* c = d_Carray[batch] + ldc * rhs;
@@ -277,7 +298,8 @@ inline void solve_inverted_batched(int n, int nrhs, T** d_Aarray, int lda,
         }
         c[i] = tmp;
       }
-    });
+    },
+    stream);
 }
 
 } // namespace blas

--- a/include/gt-blas/cblas.h
+++ b/include/gt-blas/cblas.h
@@ -166,6 +166,21 @@ void gtblas_zinvert_banded_batched(int n, f2c_complex<double>** d_Aarray,
                                    f2c_complex<double>** d_Barray, int ldb,
                                    int batchSize, int lbw, int ubw);
 
+void gtblas_sgetri_batched(int n, float** d_Aarray, int lda,
+                           gt::blas::index_t* devIpiv, float** d_Carray,
+                           int ldc, int* d_infoArray, int batchSize);
+void gtblas_dgetri_batched(int n, double** d_Aarray, int lda,
+                           gt::blas::index_t* devIpiv, double** d_Carray,
+                           int ldc, int* d_infoArray, int batchSize);
+void gtblas_cgetri_batched(int n, f2c_complex<float>** d_Aarray, int lda,
+                           gt::blas::index_t* devIpiv,
+                           f2c_complex<float>** d_Carray, int ldc,
+                           int* d_infoArray, int batchSize);
+void gtblas_zgetri_batched(int n, f2c_complex<double>** d_Aarray, int lda,
+                           gt::blas::index_t* devIpiv,
+                           f2c_complex<double>** d_Carray, int ldc,
+                           int* d_infoArray, int batchSize);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -7,6 +7,9 @@
 
 #include <cuda_runtime_api.h>
 
+//#include "thrust/cuda/system/execution_policy.h"
+#include "thrust/execution_policy.h"
+
 // ======================================================================
 // gt::backend::cuda
 
@@ -211,6 +214,8 @@ public:
 
   auto get_backend_stream() { return stream_; }
 
+  auto get_execution_policy() { return thrust::cuda::par.on(stream_); }
+
   bool is_default() { return stream_ == nullptr; }
 
   void synchronize() { gtGpuCheck(cudaStreamSynchronize(stream_)); }
@@ -231,6 +236,8 @@ public:
   }
 
   auto get_backend_stream() { return stream_; }
+
+  auto get_execution_policy() { return thrust::cuda::par.on(stream_); }
 
   bool is_default() { return stream_ == nullptr; }
 

--- a/include/gtensor/backend_hip.h
+++ b/include/gtensor/backend_hip.h
@@ -6,6 +6,8 @@
 
 #include <hip/hip_runtime.h>
 
+#include <thrust/system/hip/execution_policy.h>
+
 // ======================================================================
 // gt::backend::hip
 
@@ -209,6 +211,8 @@ public:
 
   auto get_backend_stream() { return stream_; }
 
+  auto get_execution_policy() { return thrust::hip::par.on(stream_); }
+
   bool is_default() { return stream_ == nullptr; }
 
   void synchronize() { gtGpuCheck(hipStreamSynchronize(stream_)); }
@@ -229,6 +233,8 @@ public:
   }
 
   auto get_backend_stream() { return stream_; }
+
+  auto get_execution_policy() { return thrust::hip::par.on(stream_); }
 
   bool is_default() { return stream_ == nullptr; }
 

--- a/include/gtensor/reductions.h
+++ b/include/gtensor/reductions.h
@@ -320,7 +320,7 @@ template <typename Container,
             has_data_method_v<Container> &&
             std::is_same<typename Container::space_type, space::host>::value>,
           typename = int>
-inline auto sum(const Container& a)
+inline auto sum(const Container& a, gt::stream_view stream = gt::stream_view{})
 {
   using T = typename Container::value_type;
   auto data = a.data();
@@ -357,7 +357,7 @@ template <typename Container,
             has_data_method_v<Container> &&
             std::is_same<typename Container::space_type, space::host>::value>,
           typename = int>
-inline auto min(const Container& a)
+inline auto min(const Container& a, gt::stream_view stream = gt::stream_view{})
 {
   using T = typename Container::value_type;
   auto data = a.data();
@@ -377,7 +377,8 @@ template <typename Container, typename OutputType, typename BinaryReductionOp,
             std::is_same<typename Container::space_type, space::host>::value>,
           typename = int>
 inline OutputType reduce(const Container& a, OutputType init,
-                         BinaryReductionOp reduction_op)
+                         BinaryReductionOp reduction_op,
+                         gt::stream_view stream = gt::stream_view{})
 {
   using P = const typename Container::value_type*;
   P begin(a.data());
@@ -393,7 +394,8 @@ template <typename Container, typename OutputType, typename BinaryReductionOp,
           typename = int>
 inline OutputType transform_reduce(const Container& a, OutputType init,
                                    BinaryReductionOp reduction_op,
-                                   UnaryTransformOp transform_op)
+                                   UnaryTransformOp transform_op,
+                                   gt::stream_view stream = gt::stream_view{})
 {
   using P = const typename Container::value_type*;
   P begin(a.data());
@@ -501,14 +503,14 @@ struct UnaryOpNorm<Tin, Tout,
  * pointers.
  */
 template <typename E>
-auto sum_squares(const E& e)
+auto sum_squares(const E& e, gt::stream_view stream = gt::stream_view{})
 {
   // FIXME, the gt::eval is a workaround for gt::transform_reduce only handling
   // containers
   using ValueType = expr_value_type<E>;
   using Real = gt::complex_subtype_t<ValueType>;
   return gt::transform_reduce(gt::eval(e), 0.0, std::plus<>{},
-                              detail::UnaryOpNorm<ValueType, Real>{});
+                              detail::UnaryOpNorm<ValueType, Real>{}, stream);
 }
 
 } // namespace gt

--- a/src/cgtblas.cxx
+++ b/src/cgtblas.cxx
@@ -351,3 +351,22 @@ CREATE_C_INVERT_BANDED_BATCHED(gtblas_zinvert_banded_batched,
                                f2c_complex<double>)
 
 #undef CREATE_C_INVERT_BANDED_BATCHED
+
+// ======================================================================
+// gtblas_Xgetri_batched
+#define CREATE_C_GETRI_BATCHED(CNAME, CPPTYPE)                                 \
+  void CNAME(int n, CPPTYPE** d_Aarray, int lda,                               \
+             gt::blas::index_t* d_PivotArray, CPPTYPE** d_Carray, int ldc,     \
+             int* d_infoArray, int batchSize)                                  \
+  {                                                                            \
+    gt::blas::getri_batched(g_handle, n, detail::cast_aligned(d_Aarray), lda,  \
+                            d_PivotArray, detail::cast_aligned(d_Carray), ldc, \
+                            d_infoArray, batchSize);                           \
+  }
+
+CREATE_C_GETRI_BATCHED(gtblas_sgetri_batched, float)
+CREATE_C_GETRI_BATCHED(gtblas_dgetri_batched, double)
+CREATE_C_GETRI_BATCHED(gtblas_cgetri_batched, f2c_complex<float>)
+CREATE_C_GETRI_BATCHED(gtblas_zgetri_batched, f2c_complex<double>)
+
+#undef CREATE_C_GETRI_BATCHED

--- a/tests/test_bandsolver.cxx
+++ b/tests/test_bandsolver.cxx
@@ -189,14 +189,12 @@ void test_getrs_batch_real()
   gt::copy(h_B, d_B);
   gt::copy(h_p, d_p);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   gt::blas::getrs_banded_batched(
     h, N, NRHS, gt::raw_pointer_cast(d_Aptr.data()), N,
     gt::raw_pointer_cast(d_p.data()), gt::raw_pointer_cast(d_Bptr.data()), N,
     batch_size, N - 1, N - 1);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_B, h_B);
 
@@ -298,14 +296,12 @@ void test_getrs_batch_complex()
   gt::copy(h_B, d_B);
   gt::copy(h_p, d_p);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   gt::blas::getrs_banded_batched(
     h, N, NRHS, gt::raw_pointer_cast(d_Aptr.data()), N,
     gt::raw_pointer_cast(d_p.data()), gt::raw_pointer_cast(d_Bptr.data()), N,
     batch_size, N - 1, N - 1);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_B, h_B);
 
@@ -372,7 +368,7 @@ void test_get_max_bandwidth()
   gt::copy(h_A, d_A);
   gt::copy(h_Aptr, d_Aptr);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   auto bw0 = gt::blas::get_max_bandwidth(
     h, N, gt::raw_pointer_cast(d_Aptr.data()), N, 1);
@@ -388,8 +384,6 @@ void test_get_max_bandwidth()
     h, N, gt::raw_pointer_cast(d_Aptr.data()), N, batch_size);
   EXPECT_EQ(bw.lower, N - 3);
   EXPECT_EQ(bw.upper, 1);
-
-  gt::blas::destroy(h);
 }
 
 TEST(bandsolve, sget_max_bandwidth)
@@ -454,14 +448,12 @@ void test_invert_batch_complex()
   gt::copy(h_Ainv, d_Ainv);
   gt::copy(h_p, d_p);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   gt::blas::invert_banded_batched(h, N, gt::raw_pointer_cast(d_Aptr.data()), N,
                                   gt::raw_pointer_cast(d_p.data()),
                                   gt::raw_pointer_cast(d_Ainvptr.data()), N,
                                   batch_size, N - 1, N - 1);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_Ainv, h_Ainv);
 
@@ -611,14 +603,12 @@ void test_solve_inverted_batch_complex()
 
   gt::copy(h_Cptr, d_Cptr);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   gt::blas::solve_inverted_batched(
     h, N, NRHS, gt::raw_pointer_cast(d_Ainvptr.data()), N,
     gt::raw_pointer_cast(d_Bptr.data()), N, gt::raw_pointer_cast(d_Cptr.data()),
     N, batch_size);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_C, h_C);
 
@@ -759,10 +749,10 @@ void test_full_solve_real(gt::stream_view stream = gt::stream_view{})
   gt::copy(h_Bptr, d_Bptr);
   gt::copy(h_Cptr, d_Cptr);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   if (!stream.is_default()) {
-    gt::blas::set_stream(h, stream);
+    h.set_stream(stream);
   }
 
   gt::blas::getrf_batched(h, N, gt::raw_pointer_cast(d_Aptr.data()), N,
@@ -797,8 +787,6 @@ void test_full_solve_real(gt::stream_view stream = gt::stream_view{})
                             gt::raw_pointer_cast(d_Bptr.data()), N, 0.0,
                             gt::raw_pointer_cast(d_Cptr.data()), N, batch_size);
   gt::synchronize();
-
-  gt::blas::destroy(h);
 
   gt::copy(d_C, h_C);
 

--- a/tests/test_bandsolver.cxx
+++ b/tests/test_bandsolver.cxx
@@ -189,10 +189,14 @@ void test_getrs_batch_real()
   gt::copy(h_B, d_B);
   gt::copy(h_p, d_p);
 
-  gt::blas::getrs_banded_batched(N, NRHS, gt::raw_pointer_cast(d_Aptr.data()),
-                                 N, gt::raw_pointer_cast(d_p.data()),
-                                 gt::raw_pointer_cast(d_Bptr.data()), N,
-                                 batch_size, N - 1, N - 1);
+  gt::blas::handle_t* h = gt::blas::create();
+
+  gt::blas::getrs_banded_batched(
+    h, N, NRHS, gt::raw_pointer_cast(d_Aptr.data()), N,
+    gt::raw_pointer_cast(d_p.data()), gt::raw_pointer_cast(d_Bptr.data()), N,
+    batch_size, N - 1, N - 1);
+
+  gt::blas::destroy(h);
 
   gt::copy(d_B, h_B);
 
@@ -294,10 +298,14 @@ void test_getrs_batch_complex()
   gt::copy(h_B, d_B);
   gt::copy(h_p, d_p);
 
-  gt::blas::getrs_banded_batched(N, NRHS, gt::raw_pointer_cast(d_Aptr.data()),
-                                 N, gt::raw_pointer_cast(d_p.data()),
-                                 gt::raw_pointer_cast(d_Bptr.data()), N,
-                                 batch_size, N - 1, N - 1);
+  gt::blas::handle_t* h = gt::blas::create();
+
+  gt::blas::getrs_banded_batched(
+    h, N, NRHS, gt::raw_pointer_cast(d_Aptr.data()), N,
+    gt::raw_pointer_cast(d_p.data()), gt::raw_pointer_cast(d_Bptr.data()), N,
+    batch_size, N - 1, N - 1);
+
+  gt::blas::destroy(h);
 
   gt::copy(d_B, h_B);
 
@@ -364,20 +372,24 @@ void test_get_max_bandwidth()
   gt::copy(h_A, d_A);
   gt::copy(h_Aptr, d_Aptr);
 
-  auto bw0 =
-    gt::blas::get_max_bandwidth(N, gt::raw_pointer_cast(d_Aptr.data()), N, 1);
+  gt::blas::handle_t* h = gt::blas::create();
+
+  auto bw0 = gt::blas::get_max_bandwidth(
+    h, N, gt::raw_pointer_cast(d_Aptr.data()), N, 1);
   EXPECT_EQ(bw0.lower, 0);
   EXPECT_EQ(bw0.upper, 0);
 
   auto bw1 = gt::blas::get_max_bandwidth(
-    N, gt::raw_pointer_cast(d_Aptr.data()) + 1, N, 1);
+    h, N, gt::raw_pointer_cast(d_Aptr.data()) + 1, N, 1);
   EXPECT_EQ(bw1.lower, N - 3);
   EXPECT_EQ(bw1.upper, 1);
 
-  auto bw = gt::blas::get_max_bandwidth(N, gt::raw_pointer_cast(d_Aptr.data()),
-                                        N, batch_size);
+  auto bw = gt::blas::get_max_bandwidth(
+    h, N, gt::raw_pointer_cast(d_Aptr.data()), N, batch_size);
   EXPECT_EQ(bw.lower, N - 3);
   EXPECT_EQ(bw.upper, 1);
+
+  gt::blas::destroy(h);
 }
 
 TEST(bandsolve, sget_max_bandwidth)
@@ -442,9 +454,14 @@ void test_invert_batch_complex()
   gt::copy(h_Ainv, d_Ainv);
   gt::copy(h_p, d_p);
 
-  gt::blas::invert_banded_batched(
-    N, gt::raw_pointer_cast(d_Aptr.data()), N, gt::raw_pointer_cast(d_p.data()),
-    gt::raw_pointer_cast(d_Ainvptr.data()), N, batch_size, N - 1, N - 1);
+  gt::blas::handle_t* h = gt::blas::create();
+
+  gt::blas::invert_banded_batched(h, N, gt::raw_pointer_cast(d_Aptr.data()), N,
+                                  gt::raw_pointer_cast(d_p.data()),
+                                  gt::raw_pointer_cast(d_Ainvptr.data()), N,
+                                  batch_size, N - 1, N - 1);
+
+  gt::blas::destroy(h);
 
   gt::copy(d_Ainv, h_Ainv);
 
@@ -594,10 +611,14 @@ void test_solve_inverted_batch_complex()
 
   gt::copy(h_Cptr, d_Cptr);
 
+  gt::blas::handle_t* h = gt::blas::create();
+
   gt::blas::solve_inverted_batched(
-    N, NRHS, gt::raw_pointer_cast(d_Ainvptr.data()), N,
+    h, N, NRHS, gt::raw_pointer_cast(d_Ainvptr.data()), N,
     gt::raw_pointer_cast(d_Bptr.data()), N, gt::raw_pointer_cast(d_Cptr.data()),
     N, batch_size);
+
+  gt::blas::destroy(h);
 
   gt::copy(d_C, h_C);
 
@@ -745,15 +766,16 @@ void test_full_solve_real()
                           gt::raw_pointer_cast(d_info.data()), batch_size);
   gt::synchronize();
 
-  auto bw =
-    gt::blas::get_max_bandwidth(N, gt::raw_pointer_cast(d_Aptr.data()), N, 1);
+  auto bw = gt::blas::get_max_bandwidth(
+    h, N, gt::raw_pointer_cast(d_Aptr.data()), N, 1);
 
   GT_DEBUG_VAR(bw.lower);
   GT_DEBUG_VAR(bw.upper);
 
-  gt::blas::invert_banded_batched(
-    N, gt::raw_pointer_cast(d_Aptr.data()), N, gt::raw_pointer_cast(d_p.data()),
-    gt::raw_pointer_cast(d_Ainvptr.data()), N, batch_size, bw.lower, bw.upper);
+  gt::blas::invert_banded_batched(h, N, gt::raw_pointer_cast(d_Aptr.data()), N,
+                                  gt::raw_pointer_cast(d_p.data()),
+                                  gt::raw_pointer_cast(d_Ainvptr.data()), N,
+                                  batch_size, bw.lower, bw.upper);
   gt::synchronize();
 
   gt::copy(d_Ainv, h_Ainv);

--- a/tests/test_blas.cxx
+++ b/tests/test_blas.cxx
@@ -24,13 +24,11 @@ void test_axpy_real()
   gt::copy(h_x, d_x);
   gt::copy(h_y, d_y);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   // gt::blas::axpy(h, N, &a, gt::raw_pointer_cast(d_x.data()), 1,
   //               gt::raw_pointer_cast(d_y.data()), 1);
   gt::blas::axpy(h, a, d_x, d_y);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_y, h_y);
 
@@ -68,12 +66,10 @@ void test_axpy_complex()
   gt::copy(h_x, d_x);
   gt::copy(h_y, d_y);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   gt::blas::axpy(h, N, a, gt::raw_pointer_cast(d_x.data()), 1,
                  gt::raw_pointer_cast(d_y.data()), 1);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_y, h_y);
 
@@ -111,13 +107,11 @@ void test_scal_complex()
   gt::copy(h_x, d_x);
   gt::copy(h_x, d_y);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   // gt::blas::scal(h, N, a, gt::raw_pointer_cast(d_x.data()), 1);
   gt::blas::scal(h, a, d_x);
   gt::blas::scal(h, b, d_y);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_x, h_x);
   gt::copy(d_y, h_y);
@@ -152,12 +146,10 @@ void test_scal_real()
 
   gt::copy(h_x, d_x);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   // gt::blas::scal(h, N, a, gt::raw_pointer_cast(d_x.data()), 1);
   gt::blas::scal(h, a, d_x);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_x, h_x);
 
@@ -194,11 +186,9 @@ void test_copy_complex()
   gt::copy(h_x, d_x);
   gt::copy(h_y, d_y);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   gt::blas::copy(h, d_x, d_y);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_y, h_y);
 
@@ -234,11 +224,9 @@ void test_dot_real()
   gt::copy(h_x, d_x);
   gt::copy(h_y, d_y);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   T result = gt::blas::dot(h, d_x, d_y);
-
-  gt::blas::destroy(h);
 
   // sum of first (N-1) integers * 2
   EXPECT_EQ(result, (N - 1) * N);
@@ -272,12 +260,10 @@ void test_dot_complex()
   gt::copy(h_x, d_x);
   gt::copy(h_y, d_y);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   T resultu = gt::blas::dotu(h, d_x, d_y);
   T resultc = gt::blas::dotc(h, d_x, d_y);
-
-  gt::blas::destroy(h);
 
   // sum of first (N-1) integers * 2, which is the sum of real values
   // of x
@@ -341,14 +327,12 @@ void test_gemv_real()
   gt::copy(h_x, d_x);
   gt::copy(h_y, d_y);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   // gt::blas::gemv(h, N, N, a, gt::raw_pointer_cast(d_A.data()), N,
   //                gt::raw_pointer_cast(d_x.data()), 1, b,
   //                gt::raw_pointer_cast(d_y.data()), 1);
   gt::blas::gemv(h, a, d_A, d_x, b, d_y);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_y, h_y);
 
@@ -402,14 +386,12 @@ void test_gemv_complex()
   gt::copy(h_y, d_y);
   gt::copy(h_mat, d_mat);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   // gt::blas::gemv(h, N, N, a, gt::raw_pointer_cast(d_mat.data()), N,
   //                gt::raw_pointer_cast(d_x.data()), 1, b,
   //                gt::raw_pointer_cast(d_y.data()), 1);
   gt::blas::gemv(h, a, d_mat, d_x, b, d_y);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_y, h_y);
 
@@ -484,14 +466,12 @@ void test_gemm_batched_real()
   gt::copy(h_yptr, d_yptr);
   gt::copy(h_matptr, d_matptr);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   gt::blas::gemm_batched<R>(h, m, n, k, a,
                             gt::raw_pointer_cast(d_matptr.data()), N,
                             gt::raw_pointer_cast(d_xptr.data()), N, b,
                             gt::raw_pointer_cast(d_yptr.data()), N, batch_size);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_Y, h_Y);
 
@@ -569,14 +549,12 @@ void test_gemm_batched_complex()
   gt::copy(h_yptr, d_yptr);
   gt::copy(h_matptr, d_matptr);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   gt::blas::gemm_batched<T>(h, m, n, k, a,
                             gt::raw_pointer_cast(d_matptr.data()), N,
                             gt::raw_pointer_cast(d_xptr.data()), N, b,
                             gt::raw_pointer_cast(d_yptr.data()), N, batch_size);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_Y, h_Y);
 
@@ -662,14 +640,12 @@ void test_gemm_batched_b0_complex()
   gt::copy(h_yptr, d_yptr);
   gt::copy(h_matptr, d_matptr);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   gt::blas::gemm_batched<T>(h, m, n, k, a,
                             gt::raw_pointer_cast(d_matptr.data()), N,
                             gt::raw_pointer_cast(d_xptr.data()), N, 0.0,
                             gt::raw_pointer_cast(d_yptr.data()), N, batch_size);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_Y, h_Y);
 

--- a/tests/test_lapack.cxx
+++ b/tests/test_lapack.cxx
@@ -168,13 +168,11 @@ void test_getrf_batch_real()
   gt::copy(h_A, d_A);
   gt::copy(h_Aptr, d_Aptr);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   gt::blas::getrf_batched(h, N, gt::raw_pointer_cast(d_Aptr.data()), N,
                           gt::raw_pointer_cast(d_p.data()),
                           gt::raw_pointer_cast(d_info.data()), batch_size);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_A, h_A);
   gt::copy(d_p, h_p);
@@ -258,13 +256,11 @@ void test_getrs_batch_real()
   gt::copy(h_B, d_B);
   gt::copy(h_p, d_p);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   gt::blas::getrs_batched(h, N, NRHS, gt::raw_pointer_cast(d_Aptr.data()), N,
                           gt::raw_pointer_cast(d_p.data()),
                           gt::raw_pointer_cast(d_Bptr.data()), N, batch_size);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_B, h_B);
 
@@ -317,13 +313,11 @@ void test_getrf_batch_complex()
   gt::copy(h_A, d_A);
   gt::copy(h_Aptr, d_Aptr);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   gt::blas::getrf_batched(h, N, gt::raw_pointer_cast(d_Aptr.data()), N,
                           gt::raw_pointer_cast(d_p.data()),
                           gt::raw_pointer_cast(d_info.data()), batch_size);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_A, h_A);
   gt::copy(d_p, h_p);
@@ -414,12 +408,10 @@ void test_getrf_npvt_batch_complex()
   gt::copy(h_A, d_A);
   gt::copy(h_Aptr, d_Aptr);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   gt::blas::getrf_npvt_batched(h, N, gt::raw_pointer_cast(d_Aptr.data()), N,
                                gt::raw_pointer_cast(d_info.data()), batch_size);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_A, h_A);
   gt::copy(d_info, h_info);
@@ -546,13 +538,11 @@ void test_getrs_batch_complex()
   gt::copy(h_B, d_B);
   gt::copy(h_p, d_p);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   gt::blas::getrs_batched(h, N, NRHS, gt::raw_pointer_cast(d_Aptr.data()), N,
                           gt::raw_pointer_cast(d_p.data()),
                           gt::raw_pointer_cast(d_Bptr.data()), N, batch_size);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_B, h_B);
 
@@ -637,14 +627,12 @@ void test_getri_batch_complex()
   gt::copy(h_C, d_C);
   gt::copy(h_p, d_p);
 
-  gt::blas::handle_t* h = gt::blas::create();
+  gt::blas::handle_t h;
 
   gt::blas::getri_batched(h, N, gt::raw_pointer_cast(d_Aptr.data()), N,
                           gt::raw_pointer_cast(d_p.data()),
                           gt::raw_pointer_cast(d_Cptr.data()), N,
                           gt::raw_pointer_cast(d_info.data()), batch_size);
-
-  gt::blas::destroy(h);
 
   gt::copy(d_C, h_C);
 


### PR DESCRIPTION
Adds `gt::blas::getri_batched`, along with tests and benchmark, and refactors and improves stream handling. 

* refactor stream handling in gt-blas, using stream_view for set/get instead of gt::blas::stream_t
* bandsolver family of calls now take a blas handle, and respect the stream set on the handle
* reduction API now has an optional stream_view argument.
* C API still uses gt::blas::stream_t, to keep disruption to existing Fortran code to a minimum.