### PR TITLE
config: GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT opt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ set(GTENSOR_DEVICE "cuda" CACHE STRING "Device type 'host', 'cuda', or 'hip'")
 set_property(CACHE GTENSOR_DEVICE PROPERTY STRINGS "host" "cuda" "hip" "sycl")
 set(GTENSOR_BUILD_DEVICES "" CACHE STRING "List of device types 'host', 'cuda', 'hip', and 'sycl' (semicolon separated)")
 
+set(GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT "managed" CACHE STRING
+   "One of 'managed', 'device', or for HIP 'managed_coarse' or 'managed_fine'")
+set_property(CACHE GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT
+             PROPERTY STRINGS "managed" "device" "managed_coarse" "managed_fine")
+
 option(USE_GTEST_DISCOVER_TESTS "use gtest_discover_tests()" ON)
 option(GTENSOR_USE_THRUST "Use thrust (cuda and hip devices)" OFF)
 option(GTENSOR_TEST_DEBUG "Turn on debug printing for unit tests" OFF)
@@ -38,8 +43,6 @@ set(ROCM_PATH "/opt/rocm" CACHE STRING "path to ROCm installation")
 set(HIP_PATH "/opt/rocm/hip" CACHE STRING "path to HIP installation")
 set(HIP_GPU_ARCHITECTURES "gfx803,gfx906,gfx908,gfx90a" CACHE
     STRING "comma separated list of AMD gpu architectures to build for")
-  set(GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE "coarse" CACHE STRING
-    "One of 'coarse', 'fine', or 'device'")
 
 # SYCL specific configuration
 set(GTENSOR_DEVICE_SYCL_SELECTOR "default" CACHE STRING
@@ -186,21 +189,6 @@ if ("hip" IN_LIST GTENSOR_BUILD_DEVICES)
   target_link_options(gtensor_hip INTERFACE
     $<$<LINK_LANGUAGE:CXX>:--amdgpu-target=${HIP_GPU_ARCHITECTURES}>)
 
-  if (${GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE} STREQUAL "fine")
-    target_compile_definitions(gtensor_hip INTERFACE
-      GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE_FINE)
-  elseif(${GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE} STREQUAL "device")
-    target_compile_definitions(gtensor_hip INTERFACE
-      GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE_DEVICE)
-  elseif(${GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE} STREQUAL "coarse")
-    target_compile_definitions(gtensor_hip INTERFACE
-      GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE_COARSE)
-  else()
-    message(FATAL_ERROR "${PROJECT_NAME}: unknown value of GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE: '${GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE}'")
-    message(STATUS "${PROJECT_NAME}: hip managed memory type '${GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE}'")
-  endif()
-  message(STATUS "${PROJECT_NAME}: hip managed memory type '${GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE}'")
-
   if (HIP_GCC_TOOLCHAIN)
     target_compile_options(gtensor_hip INTERFACE
       $<$<COMPILE_LANGUAGE:CXX>:--gcc-toolchain=${HIP_GCC_TOOLCHAIN}>)
@@ -304,6 +292,10 @@ else()
                              INTERFACE GTENSOR_ALLOCATOR_NO_CACHING)
   message(STATUS "${PROJECT_NAME}: caching allocator disabled")
 endif()
