### PR TITLE
add fortran interoperability

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -130,11 +130,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: gtensor cmake
-      run: cmake -S . -B build-install -DGTENSOR_DEVICE=host -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/gtensor-install -DBUILD_TESTING=OFF
+      run: cmake -S . -B build-install -DGTENSOR_DEVICE=host -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/gtensor-install -DBUILD_TESTING=OFF -DGTENSOR_ENABLE_FORTRAN=ON
     - name: gtensor install
       run: cmake --build build-install -v -t install
     - name: examples cmake
-      run: cmake -S . -B build-find-package -DGTENSOR_DEVICE=host -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGTENSOR_EXAMPLES_USE_FIND_PACKAGE=ON -DGTENSOR_ENABLE_CLIB=ON
+      run: cmake -S . -B build-find-package -DGTENSOR_DEVICE=host -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGTENSOR_EXAMPLES_USE_FIND_PACKAGE=ON -DGTENSOR_ENABLE_CLIB=ON -DGTENSOR_ENABLE_FORTRAN=ON
       working-directory: ${{ github.workspace }}/examples
       env:
         gtensor_DIR: ${{ github.workspace }}/gtensor-install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ option(GTENSOR_BUILD_EXAMPLES "Build example programs" OFF)
 option(GTENSOR_ENABLE_CLIB "Enable libcgtensor" OFF)
 option(GTENSOR_ENABLE_BLAS "Enable gtblas" OFF)
 option(GTENSOR_ENABLE_FFT  "Enable gtfft" OFF)
+option(GTENSOR_ENABLE_FORTRAN "Enable Fortran interoperability" OFF)
 
 option(GTENSOR_PER_DIM_KERNELS
        "Enable per dim kernels (may break for large arrays)" OFF)
@@ -40,6 +41,12 @@ option(GTENSOR_ALLOCATOR_CACHING "Enable naive caching allocators" ON)
 option(GTENSOR_BOUNDS_CHECK "Enable per access bounds checking" OFF)
 option(GTENSOR_ADDRESS_CHECK "Enable address checking for device spans" OFF)
 option(GTENSOR_SYNC_KERNELS "Enable host sync after assign and launch kernels" OFF)
+
+if (GTENSOR_ENABLE_FORTRAN)
+  # do this early (here) since later the `enable_language(Fortran)` gives me trouble
+  message(STATUS "${PROJECT_NAME}: Fortran is ENABLED")
+  enable_language(Fortran)
+endif()
 
 # HIP specific configuration
 set(HIP_GCC_TOOLCHAIN "" CACHE STRING "pass gcc-toolchain option to hipcc")
@@ -442,6 +449,32 @@ if (GTENSOR_ENABLE_FFT)
   add_library(gtensor::gtfft ALIAS gtfft)
 endif()
 
+if (GTENSOR_ENABLE_FORTRAN)
+  # message(STATUS "${PROJECT_NAME}: Fortran is ENABLED")
+  # enable_language(Fortran)
+  CPMAddPackage(
+    NAME flcl
+    GITHUB_REPOSITORY kokkos/kokkos-fortran-interop
+    GIT_TAG develop
+    VERSION 0.99
+    DOWNLOAD_ONLY TRUE)
+
+  add_library(fgtensor)
+  target_sources(fgtensor PRIVATE
+    ${flcl_SOURCE_DIR}/src/flcl-types-f.f90
+    ${flcl_SOURCE_DIR}/src/flcl-ndarray-f.f90)
+  set_target_properties(fgtensor PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/fortran)
+  target_include_directories(fgtensor
+    INTERFACE
+       $<INSTALL_INTERFACE:include/gtensor/fortran>
+       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/fortran>
+  )
+  target_link_libraries(fgtensor PUBLIC gtensor)
+
+  list(APPEND GTENSOR_TARGETS fgtensor)
+  add_library(gtensor::fgtensor ALIAS fgtensor)
+endif()
+
 # See https://github.com/pabloariasal/modern-cmake-sample
 ##############################################
 # Installation instructions
