### PR TITLE
indexing: use size_type for flat index, nd kernel

### DIFF
--- a/include/gtensor/assign.h
+++ b/include/gtensor/assign.h
@@ -344,10 +344,10 @@ struct assigner<6, space::device>
 #else // not defined GTENSOR_PER_DIM_KERNELS
 
 template <typename Elhs, typename Erhs, size_type N>
-__global__ void kernel_assign_N(Elhs lhs, Erhs rhs, int size,
+__global__ void kernel_assign_N(Elhs lhs, Erhs rhs, size_type size,
                                 gt::shape_type<N> strides)
 {
-  int i = threadIdx.x + blockIdx.x * blockDim.x;
+  size_type i = threadIdx.x + blockIdx.x * blockDim.x;
 
   if (i < size) {
     auto idx = unravel(i, strides);
@@ -361,9 +361,12 @@ struct assigner<N, space::device>
   template <typename E1, typename E2>
   static void run(E1& lhs, const E2& rhs, stream_view stream)
   {
-    int size = int(calc_size(lhs.shape()));
+    auto size = calc_size(lhs.shape());
     auto strides = calc_strides(lhs.shape());
-    auto block_size = std::min(size, BS_LINEAR);
+    unsigned int block_size = BS_LINEAR;
+    if (block_size > size) {
+      block_size = static_cast<unsigned int>(size);
+    }
 
     dim3 numThreads(block_size);
     dim3 numBlocks(gt::div_ceil(size, block_size));
@@ -399,7 +402,7 @@ struct assigner<1, space::device>
       using rtype = decltype(k_rhs);
       using kname = gt::backend::sycl::Assign1<E1, E2, ltype, rtype>;
       cgh.parallel_for<kname>(range, [=](sycl::item<1> item) {
-        int i = item.get_id();
+        auto i = item.get_id();
         k_lhs(i) = k_rhs(i);
       });
     });
@@ -425,8 +428,8 @@ struct assigner<2, space::device>
       using rtype = decltype(k_rhs);
       using kname = gt::backend::sycl::Assign2<E1, E2, ltype, rtype>;
       cgh.parallel_for<kname>(range, [=](sycl::item<2> item) {
-        int i = item.get_id(1);
-        int j = item.get_id(0);
+        auto i = item.get_id(1);
+        auto j = item.get_id(0);
         k_lhs(i, j) = k_rhs(i, j);
       });
     });
@@ -452,9 +455,9 @@ struct assigner<3, space::device>
       using rtype = decltype(k_rhs);
       using kname = gt::backend::sycl::Assign3<E1, E2, ltype, rtype>;
       cgh.parallel_for<kname>(range, [=](sycl::item<3> item) {
-        int i = item.get_id(2);
-        int j = item.get_id(1);
-        int k = item.get_id(0);
+        auto i = item.get_id(2);
+        auto j = item.get_id(1);
+        auto k = item.get_id(0);
         k_lhs(i, j, k) = k_rhs(i, j, k);
       });
     });