+
+target_compile_definitions(gtensor_${GTENSOR_DEVICE} INTERFACE
+  GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT="${GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT}")
+message(STATUS "${PROJECT_NAME}: default managed memory type '${GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT}'")
 
 # define aliases for use in tests and examples subdirs
 add_library(gtensor ALIAS gtensor_${GTENSOR_DEVICE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,7 +294,7 @@ else()
 endif()
 
 target_compile_definitions(gtensor_${GTENSOR_DEVICE} INTERFACE
-  GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT="${GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT}")
+  GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT=managed_memory_type::${GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT})
 message(STATUS "${PROJECT_NAME}: default managed memory type '${GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT}'")
 
 # define aliases for use in tests and examples subdirs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ set(ROCM_PATH "/opt/rocm" CACHE STRING "path to ROCm installation")
 set(HIP_PATH "/opt/rocm/hip" CACHE STRING "path to HIP installation")
 set(HIP_GPU_ARCHITECTURES "gfx803,gfx906,gfx908,gfx90a" CACHE
     STRING "comma separated list of AMD gpu architectures to build for")
+  set(GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE "coarse" CACHE STRING
+    "One of 'coarse', 'fine', or 'device'")
 
 # SYCL specific configuration
 set(GTENSOR_DEVICE_SYCL_SELECTOR "default" CACHE STRING
@@ -183,6 +185,21 @@ if ("hip" IN_LIST GTENSOR_BUILD_DEVICES)
     $<$<COMPILE_LANGUAGE:CXX>:--amdgpu-target=${HIP_GPU_ARCHITECTURES}>)
   target_link_options(gtensor_hip INTERFACE
     $<$<LINK_LANGUAGE:CXX>:--amdgpu-target=${HIP_GPU_ARCHITECTURES}>)
+
+  if (${GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE} STREQUAL "fine")
+    target_compile_definitions(gtensor_hip INTERFACE
+      GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE_FINE)
+  elseif(${GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE} STREQUAL "device")
+    target_compile_definitions(gtensor_hip INTERFACE
+      GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE_DEVICE)
+  elseif(${GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE} STREQUAL "coarse")
+    target_compile_definitions(gtensor_hip INTERFACE
+      GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE_COARSE)
+  else()
+    message(FATAL_ERROR "${PROJECT_NAME}: unknown value of GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE: '${GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE}'")
+    message(STATUS "${PROJECT_NAME}: hip managed memory type '${GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE}'")
+  endif()
+  message(STATUS "${PROJECT_NAME}: hip managed memory type '${GTENSOR_DEVICE_HIP_MANAGED_MEMORY_TYPE}'")
 
   if (HIP_GCC_TOOLCHAIN)
     target_compile_options(gtensor_hip INTERFACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,7 +294,7 @@ else()
 endif()
 
 target_compile_definitions(gtensor_${GTENSOR_DEVICE} INTERFACE
-  GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT=managed_memory_type::${GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT})
+  GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT=${GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT})
 message(STATUS "${PROJECT_NAME}: default managed memory type '${GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT}'")
 
 # define aliases for use in tests and examples subdirs

--- a/README.md
+++ b/README.md
@@ -66,16 +66,20 @@ gtensor for nVidia GPUs with CUDA requires
 
 ### AMD HIP requirements
 
-gtensor for AMD GPUs with HIP requires ROCm 3.3.0+, and
-rocthrust and rocprim unless `-DGTENSOR_USE_THRUST=OFF`. See the
-[ROCm installation guide](https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html)
+gtensor for AMD GPUs with HIP requires ROCm 4.5.0+, and rocthrust and
+rocprim. See the [ROCm installation
+guide](https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html)
 for details. In Ubuntu, after setting up the ROCm repository, the required
 packages can be installed like this:
 ```
 sudo apt install rocm-dkms rocm-dev rocthrust
 ```
 The official packages install to `/opt/rocm`. If using a different install
-location, add it to `CMAKE_PREFIX_PATH` when running cmake for the application.
+location, set the `ROCM_PATH` cmake variable. To use coarse grained
+managed memory, ROCm 5.0+ is required.
+
+To use gt-fft and gt-blas, rocsolver, rocblas, and rocfft packages need
+to be installed as well.
 
 ### Intel SYCL requirements
 

--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -48,9 +48,9 @@ struct gallocator<gt::space::cuda_managed>
     T* p;
     auto nbytes = sizeof(T) * n;
     auto mtype = gt::backend::get_managed_memory_type();
-    if (strcmp(mtype, "managed") == 0) {
+    if (mtype == gt::backend::managed_memory_type::managed) {
       gtGpuCheck(cudaMallocManaged(&p, nbytes));
-    } else if (strcmp(mtype, "device") == 0) {
+    } else if (mtype == gt::backend::managed_memory_type::device) {
       gtGpuCheck(cudaMalloc(&p, nbytes));
     } else {
       throw std::runtime_error("unsupported managed memory type for backend");

--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -46,7 +46,15 @@ struct gallocator<gt::space::cuda_managed>
   static T* allocate(size_t n)
   {
     T* p;
-    gtGpuCheck(cudaMallocManaged(&p, sizeof(T) * n));
+    auto nbytes = sizeof(T) * n;
+    auto mtype = gt::backend::get_managed_memory_type();
+    if (strcmp(mtype, "managed") == 0) {
+      gtGpuCheck(cudaMallocManaged(&p, nbytes));
+    } else if (strcmp(mtype, "device") == 0) {
+      gtGpuCheck(cudaMalloc(&p, nbytes));
+    } else {
+      throw std::runtime_error("unsupported managed memory type for backend");
+    }
     return p;
   }
 

--- a/include/gtensor/backend_sycl.h
+++ b/include/gtensor/backend_sycl.h
@@ -120,7 +120,14 @@ struct gallocator<gt::space::sycl_managed>
   template <typename T>
   static T* allocate(size_t n)
   {
-    return cl::sycl::malloc_shared<T>(n, gt::backend::sycl::get_queue());
+    auto mtype = gt::backend::get_managed_memory_type();
+    if (strcmp(mtype, "managed") == 0) {
+      return cl::sycl::malloc_shared<T>(n, gt::backend::sycl::get_queue());
+    } else if (strcmp(mtype, "device") == 0) {
+      return cl::sycl::malloc_device<T>(n, gt::backend::sycl::get_queue());
+    } else {
+      throw std::runtime_error("unsupported managed memory type for backend");
+    }
   }
 
   template <typename T>

--- a/include/gtensor/backend_sycl.h
+++ b/include/gtensor/backend_sycl.h
@@ -121,9 +121,9 @@ struct gallocator<gt::space::sycl_managed>
   static T* allocate(size_t n)
   {
     auto mtype = gt::backend::get_managed_memory_type();
-    if (strcmp(mtype, "managed") == 0) {
+    if (mtype == gt::backend::managed_memory_type::managed) {
       return cl::sycl::malloc_shared<T>(n, gt::backend::sycl::get_queue());
-    } else if (strcmp(mtype, "device") == 0) {
+    } else if (mtype == gt::backend::managed_memory_type::device) {
       return cl::sycl::malloc_device<T>(n, gt::backend::sycl::get_queue());
     } else {
       throw std::runtime_error("unsupported managed memory type for backend");

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -27,6 +27,50 @@ namespace backend
 {
 
 // ======================================================================
+// library wide configuration
+
+#ifndef GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT
+#define GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT "managed"
+#endif
+
+namespace config
+{
+
+class GtensorConfig
+{
+public:
+  GtensorConfig() : managed_memory_type_(GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT) {}
+
+  void set_managed_memory_type(const char* mtype)
+  {
+    managed_memory_type_ = mtype;
+  }
+
+  auto get_managed_memory_type() { return managed_memory_type_; }
+
+private:
+  const char* managed_memory_type_;
+};
+
+inline GtensorConfig& get_config_instance()
+{
+  static GtensorConfig config;
+  return config;
+}
+
+} // namespace config
+
+inline void set_managed_memory_type(const char* mtype)
+{
+  config::get_config_instance().set_managed_memory_type(mtype);
+}
+
+inline auto get_managed_memory_type()
+{
+  return config::get_config_instance().get_managed_memory_type();
+}
+
+// ======================================================================
 // stream interface
 
 namespace stream_interface

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -30,7 +30,7 @@ namespace backend
 // library wide configuration
 
 #ifndef GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT
-#define GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT managed_memory_type::managed
+#define GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT managed
 #endif
 
 #ifdef GTENSOR_DEVICE_HIP
@@ -61,11 +61,15 @@ enum class managed_memory_type
 namespace config
 {
 
+#define QUALIFY_MMTYPE(x) gt::backend::managed_memory_type::x
+
 struct gtensor_config
 {
   gt::backend::managed_memory_type managed_memory_type =
-    GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT;
+    QUALIFY_MMTYPE(GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT);
 };
+
+#undef QUALIFY_MMTYPE
 
 inline gtensor_config& get_instance()
 {

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -30,44 +30,59 @@ namespace backend
 // library wide configuration
 
 #ifndef GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT
-#define GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT "managed"
+#define GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT managed_memory_type::managed
+#endif
+
+#ifdef GTENSOR_DEVICE_HIP
+#if HIP_VERSION_MAJOR >= 5
+enum class managed_memory_type
+{
+  managed,
+  device,
+  managed_fine,
+  managed_coarse
+};
+#else
+enum class managed_memory_type
+{
+  managed,
+  device,
+  managed_fine
+};
+#endif // HIP_VERSION_MAJOR
+#else
+enum class managed_memory_type
+{
+  managed,
+  device
+};
 #endif
 
 namespace config
 {
 
-class GtensorConfig
+struct gtensor_config
 {
-public:
-  GtensorConfig() : managed_memory_type_(GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT) {}
-
-  void set_managed_memory_type(const char* mtype)
-  {
-    managed_memory_type_ = mtype;
-  }
-
-  auto get_managed_memory_type() { return managed_memory_type_; }
-
-private:
-  const char* managed_memory_type_;
+  gt::backend::managed_memory_type managed_memory_type =
+    GTENSOR_MANAGED_MEMORY_TYPE_DEFAULT;
 };
 
-inline GtensorConfig& get_config_instance()
+inline gtensor_config& get_instance()
 {
-  static GtensorConfig config;
+  static gtensor_config config;
   return config;
 }
 
 } // namespace config
 
-inline void set_managed_memory_type(const char* mtype)
+inline void set_managed_memory_type(managed_memory_type mtype)
 {
-  config::get_config_instance().set_managed_memory_type(mtype);
+  config::get_instance().managed_memory_type = mtype;
 }
 
 inline auto get_managed_memory_type()
 {
-  return config::get_config_instance().get_managed_memory_type();
+  return config::get_instance().managed_memory_type;
 }
 
 // ======================================================================


### PR DESCRIPTION
Set to 'coarse' (default), 'device', or 'fine'. Note that this is
a change to default behavior - previous default was 'fine'.