### PR TITLE
stream: refactor stream view and owning classes

### DIFF
--- a/include/gtensor/backend_sycl.h
+++ b/include/gtensor/backend_sycl.h
@@ -241,8 +241,51 @@ inline bool is_device_address(const Ptr p)
           alloc_type == ::sycl::usm::alloc::shared);
 }
 
+namespace stream_interface
+{
+
+using sycl_stream_t = cl::sycl::queue&;
+
+template <>
+inline sycl_stream_t create<sycl_stream_t>()
+{
+  return gt::backend::sycl::new_stream_queue();
+}
+
+template <>
+inline sycl_stream_t get_default<sycl_stream_t>()
+{
+  return gt::backend::sycl::get_queue();
+}
+
+template <>
+inline void destroy<sycl_stream_t>(sycl_stream_t q)
+{
+  return gt::backend::sycl::delete_stream_queue(q);
+}
+
+template <>
+inline bool is_default<sycl_stream_t>(sycl_stream_t s)
+{
+  return s == gt::backend::sycl::get_queue();
+}
+
+template <>
+inline void synchronize<sycl_stream_t>(sycl_stream_t s)
+{
+  s.wait();
+}
+
+} // namespace stream_interface
+
 } // namespace backend
 
+using stream_view =
+  backend::stream_interface::stream_view_base<cl::sycl::queue&>;
+using stream =
+  backend::stream_interface::stream_base<cl::sycl::queue&, stream_view>;
+
+/*
 class stream_view
 {
 public:
@@ -277,7 +320,7 @@ public:
 private:
   cl::sycl::queue& stream_;
 };
-
+*/
 } // namespace gt
 
 #endif // GTENSOR_BACKEND_SYCL_H


### PR DESCRIPTION
Use common stream classes. The existing code relies on each backend defining them correctly, with no help from the compiler.

Note that the hip and cuda backends still use a subclass that adds get_execution_policy - this is used by thrust reductions. Perhaps there is a more elegant way of handling this. It could be part of the interface, and sycl has a dummy implementation. Or sycl could have an implementation using oneDPL, but that makes us even more dependent on oneAPI vs SYCL standard.