@@ -515,7 +518,7 @@ template <typename S>
 inline void valid_assign_broadcast_or_throw(const S& lhs_shape,
                                             const S& rhs_shape)
 {
-  for (int i = 0; i < lhs_shape.size(); i++) {
+  for (size_type i = 0; i < lhs_shape.size(); i++) {
     if (lhs_shape[i] != rhs_shape[i] && rhs_shape[i] != 1) {
       throw std::runtime_error("cannot assign lhs = " + to_string(lhs_shape) +
                                " rhs = " + to_string(rhs_shape) + "\n");

--- a/include/gtensor/assign.h
+++ b/include/gtensor/assign.h
@@ -347,7 +347,8 @@ template <typename Elhs, typename Erhs, size_type N>
 __global__ void kernel_assign_N(Elhs lhs, Erhs rhs, size_type size,
                                 gt::shape_type<N> strides)
 {
-  size_type i = threadIdx.x + blockIdx.x * blockDim.x;
+  // workaround ROCm 5.2.0 compiler bug
+  size_type i = threadIdx.x + static_cast<size_type>(blockIdx.x) * blockDim.x;
 
   if (i < size) {
     auto idx = unravel(i, strides);

--- a/include/gtensor/defs.h
+++ b/include/gtensor/defs.h
@@ -25,8 +25,8 @@ class sarray;
 template <size_type N>
 using shape_type = sarray<int, N>;
 
-template <typename T>
-T div_ceil(const T n, const T d)
+template <typename T1, typename T2>
+auto div_ceil(const T1 n, const T2 d)
 {
   return (n - 1) / d + 1;
 }

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -312,7 +312,8 @@ __global__ void kernel_launch(gt::shape_type<6> shape, F f)
 template <typename F, size_type N>
 __global__ void kernel_launch_N(F f, size_type size, gt::shape_type<N> strides)
 {
-  size_type i = threadIdx.x + blockIdx.x * blockDim.x;
+  // workaround ROCm 5.2.0 compiler bug
+  size_type i = threadIdx.x + static_cast<size_type>(blockIdx.x) * blockDim.x;
 
   if (i < size) {
     auto idx = unravel(i, strides);

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -310,9 +310,9 @@ __global__ void kernel_launch(gt::shape_type<6> shape, F f)
 #else // not GTENSOR_PER_DIM_KERNELS
 
 template <typename F, size_type N>
-__global__ void kernel_launch_N(F f, int size, gt::shape_type<N> strides)
+__global__ void kernel_launch_N(F f, size_type size, gt::shape_type<N> strides)
 {
-  int i = threadIdx.x + blockIdx.x * blockDim.x;
+  size_type i = threadIdx.x + blockIdx.x * blockDim.x;
 
   if (i < size) {
     auto idx = unravel(i, strides);
@@ -540,9 +540,12 @@ struct launch<N, space::device>
   template <typename F>
   static void run(const gt::shape_type<N>& shape, F&& f, gt::stream_view stream)
   {
-    int size = int(calc_size(shape));
+    auto size = calc_size(shape);
     auto strides = calc_strides(shape);
-    auto block_size = std::min(size, BS_LINEAR);
+    unsigned int block_size = BS_LINEAR;
+    if (block_size > size) {
+      block_size = static_cast<unsigned int>(size);
+    }
 
     dim3 numThreads(block_size);
     dim3 numBlocks(gt::div_ceil(size, block_size));
@@ -574,7 +577,7 @@ struct launch<1, space::device>
     auto e = q.submit([&](sycl::handler& cgh) {
       // using kname = gt::backend::sycl::Launch1<decltype(f)>;
       cgh.parallel_for(range, [=](sycl::item<1> item) {
-        int i = item.get_id(0);
+        auto i = item.get_id(0);
         f(i);
       });
     });
@@ -596,8 +599,8 @@ struct launch<2, space::device>
     auto e = q.submit([&](sycl::handler& cgh) {
       // using kname = gt::backend::sycl::Launch2<decltype(f)>;
       cgh.parallel_for(range, [=](sycl::item<2> item) {
-        int i = item.get_id(1);
-        int j = item.get_id(0);
+        auto i = item.get_id(1);
+        auto j = item.get_id(0);
         f(i, j);
       });
     });
@@ -619,9 +622,9 @@ struct launch<3, space::device>
     auto e = q.submit([&](sycl::handler& cgh) {
       // using kname = gt::backend::sycl::Launch3<decltype(f)>;
       cgh.parallel_for(range, [=](sycl::item<3> item) {
-        int i = item.get_id(2);
-        int j = item.get_id(1);
-        int k = item.get_id(0);
+        auto i = item.get_id(2);
+        auto j = item.get_id(1);
+        auto k = item.get_id(0);
         f(i, j, k);
       });
     });
@@ -641,7 +644,7 @@ struct launch<N, space::device>
     gpuSyncIfEnabledStream(stream);
 
     sycl::queue q = stream.get_backend_stream();
-    int size = calc_size(shape);
+    auto size = calc_size(shape);
     auto strides = calc_strides(shape);
     auto e = q.submit([&](sycl::handler& cgh) {
       // using kname = gt::backend::sycl::LaunchN<decltype(f)>;

--- a/include/gtensor/gtensor_storage.h
+++ b/include/gtensor/gtensor_storage.h
@@ -216,7 +216,7 @@ bool operator==(const gtensor_storage<T, A, O>& v1,
   auto&& h2 = host_mirror(v2);
   copy(v1, h1);
   copy(v2, h2);
-  for (int i = 0; i < h1.size(); i++) {
+  for (size_type i = 0; i < h1.size(); i++) {
     if (h1[i] != h2[i]) {
       return false;
     }

--- a/include/gtensor/operator.h
+++ b/include/gtensor/operator.h
@@ -202,7 +202,7 @@ struct equals<N, N>
               <<  e1.strides() << std::endl;
     std::cout << "e2 " << e2_.strides() " -> "
               <<  e2.strides() << std::endl;
-    for (int i = 0; i < calc_size(e1.shape()); i++) {
+    for (size_type i = 0; i < calc_size(e1.shape()); i++) {
       if (e1.data_access(i) != e2.data_access(i)) {
         std::cout << e1.data_access(i) << " != "
                   << e2.data_access(i) << std::endl;

--- a/include/gtensor/reductions.h
+++ b/include/gtensor/reductions.h
@@ -335,7 +335,7 @@ inline auto sum(const Container& a, gt::stream_view stream = gt::stream_view{})
   // TODO: this assumes type has an initializer from int(0), which should be
   // true for all numeric types encountered in practice, but this is ugly
   T tmp = 0;
-  for (int i = 0; i < a.size(); i++) {
+  for (size_type i = 0; i < a.size(); i++) {
     tmp += data[i];
   }
   return tmp;
@@ -352,7 +352,7 @@ inline auto max(const Container& a, gt::stream_view stream = gt::stream_view{})
   auto data = a.data();
   T max_value = data[0];
   T current_value;
-  for (int i = 1; i < a.size(); i++) {
+  for (size_type i = 1; i < a.size(); i++) {
     current_value = data[i];
     if (current_value > max_value)
       max_value = current_value;
@@ -371,7 +371,7 @@ inline auto min(const Container& a, gt::stream_view stream = gt::stream_view{})
   auto data = a.data();
   T min_value = data[0];
   T current_value;
-  for (int i = 0; i < a.size(); i++) {
+  for (size_type i = 0; i < a.size(); i++) {
     current_value = data[i];
     if (current_value < min_value)
       min_value = current_value;


### PR DESCRIPTION
Does not change external interface (shape_type is still int sarray).
This should make sure there is no int overflow in internal index
calculations. Note that reshape could still overflow, but the
assert that the sizes stayed the same in the implementation should
at least catch it in debug builds.