### PR TITLE
Bugfix/stream capi sycl

### DIFF
--- a/include/gt-blas/backend/sycl.h
+++ b/include/gt-blas/backend/sycl.h
@@ -13,7 +13,7 @@ namespace blas
 // ======================================================================
 // types aliases
 
-using stream_t = cl::sycl::queue;
+using stream_t = cl::sycl::queue*;
 using index_t = std::int64_t;
 
 // ======================================================================

--- a/src/cgtblas.cxx
+++ b/src/cgtblas.cxx
@@ -1,5 +1,6 @@
 #include <cassert>
 #include <cstdint>
+#include <type_traits>
 
 #include "gt-blas/blas.h"
 #include "gt-blas/cblas.h"
@@ -72,6 +73,46 @@ inline auto cast_aligned(const f2c_complex<T>** c)
   return reinterpret_cast<const gt::complex<T>**>(c);
 }
 
+template <typename Stream,
+          typename std::enable_if_t<
+            std::is_same<std::decay_t<Stream>,
+                         std::decay_t<gt::stream_view::stream_t>>::value,
+            int> = 0>
+void set_stream(Stream stream_id)
+{
+  g_handle->set_stream(gt::stream_view{stream_id});
+}
+
+template <typename Stream,
+          typename std::enable_if_t<
+            std::is_same<std::decay_t<Stream>,
+                         std::decay_t<gt::stream_view::stream_t>*>::value,
+            int> = 0>
+void set_stream(Stream stream_id)
+{
+  g_handle->set_stream(gt::stream_view{*stream_id});
+}
+
+template <typename Stream,
+          typename std::enable_if_t<
+            std::is_same<std::decay_t<Stream>,
+                         std::decay_t<gt::stream_view::stream_t>>::value,
+            int> = 0>
+void get_stream(Stream* stream_id)
+{
+  *stream_id = g_handle->get_stream().get_backend_stream();
+}
+
+template <typename Stream,
+          typename std::enable_if_t<
+            std::is_same<std::decay_t<Stream>,
+                         std::decay_t<gt::stream_view::stream_t>*>::value,
+            int> = 0>
+void get_stream(Stream* stream_id)
+{
+  *stream_id = &g_handle->get_stream().get_backend_stream();
+}
+
 } // namespace detail
 
 void gtblas_create()
@@ -91,12 +132,12 @@ void gtblas_destroy()
 
 void gtblas_set_stream(gt::blas::stream_t stream_id)
 {
-  g_handle->set_stream(gt::stream_view{stream_id});
+  detail::set_stream(stream_id);
 }
 
 void gtblas_get_stream(gt::blas::stream_t* stream_id)
 {
-  *stream_id = g_handle->get_stream().get_backend_stream();
+  detail::get_stream(stream_id);
 }
 
 // ======================================================================

--- a/src/cgtblas.cxx
+++ b/src/cgtblas.cxx
@@ -90,7 +90,11 @@ template <typename Stream,
             int> = 0>
 void set_stream(Stream stream_id)
 {
-  g_handle->set_stream(gt::stream_view{*stream_id});
+  if (stream_id) {
+    g_handle->set_stream(gt::stream_view{*stream_id});
+  } else {
+    g_handle->set_stream(gt::stream_view{});
+  }
 }
 
 template <typename Stream,


### PR DESCRIPTION
In the SYCL variant of gtblas_get_stream the call to get_backend_stream() returns a sycl::queue&. But reference types are a C++ feature and not interoperable with C / Fortran. Here, I change stream_t to sycl::queue* for easy interopability. In order to distinguish between the cuda/hip and SYCL code-paths the detail::(get|set)_stream methods are introduced.