@@ -456,6 +489,9 @@ install(TARGETS ${GTENSOR_TARGETS}
 )
 
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if (GTENSOR_ENABLE_FORTRAN)
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/fortran DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gtensor)
+endif()
 
 #Export the targets to a script
 install(EXPORT gtensor-targets

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,6 +8,10 @@ option(GTENSOR_EXAMPLES_USE_FIND_PACKAGE,
     "when ON, use find_package, when OFF use a copy of gtensor as subdir"
     OFF)
 
+if (GTENSOR_ENABLE_FORTRAN)
+  enable_language(Fortran)
+endif()
+
 # support building as a subdirectory of the main project, or
 # as an independent project with gtensor installed or gtensor
 # as a subdirectory
@@ -62,4 +66,9 @@ if ("${GTENSOR_DEVICE}" STREQUAL "cuda")
   add_executable(trig_adapted)
   target_gtensor_sources(trig_adapted PRIVATE src/trig_adapted.cxx)
   target_link_libraries(trig_adapted gtensor::gtensor)
+endif()
+
+if (GTENSOR_ENABLE_FORTRAN)
+  add_executable(test_fortran src/test_fortran.F90 src/c_test_fortran.cxx)
+  target_link_libraries(test_fortran PRIVATE gtensor::fgtensor)
 endif()

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -53,12 +53,29 @@ GTENSOR_TARGETS = daxpy stencil1d mult_table
 ifeq ($(GTENSOR_DEVICE),cuda)
   GTENSOR_TARGETS += trig_adapted
 endif
+ifneq ($(GTENSOR_ENABLE_FORTRAN),)
+  FC := gfortran
+  FCFLAGS := -I$(GTENSOR_DIR)/include/gtensor/fortran
+  FLIBS := $(shell $(FC) --print-file-name=libgfortran.dylib)
+  FLIBS += $(shell $(FC) --print-libgcc-file-name)
+  GTENSOR_LIBS += $(GTENSOR_DIR)/lib/libfgtensor.a
+  GTENSOR_TARGETS += test_fortran
+endif
 
 .PHONY: all
 all: $(GTENSOR_TARGETS)
 
-$(GTENSOR_TARGETS): % : src/%.cxx $(GTENSOR_HEADERS)
+% : src/%.cxx $(GTENSOR_HEADERS)
 	$(GTENSOR_CXX) $(GTENSOR_FLAGS) -o $@ $<
+
+test_fortran: src/test_fortran.o src/c_test_fortran.o
+	$(GTENSOR_CXX) $^ $(FLIBS) $(GTENSOR_LIBS) -o $@
+
+src/%.o: src/%.F90
+	$(FC) $(FCFLAGS) -c $< -o $@
+
+src/%.o: src/%.cxx
+	$(GTENSOR_CXX) $(GTENSOR_FLAGS) -c $< -o $@
 
 .PHONY: clean
 clean:

--- a/examples/src/c_test_fortran.cxx
+++ b/examples/src/c_test_fortran.cxx
@@ -1,0 +1,12 @@
+
+#include <gtensor/fortran.h>
+
+#include <iostream>
+
+extern "C" void c_test_arr2d(flcl_ndarray<const float>* nd_arr)
+{
+  auto arr = gt::adapt<2>(nd_arr);
+
+  std::cout << "arr " << arr.shape() << "\n";
+  std::cout << arr << "\n";
+}

--- a/examples/src/test_fortran.F90
+++ b/examples/src/test_fortran.F90
@@ -1,0 +1,47 @@
+
+module test_fortran_m
+   use, intrinsic :: iso_c_binding
+   use :: flcl_ndarray_mod
+   implicit none
+
+   private
+   public :: f_test_arr2d
+
+   interface
+      subroutine c_test_arr2d(arr) bind(c)
+         import
+         type(nd_array_t) :: arr
+      end subroutine c_test_arr2d
+   end interface
+
+contains
+
+   subroutine f_test_arr2d(arr)
+      real, dimension(:,:) :: arr
+
+      call c_test_arr2d(to_nd_array(arr))
+   end subroutine f_test_arr2d
+
+end module test_fortran_m
+
+program main
+   use :: test_fortran_m
+   implicit none
+
+   integer, parameter :: ni = 4, nj = 3
+   real :: arr2d(ni, nj)
+   integer :: i, j
+
+   print *, shape(arr2d)
+   do j = 1, nj
+      do i = 1, ni
+         arr2d(i, j) = i + 10 * j
+      end do
+   end do
+
+   print *, 'arr2d', arr2d
+   call f_test_arr2d(arr2d)
+
+   print *, 'arr2d(3:4, 1:2)', arr2d(3:4, 1:2)
+   call f_test_arr2d(arr2d(3:4, 1:2))
+end program

--- a/include/gtensor/fortran.h
+++ b/include/gtensor/fortran.h
@@ -1,0 +1,40 @@
+
+#pragma once
+
+#include <gtensor/fortran/flcl.h>
+#include <gtensor/gtensor.h>
+
+namespace gt
+{
+
+namespace detail
+{
+
+template <std::size_t N>
+auto to_shape(const flcl_ndarray_index_c_t* shape_in)
+{
+  shape_type<N> shape;
+  for (std::size_t i = 0; i < N; i++) {
+    shape[i] = shape_in[i];
+  }
+  return shape;
+}
+
+} // namespace detail
+
+template <std::size_t N, typename T, typename S = space::host>
+gtensor_span<T, N> adapt(const flcl_ndarray<T>* nd)
+{
+  assert(nd->rank == N);
+  return gtensor_span<T, N>(static_cast<T*>(nd->data),
+                            detail::to_shape<N>(nd->dims),
+                            detail::to_shape<N>(nd->strides));
+}
+
+template <std::size_t N, typename T>
+gtensor_span<T, N> adapt_device(const flcl_ndarray<T>* nd)
+{
+  return adapt<N, T, space::device>(nd);
+}
+
+} // namespace gt

--- a/include/gtensor/fortran/flcl.h
+++ b/include/gtensor/fortran/flcl.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S. Department of Energy/National Nuclear
+// Security Administration. All rights in the program are reserved by Triad
+// National Security, LLC, and the U.S. Department of Energy/National Nuclear
+// Security Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide license
+// in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do
+// so.
+//
+// This program is open source under the BSD-3 License.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the
+//   names of its contributors may be used to endorse or promote products
+//   derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef FLCL_H
+#define FLCL_H
+
+#include <cstddef>
+
+#define FLCL_NDARRAY_MAX_RANK 8
+
+using flcl_ndarray_index_c_t = std::size_t;
+
+template <typename T>
+struct flcl_ndarray
+{
+  flcl_ndarray_index_c_t rank;
+  flcl_ndarray_index_c_t dims[FLCL_NDARRAY_MAX_RANK];
+  flcl_ndarray_index_c_t strides[FLCL_NDARRAY_MAX_RANK];
+  T* data;
+};
+
+#endif // FLCL_H


### PR DESCRIPTION
This is basd on kokkos, essentially using their way of passing Fortran arrays (including non-contiguous ones). Adapted to create `gtensor_span` on the C++ side.