### PR TITLE
add typestr expression method for debugging

### DIFF
--- a/include/gtensor/expression.h
+++ b/include/gtensor/expression.h
@@ -2,6 +2,8 @@
 #ifndef GTENSOR_EXPRESSION_H
 #define GTENSOR_EXPRESSION_H
 
+#include <string>
+
 #include "defs.h"
 #include "gtensor_forward.h"
 #include "gtl.h"
@@ -32,6 +34,8 @@ public:
   GT_INLINE const derived_type& derived() const&;
   GT_INLINE derived_type& derived() &;
   derived_type derived() &&;
+
+  inline std::string typestr() const&;
 };
 
 template <typename D>
@@ -50,6 +54,13 @@ template <typename D>
 inline auto expression<D>::derived() && -> derived_type
 {
   return static_cast<derived_type&&>(*this);
+}
+
+template <typename D>
+inline std::string expression<D>::typestr() const&
+{
+  auto sv = get_type_name<D>();
+  return std::string(sv.data, sv.size);
 }
 
 // ======================================================================

--- a/include/gtensor/gscalar.h
+++ b/include/gtensor/gscalar.h
@@ -2,6 +2,8 @@
 #ifndef GTENSOR_GSCALAR_H
 #define GTENSOR_GSCALAR_H
 
+#include <sstream>
+
 #include "expression.h"
 #include "sarray.h"
 
@@ -29,6 +31,13 @@ public:
   }
 
   gscalar<value_type> to_kernel() const { return gscalar<value_type>(value_); }
+
+  inline std::string typestr() const&
+  {
+    std::stringstream s;
+    s << value_ << "<" << get_type_name<T>() << ">";
+    return s.str();
+  }
 
 private:
   value_type value_;

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -2,6 +2,9 @@
 #ifndef GTENSOR_GTENSOR_H
 #define GTENSOR_GTENSOR_H
 
+#include <sstream>
+#include <string>
+
 #include "defs.h"
 #include "device_backend.h"
 
@@ -12,6 +15,7 @@
 #include "gtensor_forward.h"
 #include "gtensor_span.h"
 #include "gview.h"
+#include "helper.h"
 #include "operator.h"
 #include "space.h"
 
@@ -74,6 +78,8 @@ public:
 
   const_kernel_type to_kernel() const;
   kernel_type to_kernel();
+
+  std::string typestr() const&;
 
 private:
   GT_INLINE const storage_type& storage_impl() const;
@@ -178,6 +184,15 @@ template <typename T, size_type N>
 inline auto gtensor_container<T, N>::to_kernel() -> kernel_type
 {
   return kernel_type(this->data(), this->shape(), this->strides());
+}
+
+template <typename T, size_type N>
+inline std::string gtensor_container<T, N>::typestr() const&
+{
+  std::stringstream s;
+  s << "d" << N << "<" << get_type_name<typename T::value_type>() << ">"
+    << this->shape() << this->strides();
+  return s.str();
 }
 
 // ======================================================================

--- a/include/gtensor/gtensor_span.h
+++ b/include/gtensor/gtensor_span.h
@@ -2,6 +2,8 @@
 #ifndef GTENSOR_GTENSOR_VIEW_H
 #define GTENSOR_GTENSOR_VIEW_H
 
+#include <cassert>
+#include <sstream>
 #include <type_traits>
 
 #include "device_backend.h"
@@ -108,6 +110,8 @@ public:
 
   GT_INLINE reference data_access(size_type i) const;
 
+  inline std::string typestr() const&;
+
 private:
   storage_type storage_;
 
@@ -202,6 +206,15 @@ GT_INLINE auto gtensor_span<T, N, S>::operator[](const shape_type& idx) const
   -> reference
 {
   return access(std::make_index_sequence<shape_type::dimension>(), idx);
+}
+
+template <typename T, size_type N, typename S>
+inline std::string gtensor_span<T, N, S>::typestr() const&
+{
+  std::stringstream s;
+  s << "s" << N << "<" << get_type_name<T>() << ">" << this->shape()
+    << this->strides();
+  return s.str();
 }
 
 // ======================================================================

--- a/include/gtensor/gview.h
+++ b/include/gtensor/gview.h
@@ -2,6 +2,8 @@
 #ifndef GTENSOR_GVIEW_H
 #define GTENSOR_GVIEW_H
 
+#include <sstream>
+
 #include "assign.h"
 #include "defs.h"
 #include "expression.h"
@@ -64,6 +66,8 @@ public:
     shape_type idx = unravel(i, strides_);
     return access(std::make_index_sequence<idx.size()>(), idx);
   }
+
+  inline std::string typestr() const& { return e_.typestr(); }
 
 private:
   template <size_type... I>
@@ -211,6 +215,8 @@ public:
   GT_INLINE decltype(auto) data_access(size_type i) const;
   GT_INLINE decltype(auto) data_access(size_type i);
 
+  inline std::string typestr() const&;
+
 private:
   EC e_;
   size_type offset_;
@@ -288,6 +294,15 @@ template <typename EC, size_type N>
 GT_INLINE decltype(auto) gview<EC, N>::data_access(size_t i)
 {
   return e_.data_access(offset_ + i);
+}
+
+template <typename EC, size_type N>
+inline std::string gview<EC, N>::typestr() const&
+{
+  std::stringstream s;
+  s << "v" << N << "(" << e_.typestr() << ")" << this->shape()
+    << this->strides();
+  return s.str();
 }
 
 template <typename EC, size_type N>

