### PR TITLE
cmake: don't support old-style buildtree export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,13 +487,3 @@ install(FILES
     cmake/target-gtensor-sources-macro.cmake
     DESTINATION ${INSTALL_CONFIGDIR}
 )
-
-##############################################
-## Exporting from the build tree
-
-export(EXPORT gtensor-targets
-    FILE ${CMAKE_CURRENT_BINARY_DIR}/gtensor-targets.cmake
-    NAMESPACE gtensor::)
-
-#Register package in user's package registry
-export(PACKAGE gtensor)


### PR DESCRIPTION
I don't know anyone who's ever used this, and we already support regular installs as well as `add_subdirectory()`, which should suffice.

In particular this causes hassles integrating with other projects via `add_subdirectory()` that don't support buildtree export.