### PR TITLE
cmake: make SYCL backend builds  work with .cu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,22 +335,7 @@ if (GTENSOR_BUILD_BENCHMARKS)
   )
 endif()
 
-function(target_gtensor_sources TARGET)
-  set(options "")
-  set(oneValueArgs "")
-  set(multiValueArgs PRIVATE)
-  cmake_parse_arguments(target_gtensor_sources "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
-  target_sources(${TARGET} PRIVATE ${target_gtensor_sources_PRIVATE})
-  if ("${GTENSOR_DEVICE}" STREQUAL "cuda")
-    set_source_files_properties(${target_gtensor_sources_PRIVATE}
-                                TARGET_DIRECTORY ${TARGET}
-                                PROPERTIES LANGUAGE CUDA)
-  else()
-    set_source_files_properties(${target_gtensor_sources_PRIVATE}
-                                TARGET_DIRECTORY ${TARGET}
-                                PROPERTIES LANGUAGE CXX)
-  endif()
-endfunction()
+include(cmake/target-gtensor-sources-macro.cmake)
 
 if (BUILD_TESTING AND IS_MAIN_PROJECT)
   add_subdirectory(tests)
@@ -462,6 +447,7 @@ configure_package_config_file(
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/gtensor-config.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/gtensor-config-version.cmake
+    cmake/target-gtensor-sources-macro.cmake
     DESTINATION ${INSTALL_CONFIGDIR}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,13 @@ macro(add_gtensor_library DEVICE)
        $<INSTALL_INTERFACE:include>
        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   )
-  target_compile_features(gtensor_${DEVICE} INTERFACE cxx_std_14)
+  if ("${GTENSOR_DEVICE}" STREQUAL "sycl")
+    # Note: SYCL 2020 standard requires C++17, and gtensor takes advantage of this
+    # in some SYCL backend specific code
+    target_compile_features(gtensor_${DEVICE} INTERFACE cxx_std_17)
+  else()
+    target_compile_features(gtensor_${DEVICE} INTERFACE cxx_std_14)
+  endif()
 
   list(APPEND GTENSOR_TARGETS gtensor_${DEVICE})
 
@@ -194,7 +200,7 @@ if ("sycl" IN_LIST GTENSOR_BUILD_DEVICES)
   add_gtensor_library(sycl)
 
   target_compile_options(gtensor_sycl INTERFACE
-                         $<$<COMPILE_LANGUAGE:CXX>:-fsycl>)
+                         $<$<COMPILE_LANGUAGE:CXX>:-fsycl -x c++>)
   target_link_options(gtensor_sycl INTERFACE
                       $<$<COMPILE_LANGUAGE:CXX>:-fsycl>)
   target_compile_definitions(gtensor_sycl INTERFACE GTENSOR_HAVE_DEVICE)

--- a/cmake/target-gtensor-sources-macro.cmake
+++ b/cmake/target-gtensor-sources-macro.cmake
@@ -1,0 +1,16 @@
+function(target_gtensor_sources TARGET)
+  set(options "")
+  set(oneValueArgs "")
+  set(multiValueArgs PRIVATE)
+  cmake_parse_arguments(target_gtensor_sources "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+  target_sources(${TARGET} PRIVATE ${target_gtensor_sources_PRIVATE})
+  if ("${GTENSOR_DEVICE}" STREQUAL "cuda")
+    set_source_files_properties(${target_gtensor_sources_PRIVATE}
+                                TARGET_DIRECTORY ${TARGET}
+                                PROPERTIES LANGUAGE CUDA)
+  else()
+    set_source_files_properties(${target_gtensor_sources_PRIVATE}
+                                TARGET_DIRECTORY ${TARGET}
+                                PROPERTIES LANGUAGE CXX)
+  endif()
+endfunction()

--- a/gtensor-config.cmake.in
+++ b/gtensor-config.cmake.in
@@ -44,16 +44,7 @@ endif()
 # function to enable configure source properties based on the
 # gtensor device backend. In particular, enable CUDA language
 # for CUDA backend, even if the file doesn't have a .cu extension.
-function(target_gtensor_sources TARGET)
-  set(options "")
-  set(oneValueArgs "")
-  set(multiValueArgs PRIVATE)
-  cmake_parse_arguments(target_gtensor_sources "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
-  target_sources(${TARGET} PRIVATE ${target_gtensor_sources_PRIVATE})
-  if ("${GTENSOR_DEVICE}" STREQUAL "cuda")
-    set_source_files_properties(${target_gtensor_sources_PRIVATE} PROPERTIES LANGUAGE CUDA)
-  endif()
-endfunction()
+include("${GTENSOR_CMAKE_DIR}/target-gtensor-sources-macro.cmake")
 
 set(GTENSOR_LIBRARIES @GTENSOR_TARGETS@)
 list(TRANSFORM GTENSOR_LIBRARIES PREPEND "gtensor::")


### PR DESCRIPTION
Support for codes porting cuda code that use the .cu extension.
This works for CUDA backend and HIP backend, but requires this
extra option to work with SYCL backend and Intel dpcpp