--- a/include/gtensor/helper.h
+++ b/include/gtensor/helper.h
@@ -338,6 +338,55 @@ struct is_allowed_element_type_conversion
   : std::is_convertible<From (*)[], To (*)[]>
 {};
 
+// ======================================================================
+// get_type_name
+
+// See https://stackoverflow.com/a/35943472
+
+namespace detail
+{
+
+struct string_view
+{
+  char const* data;
+  std::size_t size;
+};
+
+inline std::ostream& operator<<(std::ostream& o, string_view const& s)
+{
+  return o.write(s.data, s.size);
+}
+
+} // namespace detail
+
+template <class T>
+constexpr detail::string_view get_type_name()
+{
+  // "constexpr string_view get_type_name() [with T = long unsigned int]"
+  char const* p = __PRETTY_FUNCTION__;
+
+  // scan for the equals sign
+  while (*p++ != '=')
+    ;
+  // skip space after equals sign
+  for (; *p == ' '; ++p)
+    ;
+
+  // scan to ']' to determine where type name ends
+  char const* p2 = p;
+  int count = 1;
+  for (;; ++p2) {
+    switch (*p2) {
+      case '[': ++count; break;
+      case ']':
+        --count;
+        if (!count)
+          return {p, std::size_t(p2 - p)};
+    }
+  }
+  return {};
+}
+
 } // namespace gt
 
 #endif

--- a/tests/test_expression.cxx
+++ b/tests/test_expression.cxx
@@ -341,6 +341,24 @@ TEST(expression, shape_second)
   EXPECT_EQ(e.shape(), (S3{2, 3, 4}));
 }
 
+TEST(expression, typestr)
+{
+  gt::gtensor<double, 2> a = {{1, 2}, {3, 4}};
+  auto aview = a.view(gt::all, 0);
+
+  auto adfn = 5.0 + a;
+  auto avfn = 5 * aview;
+  auto asfn = 5 * a.to_kernel();
+  auto sina = gt::sin(a);
+
+  std::cout << "a     typestr " << a.typestr() << std::endl;
+  std::cout << "aview typestr " << aview.typestr() << std::endl;
+  std::cout << "adfn  typestr " << adfn.typestr() << std::endl;
+  std::cout << "avfn  typestr " << avfn.typestr() << std::endl;
+  std::cout << "asfn  typestr " << asfn.typestr() << std::endl;
+  std::cout << "sina  typestr " << sina.typestr() << std::endl;
+}
+
 template <typename S>
 void test_index_expression()
 {

--- a/tests/test_expression.cxx
+++ b/tests/test_expression.cxx
@@ -344,18 +344,36 @@ TEST(expression, shape_second)
 TEST(expression, typestr)
 {
   gt::gtensor<double, 2> a = {{1, 2}, {3, 4}};
+  // d2 -> d for owning data, 2 for 2d
+  // <double> for element type
+  // {2, 2} is shape
+  // {1, 2} is strides
+  EXPECT_EQ(a.typestr(), "d2<double>{2, 2}{1, 2}");
+  std::cout << "a     typestr " << a.typestr() << std::endl;
+
   auto aview = a.view(gt::all, 0);
+  // v1 is for 1d view
+  // (...) is the owning data object the view is over (above)
+  // {2}{1} are the strides of the view
+  EXPECT_EQ(aview.typestr(), "v1(d2<double>{2, 2}{1, 2}){2}{1}");
+  std::cout << "aview typestr " << aview.typestr() << std::endl;
 
   auto adfn = 5.0 + a;
-  auto avfn = 5 * aview;
-  auto asfn = 5 * a.to_kernel();
-  auto sina = gt::sin(a);
-
-  std::cout << "a     typestr " << a.typestr() << std::endl;
-  std::cout << "aview typestr " << aview.typestr() << std::endl;
+  // fn:(... OP ...) for standard binary ops
+  EXPECT_EQ(adfn.typestr(), "fn:(5<double> + d2<double>{2, 2}{1, 2})");
   std::cout << "adfn  typestr " << adfn.typestr() << std::endl;
+
+  auto avfn = 5 * aview;
+  EXPECT_EQ(avfn.typestr(), "fn:(5<int> * v1(d2<double>{2, 2}{1, 2}){2}{1})");
   std::cout << "avfn  typestr " << avfn.typestr() << std::endl;
+
+  auto asfn = 5 * a.to_kernel();
+  EXPECT_EQ(asfn.typestr(), "fn:(5<int> * s2<double>{2, 2}{1, 2})");
   std::cout << "asfn  typestr " << asfn.typestr() << std::endl;
+
+  // fn:NAME(...) for unary functions
+  auto sina = gt::sin(a);
+  EXPECT_EQ(sina.typestr(), "fn:sin(d2<double>{2, 2}{1, 2})");
   std::cout << "sina  typestr " << sina.typestr() << std::endl;
 }
 


### PR DESCRIPTION
Experimental way to add useful debug info, by calling `expr.typestr()`. This is far easier than template meta programming to do this separately, however it has the downside of requiring including string and sstream throughout the code, which I don't like.