### PR TITLE
add some support for running in host-only mode

### DIFF
--- a/include/gtensor/backend_common.h
+++ b/include/gtensor/backend_common.h
@@ -26,6 +26,14 @@ namespace gt
 namespace backend
 {
 
+enum class memory_type
+{
+  host,
+  device,
+  managed,
+  unregistered,
+};
+
 // ======================================================================
 // library wide configuration
 

--- a/include/gtensor/backend_common.h
+++ b/include/gtensor/backend_common.h
@@ -293,6 +293,9 @@ struct selector
 
 } // namespace allocator_impl
 
+template <typename S>
+class backend_ops;
+
 // ======================================================================
 // prefetch interface
 

--- a/include/gtensor/backend_common.h
+++ b/include/gtensor/backend_common.h
@@ -296,15 +296,6 @@ struct selector
 template <typename S>
 class backend_ops;
 
-// ======================================================================
-// prefetch interface
-
-template <typename T>
-void prefetch_device(T* p, size_type n);
-
-template <typename T>
-void prefetch_host(T* p, size_type n);
-
 } // namespace backend
 
 } // namespace gt

--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -188,7 +188,7 @@ public:
   }
 
   template <typename Ptr>
-  static bool is_device_address(const Ptr p)
+  static bool is_device_accessible(const Ptr p)
   {
     cudaPointerAttributes attr;
     cudaError_t rval = cudaPointerGetAttributes(&attr, p);

--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -214,7 +214,9 @@ public:
       case cudaMemoryTypeHost: return memory_type::host;
       case cudaMemoryTypeDevice: return memory_type::device;
       case cudaMemoryTypeManaged: return memory_type::managed;
-      default: assert(0);
+      default:
+        fprintf(stderr, "ERROR: unknown memoryType %d.\n", attr.type);
+        std::abort();
     }
     return static_cast<memory_type>(attr.type);
   }

--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -198,18 +198,23 @@ inline void fill(gt::space::cuda tag, Ptr first, Ptr last, const T& value)
 }
 } // namespace fill_impl
 
-template <typename Ptr>
-inline bool is_device_address(const Ptr p)
+template <>
+class backend_ops<gt::space::cuda>
 {
-  cudaPointerAttributes attr;
-  cudaError_t rval = cudaPointerGetAttributes(&attr, p);
-  if (rval == cudaErrorInvalidValue) {
-    return false;
+public:
+  template <typename Ptr>
+  static bool is_device_address(const Ptr p)
+  {
+    cudaPointerAttributes attr;
+    cudaError_t rval = cudaPointerGetAttributes(&attr, p);
+    if (rval == cudaErrorInvalidValue) {
+      return false;
+    }
+    gtGpuCheck(rval);
+    return (attr.type == cudaMemoryTypeDevice ||
+            attr.type == cudaMemoryTypeManaged);
   }
-  gtGpuCheck(rval);
-  return (attr.type == cudaMemoryTypeDevice ||
-          attr.type == cudaMemoryTypeManaged);
-}
+};
 
 namespace stream_interface
 {

--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -214,6 +214,21 @@ public:
     return (attr.type == cudaMemoryTypeDevice ||
             attr.type == cudaMemoryTypeManaged);
   }
+
+  template <typename T>
+  static void prefetch_device(T* p, size_type n)
+  {
+    int device_id;
+    gtGpuCheck(cudaGetDevice(&device_id));
+    gtGpuCheck(cudaMemPrefetchAsync(p, n * sizeof(T), device_id, nullptr));
+  }
+
+  template <typename T>
+  static void prefetch_host(T* p, size_type n)
+  {
+    gtGpuCheck(
+      cudaMemPrefetchAsync(p, n * sizeof(T), cudaCpuDeviceId, nullptr));
+  }
 };
 
 namespace stream_interface
@@ -263,23 +278,6 @@ public:
 };
 
 } // namespace stream_interface
-
-// ======================================================================
-// prefetch
-
-template <typename T>
-void prefetch_device(T* p, size_type n)
-{
-  int device_id;
-  gtGpuCheck(cudaGetDevice(&device_id));
-  gtGpuCheck(cudaMemPrefetchAsync(p, n * sizeof(T), device_id, nullptr));
-}
-
-template <typename T>
-void prefetch_host(T* p, size_type n)
-{
-  gtGpuCheck(cudaMemPrefetchAsync(p, n * sizeof(T), cudaCpuDeviceId, nullptr));
-}
 
 } // namespace backend
 

--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -84,56 +84,6 @@ struct gallocator<gt::space::cuda_host>
 
 } // namespace allocator_impl
 
-namespace cuda
-{
-
-inline void device_synchronize()
-{
-  gtGpuCheck(cudaStreamSynchronize(0));
-}
-
-template <typename T>
-inline void device_copy_async_dd(const T* src, T* dst, size_type count)
-{
-  gtGpuCheck(
-    cudaMemcpyAsync(dst, src, sizeof(T) * count, cudaMemcpyDeviceToDevice));
-}
-
-inline int device_get_count()
-{
-  int device_count;
-  gtGpuCheck(cudaGetDeviceCount(&device_count));
-  return device_count;
-}
-
-inline void device_set(int device_id)
-{
-  gtGpuCheck(cudaSetDevice(device_id));
-}
-
-inline int device_get()
-{
-  int device_id;
-  gtGpuCheck(cudaGetDevice(&device_id));
-  return device_id;
-}
-
-inline uint32_t device_get_vendor_id(int device_id)
-{
-  cudaDeviceProp prop;
-  uint32_t packed = 0;
-
-  gtGpuCheck(cudaGetDeviceProperties(&prop, device_id));
-
-  packed |= (0x000000FF & ((uint32_t)prop.pciDeviceID));
-  packed |= (0x0000FF00 & (((uint32_t)prop.pciBusID) << 8));
-  packed |= (0xFFFF0000 & (((uint32_t)prop.pciDomainID) << 16));
-
-  return packed;
-}
-
-} // namespace cuda
-
 namespace copy_impl
 {
 
@@ -202,6 +152,41 @@ template <>
 class backend_ops<gt::space::cuda>
 {
 public:
+  static void device_synchronize() { gtGpuCheck(cudaStreamSynchronize(0)); }
+
+  static int device_get_count()
+  {
+    int device_count;
+    gtGpuCheck(cudaGetDeviceCount(&device_count));
+    return device_count;
+  }
+
+  static void device_set(int device_id)
+  {
+    gtGpuCheck(cudaSetDevice(device_id));
+  }
+
+  static int device_get()
+  {
+    int device_id;
+    gtGpuCheck(cudaGetDevice(&device_id));
+    return device_id;
+  }
+
+  static uint32_t device_get_vendor_id(int device_id)
+  {
+    cudaDeviceProp prop;
+    uint32_t packed = 0;
+
+    gtGpuCheck(cudaGetDeviceProperties(&prop, device_id));
+
+    packed |= (0x000000FF & ((uint32_t)prop.pciDeviceID));
+    packed |= (0x0000FF00 & (((uint32_t)prop.pciBusID) << 8));
+    packed |= (0xFFFF0000 & (((uint32_t)prop.pciDomainID) << 16));
+
+    return packed;
+  }
+
   template <typename Ptr>
   static bool is_device_address(const Ptr p)
   {
@@ -247,6 +232,13 @@ public:
   {
     gtGpuCheck(
       cudaMemPrefetchAsync(p, n * sizeof(T), cudaCpuDeviceId, nullptr));
+  }
+
+  template <typename T>
+  static void copy_async_dd(const T* src, T* dst, size_type count)
+  {
+    gtGpuCheck(
+      cudaMemcpyAsync(dst, src, sizeof(T) * count, cudaMemcpyDeviceToDevice));
   }
 };
 

--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -215,6 +215,25 @@ public:
             attr.type == cudaMemoryTypeManaged);
   }
 
+  template <typename Ptr>
+  static memory_type get_memory_type(Ptr ptr)
+  {
+    cudaPointerAttributes attr;
+    auto rc = cudaPointerGetAttributes(&attr, ptr);
+    if (rc == cudaErrorInvalidValue) {
+      cudaGetLastError(); // clear the error
+      return memory_type::unregistered;
+    }
+    gtGpuCheck(rc);
+    switch (attr.type) {
+      case cudaMemoryTypeHost: return memory_type::host;
+      case cudaMemoryTypeDevice: return memory_type::device;
+      case cudaMemoryTypeManaged: return memory_type::managed;
+      default: assert(0);
+    }
+    return static_cast<memory_type>(attr.type);
+  }
+
   template <typename T>
   static void prefetch_device(T* p, size_type n)
   {

--- a/include/gtensor/backend_hip.h
+++ b/include/gtensor/backend_hip.h
@@ -226,7 +226,9 @@ public:
       case hipMemoryTypeHost: return memory_type::host;
       case hipMemoryTypeDevice: return memory_type::device;
       case hipMemoryTypeUnified: return memory_type::managed;
-      default: assert(0);
+      default:
+        fprintf(stderr, "ERROR: unknown memoryType %d.\n", attr.memoryType);
+        std::abort();
     }
   }
 

--- a/include/gtensor/backend_hip.h
+++ b/include/gtensor/backend_hip.h
@@ -226,6 +226,20 @@ public:
     gtGpuCheck(rval);
     return (attr.memoryType == hipMemoryTypeDevice || attr.isManaged);
   }
+
+  template <typename T>
+  static void prefetch_device(T* p, size_type n)
+  {
+    int device_id;
+    gtGpuCheck(hipGetDevice(&device_id));
+    gtGpuCheck(hipMemPrefetchAsync(p, n * sizeof(T), device_id, nullptr));
+  }
+
+  template <typename T>
+  static void prefetch_host(T* p, size_type n)
+  {
+    gtGpuCheck(hipMemPrefetchAsync(p, n * sizeof(T), hipCpuDeviceId, nullptr));
+  }
 };
 
 namespace stream_interface
@@ -275,23 +289,6 @@ public:
 };
 
 } // namespace stream_interface
-
-// ======================================================================
-// prefetch
-
-template <typename T>
-void prefetch_device(T* p, size_type n)
-{
-  int device_id;
-  gtGpuCheck(hipGetDevice(&device_id));
-  gtGpuCheck(hipMemPrefetchAsync(p, n * sizeof(T), device_id, nullptr));
-}
-
-template <typename T>
-void prefetch_host(T* p, size_type n)
-{
-  gtGpuCheck(hipMemPrefetchAsync(p, n * sizeof(T), hipCpuDeviceId, nullptr));
-}
 
 } // namespace backend
 

--- a/include/gtensor/backend_hip.h
+++ b/include/gtensor/backend_hip.h
@@ -227,6 +227,27 @@ public:
     return (attr.memoryType == hipMemoryTypeDevice || attr.isManaged);
   }
 
+  template <typename Ptr>
+  static memory_type get_memory_type(const Ptr ptr)
+  {
+    hipPointerAttribute_t attr;
+    auto rc = hipPointerGetAttributes(&attr, ptr);
+    if (rc == hipErrorInvalidValue) {
+      hipGetLastError(); // clear the error
+      return memory_type::unregistered;
+    }
+    gtGpuCheck(rc);
+    if (attr.isManaged) {
+      return memory_type::managed;
+    }
+    switch (attr.memoryType) {
+      case hipMemoryTypeHost: return memory_type::host;
+      case hipMemoryTypeDevice: return memory_type::device;
+      case hipMemoryTypeUnified: return memory_type::managed;
+      default: assert(0);
+    }
+  }
+
   template <typename T>
   static void prefetch_device(T* p, size_type n)
   {

--- a/include/gtensor/backend_hip.h
+++ b/include/gtensor/backend_hip.h
@@ -211,17 +211,22 @@ inline void fill(gt::space::hip tag, Ptr first, Ptr last, const T& value)
 }
 } // namespace fill_impl
 
-template <typename Ptr>
-inline bool is_device_address(const Ptr p)
+template <>
+class backend_ops<gt::space::hip>
 {
-  hipPointerAttribute_t attr;
-  hipError_t rval = hipPointerGetAttributes(&attr, p);
-  if (rval == hipErrorInvalidValue) {
-    return false;
+public:
+  template <typename Ptr>
+  static bool is_device_address(const Ptr p)
+  {
+    hipPointerAttribute_t attr;
+    hipError_t rval = hipPointerGetAttributes(&attr, p);
+    if (rval == hipErrorInvalidValue) {
+      return false;
+    }
+    gtGpuCheck(rval);
+    return (attr.memoryType == hipMemoryTypeDevice || attr.isManaged);
   }
-  gtGpuCheck(rval);
-  return (attr.memoryType == hipMemoryTypeDevice || attr.isManaged);
-}
+};
 
 namespace stream_interface
 {

--- a/include/gtensor/backend_hip.h
+++ b/include/gtensor/backend_hip.h
@@ -198,7 +198,7 @@ public:
   }
 
   template <typename Ptr>
-  static bool is_device_address(const Ptr p)
+  static bool is_device_accessible(const Ptr p)
   {
     hipPointerAttribute_t attr;
     hipError_t rval = hipPointerGetAttributes(&attr, p);

--- a/include/gtensor/backend_host.h
+++ b/include/gtensor/backend_host.h
@@ -46,6 +46,22 @@ inline uint32_t device_get_vendor_id(int device_id)
 
 namespace allocator_impl
 {
+template <>
+struct gallocator<gt::space::host_only>
+{
+  template <typename T>
+  static T* allocate(size_type n)
+  {
+    return static_cast<T*>(malloc(sizeof(T) * n));
+  }
+
+  template <typename T>
+  static void deallocate(T* p)
+  {
+    free(p);
+  }
+};
+
 template <typename T>
 struct selector<T, gt::space::host_only>
 {

--- a/include/gtensor/backend_host.h
+++ b/include/gtensor/backend_host.h
@@ -14,40 +14,20 @@ namespace gt
 namespace backend
 {
 
-namespace host
-{
-
-inline void device_synchronize()
-{
-  // no need to synchronize on host
-}
-
-inline int device_get_count()
-{
-  return 1;
-}
-
-inline void device_set(int device_id)
-{
-  assert(device_id == 0);
-}
-
-inline int device_get()
-{
-  return 0;
-}
-
-inline uint32_t device_get_vendor_id(int device_id)
-{
-  return 0;
-}
-
-} // namespace host
-
 template <>
 class backend_ops<gt::space::host>
 {
 public:
+  static void device_synchronize() {}
+
+  static int device_get_count() { return 1; }
+
+  static void device_set(int device_id) { assert(device_id == 0); }
+
+  static int device_get() { return 0; }
+
+  static uint32_t device_get_vendor_id(int device_id) { return 0; }
+
   template <typename Ptr>
   static bool is_device_address(const Ptr p)
   {

--- a/include/gtensor/backend_host.h
+++ b/include/gtensor/backend_host.h
@@ -53,6 +53,14 @@ public:
   {
     return true;
   }
+
+  template <typename T>
+  static void prefetch_device(T* p, size_type n)
+  {}
+
+  template <typename T>
+  static void prefetch_host(T* p, size_type n)
+  {}
 };
 
 namespace allocator_impl

--- a/include/gtensor/backend_host.h
+++ b/include/gtensor/backend_host.h
@@ -44,6 +44,17 @@ inline uint32_t device_get_vendor_id(int device_id)
 
 } // namespace host
 
+template <>
+class backend_ops<gt::space::host>
+{
+public:
+  template <typename Ptr>
+  static bool is_device_address(const Ptr p)
+  {
+    return true;
+  }
+};
+
 namespace allocator_impl
 {
 template <>

--- a/include/gtensor/backend_host.h
+++ b/include/gtensor/backend_host.h
@@ -29,7 +29,7 @@ public:
   static uint32_t device_get_vendor_id(int device_id) { return 0; }
 
   template <typename Ptr>
-  static bool is_device_address(const Ptr p)
+  static bool is_device_accessible(const Ptr p)
   {
     return true;
   }

--- a/include/gtensor/backend_host.h
+++ b/include/gtensor/backend_host.h
@@ -54,6 +54,12 @@ public:
     return true;
   }
 
+  template <typename Ptr>
+  static memory_type get_memory_type(const Ptr ptr)
+  {
+    return memory_type::host;
+  }
+
   template <typename T>
   static void prefetch_device(T* p, size_type n)
   {}

--- a/include/gtensor/backend_host.h
+++ b/include/gtensor/backend_host.h
@@ -22,6 +22,26 @@ inline void device_synchronize()
   // no need to synchronize on host
 }
 
+inline int device_get_count()
+{
+  return 1;
+}
+
+inline void device_set(int device_id)
+{
+  assert(device_id == 0);
+}
+
+inline int device_get()
+{
+  return 0;
+}
+
+inline uint32_t device_get_vendor_id(int device_id)
+{
+  return 0;
+}
+
 } // namespace host
 
 namespace allocator_impl

--- a/include/gtensor/backend_sycl.h
+++ b/include/gtensor/backend_sycl.h
@@ -252,6 +252,20 @@ public:
             alloc_type == ::sycl::usm::alloc::shared);
   }
 
+  template <typename Ptr>
+  static memory_type get_memory_type(const Ptr ptr)
+  {
+    cl::sycl::queue& q = gt::backend::sycl::get_queue();
+    auto alloc_type = ::sycl::get_pointer_type(p, q.get_context());
+    switch (alloctype) {
+      case ::sycl::usm::alloc::host: return memory_type::host;
+      case ::sycl::usm::alloc::device: return memory_type::device;
+      case ::sycl::usm::alloc::shared: return memory_type::managed;
+      case ::sycl::usm::alloc::unkown: return memory_type::unregisered;
+      default: assert(0);
+    }
+  }
+
   template <typename T>
   static void prefetch_device(T* p, size_type n)
   {

--- a/include/gtensor/backend_sycl.h
+++ b/include/gtensor/backend_sycl.h
@@ -211,33 +211,37 @@ template <>
 class backend_ops<gt::space::sycl>
 {
 public:
-  static void device_synchronize() { get_queue().wait(); }
+  static void device_synchronize() { gt::backend::sycl::get_queue().wait(); }
 
   static int device_get_count()
   {
-    return device::get_sycl_queues_instance().get_device_count();
+    return gt::backend::sycl::device::get_sycl_queues_instance()
+      .get_device_count();
   }
 
   static void device_set(int device_id)
   {
-    device::get_sycl_queues_instance().set_device_id(device_id);
+    gt::backend::sycl::device::get_sycl_queues_instance().set_device_id(
+      device_id);
   }
 
   static int device_get()
   {
-    return device::get_sycl_queues_instance().get_device_id();
+    return gt::backend::sycl::device::get_sycl_queues_instance()
+      .get_device_id();
   }
 
   static uint32_t device_get_vendor_id(int device_id)
   {
-    return device::get_sycl_queues_instance().get_device_vendor_id(device_id);
+    return gt::backend::sycl::device::get_sycl_queues_instance()
+      .get_device_vendor_id(device_id);
   }
 
   template <typename Ptr>
-  static bool is_device_accessible(const Ptr p)
+  static bool is_device_accessible(const Ptr ptr)
   {
-    cl::sycl::queue& q = gt::backend::sycl::get_queue();
-    auto alloc_type = ::sycl::get_pointer_type(p, q.get_context());
+    auto& q = gt::backend::sycl::get_queue();
+    auto alloc_type = ::sycl::get_pointer_type(ptr, q.get_context());
     return (alloc_type == ::sycl::usm::alloc::device ||
             alloc_type == ::sycl::usm::alloc::shared);
   }
@@ -245,13 +249,13 @@ public:
   template <typename Ptr>
   static memory_type get_memory_type(const Ptr ptr)
   {
-    cl::sycl::queue& q = gt::backend::sycl::get_queue();
-    auto alloc_type = ::sycl::get_pointer_type(p, q.get_context());
-    switch (alloctype) {
+    auto& q = gt::backend::sycl::get_queue();
+    auto alloc_type = ::sycl::get_pointer_type(ptr, q.get_context());
+    switch (alloc_type) {
       case ::sycl::usm::alloc::host: return memory_type::host;
       case ::sycl::usm::alloc::device: return memory_type::device;
       case ::sycl::usm::alloc::shared: return memory_type::managed;
-      case ::sycl::usm::alloc::unkown: return memory_type::unregisered;
+      case ::sycl::usm::alloc::unknown: return memory_type::unregistered;
       default: assert(0);
     }
   }
@@ -259,7 +263,7 @@ public:
   template <typename T>
   static void prefetch_device(T* p, size_type n)
   {
-    ::sycl::queue& q = gt::backend::sycl::get_queue();
+    auto& q = gt::backend::sycl::get_queue();
     q.prefetch(p, n);
   }
 
@@ -271,7 +275,7 @@ public:
   template <typename T>
   static void copy_async_dd(const T* src, T* dst, size_type count)
   {
-    cl::sycl::queue& q = get_queue();
+    auto& q = gt::backend::sycl::get_queue();
     q.memcpy(dst, src, sizeof(T) * count);
   }
 };

--- a/include/gtensor/backend_sycl.h
+++ b/include/gtensor/backend_sycl.h
@@ -234,7 +234,7 @@ public:
   }
 
   template <typename Ptr>
-  static bool is_device_address(const Ptr p)
+  static bool is_device_accessible(const Ptr p)
   {
     cl::sycl::queue& q = gt::backend::sycl::get_queue();
     auto alloc_type = ::sycl::get_pointer_type(p, q.get_context());

--- a/include/gtensor/backend_sycl.h
+++ b/include/gtensor/backend_sycl.h
@@ -251,6 +251,18 @@ public:
     return (alloc_type == ::sycl::usm::alloc::device ||
             alloc_type == ::sycl::usm::alloc::shared);
   }
+
+  template <typename T>
+  static void prefetch_device(T* p, size_type n)
+  {
+    ::sycl::queue& q = gt::backend::sycl::get_queue();
+    q.prefetch(p, n);
+  }
+
+  // Not available in SYCL 2020, make it a no-op
+  template <typename T>
+  static void prefetch_host(T* p, size_type n)
+  {}
 };
 
 namespace stream_interface
@@ -289,22 +301,6 @@ inline void synchronize<sycl_stream_t>(sycl_stream_t s)
 }
 
 } // namespace stream_interface
-
-// ======================================================================
-// prefetch
-
-template <typename T>
-void prefetch_device(T* p, size_type n)
-{
-  ::sycl::queue& q = gt::backend::sycl::get_queue();
-  q.prefetch(p, n);
-}
-
-// Not available in SYCL 2020, make it a no-op
-template <typename T>
-void prefetch_host(T* p, size_type n)
-{
-}
 
 } // namespace backend
 

--- a/include/gtensor/backend_sycl.h
+++ b/include/gtensor/backend_sycl.h
@@ -36,38 +36,6 @@ namespace backend
 namespace sycl
 {
 
-inline void device_synchronize()
-{
-  get_queue().wait();
-}
-
-inline int device_get_count()
-{
-  return device::get_sycl_queues_instance().get_device_count();
-}
-
-inline void device_set(int device_id)
-{
-  device::get_sycl_queues_instance().set_device_id(device_id);
-}
-
-inline int device_get()
-{
-  return device::get_sycl_queues_instance().get_device_id();
-}
-
-inline uint32_t device_get_vendor_id(int device_id)
-{
-  return device::get_sycl_queues_instance().get_device_vendor_id(device_id);
-}
-
-template <typename T>
-inline void device_copy_async_dd(const T* src, T* dst, size_type count)
-{
-  cl::sycl::queue& q = get_queue();
-  q.memcpy(dst, src, sizeof(T) * count);
-}
-
 // kernel name templates
 template <typename E1, typename E2, typename K1, typename K2>
 class Assign1;
@@ -243,6 +211,28 @@ template <>
 class backend_ops<gt::space::sycl>
 {
 public:
+  static void device_synchronize() { get_queue().wait(); }
+
+  static int device_get_count()
+  {
+    return device::get_sycl_queues_instance().get_device_count();
+  }
+
+  static void device_set(int device_id)
+  {
+    device::get_sycl_queues_instance().set_device_id(device_id);
+  }
+
+  static int device_get()
+  {
+    return device::get_sycl_queues_instance().get_device_id();
+  }
+
+  static uint32_t device_get_vendor_id(int device_id)
+  {
+    return device::get_sycl_queues_instance().get_device_vendor_id(device_id);
+  }
+
   template <typename Ptr>
   static bool is_device_address(const Ptr p)
   {
@@ -277,6 +267,13 @@ public:
   template <typename T>
   static void prefetch_host(T* p, size_type n)
   {}
+
+  template <typename T>
+  static void copy_async_dd(const T* src, T* dst, size_type count)
+  {
+    cl::sycl::queue& q = get_queue();
+    q.memcpy(dst, src, sizeof(T) * count);
+  }
 };
 
 namespace stream_interface

--- a/include/gtensor/backend_sycl.h
+++ b/include/gtensor/backend_sycl.h
@@ -256,7 +256,9 @@ public:
       case ::sycl::usm::alloc::device: return memory_type::device;
       case ::sycl::usm::alloc::shared: return memory_type::managed;
       case ::sycl::usm::alloc::unknown: return memory_type::unregistered;
-      default: assert(0);
+      default:
+        fprintf(stderr, "ERROR: unknown memoryType %d.\n", alloc_type);
+        std::abort();
     }
   }
 

--- a/include/gtensor/backend_sycl.h
+++ b/include/gtensor/backend_sycl.h
@@ -239,14 +239,19 @@ inline void fill(gt::space::sycl tag, Ptr first, Ptr last, const T& value)
 
 } // namespace fill_impl
 
-template <typename Ptr>
-inline bool is_device_address(const Ptr p)
+template <>
+class backend_ops<gt::space::sycl>
 {
-  cl::sycl::queue& q = gt::backend::sycl::get_queue();
-  auto alloc_type = ::sycl::get_pointer_type(p, q.get_context());
-  return (alloc_type == ::sycl::usm::alloc::device ||
-          alloc_type == ::sycl::usm::alloc::shared);
-}
+public:
+  template <typename Ptr>
+  static bool is_device_address(const Ptr p)
+  {
+    cl::sycl::queue& q = gt::backend::sycl::get_queue();
+    auto alloc_type = ::sycl::get_pointer_type(p, q.get_context());
+    return (alloc_type == ::sycl::usm::alloc::device ||
+            alloc_type == ::sycl::usm::alloc::shared);
+  }
+};
 
 namespace stream_interface
 {
@@ -298,7 +303,8 @@ void prefetch_device(T* p, size_type n)
 // Not available in SYCL 2020, make it a no-op
 template <typename T>
 void prefetch_host(T* p, size_type n)
-{}
+{
+}
 
 } // namespace backend
 

--- a/include/gtensor/capi.h
+++ b/include/gtensor/capi.h
@@ -43,7 +43,9 @@ void gt_backend_memcpy_hd(void* dst, const void* src, size_t nbytes);
 
 void gt_backend_memset(void* dst, int value, size_t nbytes);
 
-bool gt_backend_is_device_address(void* p);
+bool gt_backend_is_device_accessible(void* p);
+[[deprecated("use gt_backend_is_device_accessible() instead")]] bool
+gt_backend_is_device_address(void* p);
 
 void gt_backend_prefetch_device(void* p, size_t nbytes);
 void gt_backend_prefetch_host(void* p, size_t nbytes);

--- a/include/gtensor/capi.h
+++ b/include/gtensor/capi.h
@@ -26,14 +26,14 @@ void gt_backend_device_set(int device_id);
 int gt_backend_device_get();
 uint32_t gt_backend_device_get_vendor_id(int device_id);
 
-#ifdef GTENSOR_HAVE_DEVICE
-
 void* gt_backend_host_allocate(size_t nbytes);
 void* gt_backend_device_allocate(size_t nbytes);
 void* gt_backend_managed_allocate(size_t nbytes);
 void gt_backend_host_deallocate(void* p);
 void gt_backend_device_deallocate(void* p);
 void gt_backend_managed_deallocate(void* p);
+
+#ifdef GTENSOR_HAVE_DEVICE
 
 void gt_backend_memcpy_hh(void* dst, const void* src, size_t nbytes);
 void gt_backend_memcpy_dd(void* dst, const void* src, size_t nbytes);

--- a/include/gtensor/capi.h
+++ b/include/gtensor/capi.h
@@ -43,14 +43,14 @@ void gt_backend_memcpy_hd(void* dst, const void* src, size_t nbytes);
 
 void gt_backend_memset(void* dst, int value, size_t nbytes);
 
+#endif // GTENSOR_HAVE_DEVICE
+
 bool gt_backend_is_device_accessible(void* p);
 [[deprecated("use gt_backend_is_device_accessible() instead")]] bool
 gt_backend_is_device_address(void* p);
 
 void gt_backend_prefetch_device(void* p, size_t nbytes);
 void gt_backend_prefetch_host(void* p, size_t nbytes);
-
-#endif // GTENSOR_HAVE_DEVICE
 
 #ifdef __cplusplus
 }

--- a/include/gtensor/capi.h
+++ b/include/gtensor/capi.h
@@ -21,12 +21,12 @@ extern "C" {
 
 void gt_synchronize();
 
-#ifdef GTENSOR_HAVE_DEVICE
-
 int gt_backend_device_get_count();
 void gt_backend_device_set(int device_id);
 int gt_backend_device_get();
 uint32_t gt_backend_device_get_vendor_id(int device_id);
+
+#ifdef GTENSOR_HAVE_DEVICE
 
 void* gt_backend_host_allocate(size_t nbytes);
 void* gt_backend_device_allocate(size_t nbytes);

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -27,13 +27,13 @@ template <typename S>
 using gallocator = gt::backend::allocator_impl::gallocator<S>;
 
 #if GTENSOR_DEVICE_CUDA
-using backend_ops_clib = backend_ops<gt::space::cuda>;
+using clib = backend_ops<gt::space::cuda>;
 #elif GTENSOR_DEVICE_HIP
-using backend_ops_clib = backend_ops<gt::space::hip>;
+using clib = backend_ops<gt::space::hip>;
 #elif GTENSOR_DEVICE_SYCL
-using backend_ops_clib = backend_ops<gt::space::sycl>;
+using clib = backend_ops<gt::space::sycl>;
 #else
-using backend_ops_clib = backend_ops<gt::space::host>;
+using clib = backend_ops<gt::space::host>;
 #endif
 
 } // namespace backend
@@ -83,7 +83,7 @@ inline void copy_n(InputPtr in, gt::size_type count, OutputPtr out)
 
 void inline synchronize()
 {
-  gt::backend::backend_ops_clib::device_synchronize();
+  gt::backend::clib::device_synchronize();
 }
 
 } // namespace gt

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -45,6 +45,18 @@ bool is_device_address(Ptr ptr)
   return backend_ops<gt::space::device>::is_device_address(ptr);
 }
 
+template <typename T>
+static void prefetch_device(T* p, size_type n)
+{
+  return backend_ops<gt::space::device>::prefetch_device(p, n);
+}
+
+template <typename T>
+static void prefetch_host(T* p, size_type n)
+{
+  return backend_ops<gt::space::device>::prefetch_host(p, n);
+}
+
 } // namespace backend
 
 template <typename T, typename S = gt::space::device>

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -31,13 +31,19 @@ using namespace backend::cuda;
 using namespace backend::hip;
 #elif GTENSOR_DEVICE_SYCL
 using namespace backend::sycl;
-#else // just for device_synchronize()
+#else
 using namespace backend::host;
 #endif
 
 template <typename S>
 using gallocator = gt::backend::allocator_impl::gallocator<S>;
 } // namespace clib
+
+template <typename Ptr>
+bool is_device_address(Ptr ptr)
+{
+  return backend_ops<gt::space::device>::is_device_address(ptr);
+}
 
 } // namespace backend
 

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -25,15 +25,6 @@ namespace backend
 
 namespace clib
 {
-#if GTENSOR_DEVICE_CUDA
-using namespace backend::cuda;
-#elif GTENSOR_DEVICE_HIP
-using namespace backend::hip;
-#elif GTENSOR_DEVICE_SYCL
-using namespace backend::sycl;
-#else
-#endif
-
 template <typename S>
 using gallocator = gt::backend::allocator_impl::gallocator<S>;
 } // namespace clib

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -32,12 +32,21 @@ using namespace backend::hip;
 #elif GTENSOR_DEVICE_SYCL
 using namespace backend::sycl;
 #else
-using namespace backend::host;
 #endif
 
 template <typename S>
 using gallocator = gt::backend::allocator_impl::gallocator<S>;
 } // namespace clib
+
+#if GTENSOR_DEVICE_CUDA
+using backend_ops_clib = backend_ops<gt::space::cuda>;
+#elif GTENSOR_DEVICE_HIP
+using backend_ops_clib = backend_ops<gt::space::hip>;
+#elif GTENSOR_DEVICE_SYCL
+using backend_ops_clib = backend_ops<gt::space::sycl>;
+#else
+using backend_ops_clib = backend_ops<gt::space::host>;
+#endif
 
 template <typename Ptr>
 bool is_device_address(Ptr ptr)
@@ -110,7 +119,7 @@ inline void copy_n(InputPtr in, gt::size_type count, OutputPtr out)
 
 void inline synchronize()
 {
-  gt::backend::clib::device_synchronize();
+  gt::backend::backend_ops_clib::device_synchronize();
 }
 
 } // namespace gt

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -23,11 +23,8 @@ namespace gt
 namespace backend
 {
 
-namespace clib
-{
 template <typename S>
 using gallocator = gt::backend::allocator_impl::gallocator<S>;
-} // namespace clib
 
 #if GTENSOR_DEVICE_CUDA
 using backend_ops_clib = backend_ops<gt::space::cuda>;

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -36,30 +36,6 @@ using backend_ops_clib = backend_ops<gt::space::sycl>;
 using backend_ops_clib = backend_ops<gt::space::host>;
 #endif
 
-template <typename Ptr>
-bool is_device_address(Ptr ptr)
-{
-  return backend_ops_clib::is_device_address(ptr);
-}
-
-template <typename Ptr>
-inline memory_type get_memory_type(const Ptr ptr)
-{
-  return backend_ops_clib::get_memory_type(ptr);
-}
-
-template <typename T>
-static void prefetch_device(T* p, size_type n)
-{
-  return backend_ops_clib::prefetch_device(p, n);
-}
-
-template <typename T>
-static void prefetch_host(T* p, size_type n)
-{
-  return backend_ops_clib::prefetch_host(p, n);
-}
-
 } // namespace backend
 
 template <typename T, typename S = gt::space::device>

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -39,25 +39,25 @@ using backend_ops_clib = backend_ops<gt::space::host>;
 template <typename Ptr>
 bool is_device_address(Ptr ptr)
 {
-  return backend_ops<gt::space::device>::is_device_address(ptr);
+  return backend_ops_clib::is_device_address(ptr);
 }
 
 template <typename Ptr>
 inline memory_type get_memory_type(const Ptr ptr)
 {
-  return backend_ops<gt::space::device>::get_memory_type(ptr);
+  return backend_ops_clib::get_memory_type(ptr);
 }
 
 template <typename T>
 static void prefetch_device(T* p, size_type n)
 {
-  return backend_ops<gt::space::device>::prefetch_device(p, n);
+  return backend_ops_clib::prefetch_device(p, n);
 }
 
 template <typename T>
 static void prefetch_host(T* p, size_type n)
 {
-  return backend_ops<gt::space::device>::prefetch_host(p, n);
+  return backend_ops_clib::prefetch_host(p, n);
 }
 
 } // namespace backend

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -45,6 +45,12 @@ bool is_device_address(Ptr ptr)
   return backend_ops<gt::space::device>::is_device_address(ptr);
 }
 
+template <typename Ptr>
+inline memory_type get_memory_type(const Ptr ptr)
+{
+  return backend_ops<gt::space::device>::get_memory_type(ptr);
+}
+
 template <typename T>
 static void prefetch_device(T* p, size_type n)
 {

--- a/include/gtensor/gtensor_forward.h
+++ b/include/gtensor/gtensor_forward.h
@@ -11,7 +11,13 @@ namespace gt
 namespace space
 {
 template <typename S>
-struct space_traits2;
+struct space_traits2
+{
+#if GTENSOR_HAVE_DEVICE
+  template <typename T>
+  using storage_type = device_vector<T>;
+#endif
+};
 
 template <>
 struct space_traits2<host>
@@ -20,14 +26,6 @@ struct space_traits2<host>
   using storage_type = host_vector<T>;
 };
 
-#ifdef GTENSOR_HAVE_DEVICE
-template <>
-struct space_traits2<device>
-{
-  template <typename T>
-  using storage_type = device_vector<T>;
-};
-#endif
 } // namespace space
 
 template <typename EC, size_type N>

--- a/include/gtensor/gtensor_span.h
+++ b/include/gtensor/gtensor_span.h
@@ -218,7 +218,6 @@ gtensor_span<T, N> adapt(T* data, const int* shape_data)
   return adapt<N, T>(data, {shape_data, N});
 }
 
-#ifdef GTENSOR_HAVE_DEVICE
 template <size_type N, typename T>
 GT_INLINE gtensor_span<T, N, space::device> adapt_device(
   T* data, const shape_type<N>& shape)
@@ -232,7 +231,6 @@ gtensor_span<T, N, space::device> adapt_device(T* data, const int* shape_data)
 {
   return adapt_device<N, T>(data, {shape_data, N});
 }
-#endif
 
 // ======================================================================
 // is_gtensor_span

--- a/include/gtensor/gtensor_span.h
+++ b/include/gtensor/gtensor_span.h
@@ -145,7 +145,8 @@ GT_INLINE gtensor_span<T, N, S>::gtensor_span(pointer data,
   }
 #endif // GTENSOR_DEVICE_SYCL
   if (check_address) {
-    gtGpuAssert(gt::backend::is_device_address(gt::raw_pointer_cast(data)),
+    gtGpuAssert(gt::backend::backend_ops_clib::is_device_address(
+                  gt::raw_pointer_cast(data)),
                 "host address passed to device span");
   }
 #endif

--- a/include/gtensor/gtensor_span.h
+++ b/include/gtensor/gtensor_span.h
@@ -145,9 +145,9 @@ GT_INLINE gtensor_span<T, N, S>::gtensor_span(pointer data,
   }
 #endif // GTENSOR_DEVICE_SYCL
   if (check_address) {
-    gtGpuAssert(gt::backend::backend_ops_clib::is_device_address(
-                  gt::raw_pointer_cast(data)),
-                "host address passed to device span");
+    gtGpuAssert(
+      gt::backend::clib::is_device_accessible(gt::raw_pointer_cast(data)),
+      "host address passed to device span");
   }
 #endif
 }

--- a/include/gtensor/macros.h
+++ b/include/gtensor/macros.h
@@ -151,6 +151,14 @@ inline auto gpuGetLastError()
   } while (0)
 #endif
 
+#elif GTENSOR_DEVICE_SYCL
+
+#else
+
+#define gpuSyncIfEnabledStream(a_stream_view)                                  \
+  do {                                                                         \
+  } while (0)
+
 #endif // end CUDA or HIP
 
 #define gpuSyncIfEnabled() gpuSyncIfEnabledStream(gt::stream_view{})

--- a/include/gtensor/space_forward.h
+++ b/include/gtensor/space_forward.h
@@ -87,6 +87,9 @@ using clib_managed = sycl_managed;
 using host = host_only;
 using device = host;
 using managed = host;
+using clib_host = host;
+using clib_device = host;
+using clib_managed = host;
 
 #endif
 

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -8,8 +8,6 @@ void gt_synchronize()
   gt::synchronize();
 }
 
-#ifdef GTENSOR_HAVE_DEVICE
-
 int gt_backend_device_get_count()
 {
   return gt::backend::clib::device_get_count();
@@ -29,6 +27,8 @@ uint32_t gt_backend_device_get_vendor_id(int device_id)
 {
   return gt::backend::clib::device_get_vendor_id(device_id);
 }
+
+#ifdef GTENSOR_HAVE_DEVICE
 
 void* gt_backend_host_allocate(size_t nbytes)
 {

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -28,8 +28,6 @@ uint32_t gt_backend_device_get_vendor_id(int device_id)
   return gt::backend::clib::device_get_vendor_id(device_id);
 }
 
-#ifdef GTENSOR_HAVE_DEVICE
-
 void* gt_backend_host_allocate(size_t nbytes)
 {
   return (void*)
@@ -67,6 +65,8 @@ void gt_backend_managed_deallocate(void* p)
   gt::backend::clib::gallocator<gt::space::clib_managed>::deallocate(
     (uint8_t*)p);
 }
+
+#ifdef GTENSOR_HAVE_DEVICE
 
 void gt_backend_memcpy_hh(void* dst, const void* src, size_t nbytes)
 {

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -100,9 +100,14 @@ void gt_backend_memset(void* dst, int value, size_t nbytes)
 
 #endif
 
+bool gt_backend_is_device_accessible(void* p)
+{
+  return gt::backend::clib::is_device_accessible(p);
+}
+
 bool gt_backend_is_device_address(void* p)
 {
-  return gt::backend::clib::is_device_address(p);
+  return gt::backend::clib::is_device_accessible(p);
 }
 
 void gt_backend_prefetch_device(void* p, size_t nbytes)

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -100,7 +100,7 @@ void gt_backend_memset(void* dst, int value, size_t nbytes)
 
 bool gt_backend_is_device_address(void* p)
 {
-  return gt::backend::is_device_address(p);
+  return gt::backend::backend_ops_clib::is_device_address(p);
 }
 
 void gt_backend_prefetch_device(void* p, size_t nbytes)

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -10,22 +10,22 @@ void gt_synchronize()
 
 int gt_backend_device_get_count()
 {
-  return gt::backend::backend_ops_clib::device_get_count();
+  return gt::backend::clib::device_get_count();
 }
 
 void gt_backend_device_set(int device_id)
 {
-  return gt::backend::backend_ops_clib::device_set(device_id);
+  return gt::backend::clib::device_set(device_id);
 }
 
 int gt_backend_device_get()
 {
-  return gt::backend::backend_ops_clib::device_get();
+  return gt::backend::clib::device_get();
 }
 
 uint32_t gt_backend_device_get_vendor_id(int device_id)
 {
-  return gt::backend::backend_ops_clib::device_get_vendor_id(device_id);
+  return gt::backend::clib::device_get_vendor_id(device_id);
 }
 
 void* gt_backend_host_allocate(size_t nbytes)
@@ -76,8 +76,8 @@ void gt_backend_memcpy_dd(void* dst, const void* src, size_t nbytes)
 
 void gt_backend_memcpy_async_dd(void* dst, const void* src, size_t nbytes)
 {
-  gt::backend::backend_ops_clib::copy_async_dd<uint8_t>((uint8_t*)src,
-                                                        (uint8_t*)dst, nbytes);
+  gt::backend::clib::copy_async_dd<uint8_t>((uint8_t*)src, (uint8_t*)dst,
+                                            nbytes);
 }
 
 void gt_backend_memcpy_dh(void* dst, const void* src, size_t nbytes)
@@ -98,19 +98,19 @@ void gt_backend_memset(void* dst, int value, size_t nbytes)
            gt::device_pointer_cast((uint8_t*)dst) + nbytes, value);
 }
 
+#endif
+
 bool gt_backend_is_device_address(void* p)
 {
-  return gt::backend::backend_ops_clib::is_device_address(p);
+  return gt::backend::clib::is_device_address(p);
 }
 
 void gt_backend_prefetch_device(void* p, size_t nbytes)
 {
-  gt::backend::prefetch_device<uint8_t>(static_cast<uint8_t*>(p), nbytes);
+  gt::backend::clib::prefetch_device<uint8_t>(static_cast<uint8_t*>(p), nbytes);
 }
 
 void gt_backend_prefetch_host(void* p, size_t nbytes)
 {
-  gt::backend::prefetch_device<uint8_t>(static_cast<uint8_t*>(p), nbytes);
+  gt::backend::clib::prefetch_device<uint8_t>(static_cast<uint8_t*>(p), nbytes);
 }
-
-#endif

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -10,22 +10,22 @@ void gt_synchronize()
 
 int gt_backend_device_get_count()
 {
-  return gt::backend::clib::device_get_count();
+  return gt::backend::backend_ops_clib::device_get_count();
 }
 
 void gt_backend_device_set(int device_id)
 {
-  return gt::backend::clib::device_set(device_id);
+  return gt::backend::backend_ops_clib::device_set(device_id);
 }
 
 int gt_backend_device_get()
 {
-  return gt::backend::clib::device_get();
+  return gt::backend::backend_ops_clib::device_get();
 }
 
 uint32_t gt_backend_device_get_vendor_id(int device_id)
 {
-  return gt::backend::clib::device_get_vendor_id(device_id);
+  return gt::backend::backend_ops_clib::device_get_vendor_id(device_id);
 }
 
 void* gt_backend_host_allocate(size_t nbytes)
@@ -81,8 +81,8 @@ void gt_backend_memcpy_dd(void* dst, const void* src, size_t nbytes)
 
 void gt_backend_memcpy_async_dd(void* dst, const void* src, size_t nbytes)
 {
-  gt::backend::clib::device_copy_async_dd<uint8_t>((uint8_t*)src, (uint8_t*)dst,
-                                                   nbytes);
+  gt::backend::backend_ops_clib::copy_async_dd<uint8_t>((uint8_t*)src,
+                                                        (uint8_t*)dst, nbytes);
 }
 
 void gt_backend_memcpy_dh(void* dst, const void* src, size_t nbytes)

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -31,39 +31,34 @@ uint32_t gt_backend_device_get_vendor_id(int device_id)
 void* gt_backend_host_allocate(size_t nbytes)
 {
   return (void*)
-    gt::backend::clib::gallocator<gt::space::clib_host>::allocate<uint8_t>(
-      nbytes);
+    gt::backend::gallocator<gt::space::clib_host>::allocate<uint8_t>(nbytes);
 }
 
 void* gt_backend_device_allocate(size_t nbytes)
 {
   return (void*)
-    gt::backend::clib::gallocator<gt::space::clib_device>::allocate<uint8_t>(
-      nbytes);
+    gt::backend::gallocator<gt::space::clib_device>::allocate<uint8_t>(nbytes);
 }
 
 void* gt_backend_managed_allocate(size_t nbytes)
 {
   return (void*)
-    gt::backend::clib::gallocator<gt::space::clib_managed>::allocate<uint8_t>(
-      nbytes);
+    gt::backend::gallocator<gt::space::clib_managed>::allocate<uint8_t>(nbytes);
 }
 
 void gt_backend_host_deallocate(void* p)
 {
-  gt::backend::clib::gallocator<gt::space::clib_host>::deallocate((uint8_t*)p);
+  gt::backend::gallocator<gt::space::clib_host>::deallocate((uint8_t*)p);
 }
 
 void gt_backend_device_deallocate(void* p)
 {
-  gt::backend::clib::gallocator<gt::space::clib_device>::deallocate(
-    (uint8_t*)p);
+  gt::backend::gallocator<gt::space::clib_device>::deallocate((uint8_t*)p);
 }
 
 void gt_backend_managed_deallocate(void* p)
 {
-  gt::backend::clib::gallocator<gt::space::clib_managed>::deallocate(
-    (uint8_t*)p);
+  gt::backend::gallocator<gt::space::clib_managed>::deallocate((uint8_t*)p);
 }
 
 #ifdef GTENSOR_HAVE_DEVICE

--- a/tests/test_adapt.cxx
+++ b/tests/test_adapt.cxx
@@ -28,8 +28,6 @@ TEST(adapt, adapt_complex)
   EXPECT_EQ(a[N * M - 1], (T{1., -1.}));
 }
 
-#ifdef GTENSOR_HAVE_DEVICE
-
 TEST(adapt, adapt_device)
 {
   constexpr int N = 10;
@@ -46,5 +44,3 @@ TEST(adapt, adapt_device)
 
   EXPECT_EQ(aview, h_expected);
 }
-
-#endif // GTENSOR_HAVE_DEVICE

--- a/tests/test_clib.cxx
+++ b/tests/test_clib.cxx
@@ -26,8 +26,6 @@ TEST(clib, list_devices)
   }
 }
 
-#ifdef GTENSOR_HAVE_DEVICE
-
 #define N 10
 TEST(clib, managed_allocate)
 {
@@ -43,6 +41,8 @@ TEST(clib, managed_allocate)
   }
   gt_backend_managed_deallocate((void*)a);
 }
+
+#ifdef GTENSOR_HAVE_DEVICE
 
 #define N 10
 TEST(clib, memcpy)

--- a/tests/test_clib.cxx
+++ b/tests/test_clib.cxx
@@ -8,8 +8,6 @@
 
 #define MAX_DEVICES 100
 
-#ifdef GTENSOR_HAVE_DEVICE
-
 TEST(clib, list_devices)
 {
   int n_devices = gt_backend_device_get_count();
@@ -27,6 +25,8 @@ TEST(clib, list_devices)
     }
   }
 }
+
+#ifdef GTENSOR_HAVE_DEVICE
 
 #define N 10
 TEST(clib, managed_allocate)

--- a/tests/test_device_backend.cxx
+++ b/tests/test_device_backend.cxx
@@ -9,8 +9,6 @@
 
 #define MAX_DEVICES 100
 
-#ifdef GTENSOR_HAVE_DEVICE
-
 TEST(device_backend, list_devices)
 {
   int n_devices = gt::backend::clib::device_get_count();
@@ -33,6 +31,8 @@ TEST(device_backend, list_devices)
     }
   }
 }
+
+#ifdef GTENSOR_HAVE_DEVICE
 
 #define N 10
 TEST(device_backend, managed_allocate)

--- a/tests/test_device_backend.cxx
+++ b/tests/test_device_backend.cxx
@@ -49,15 +49,13 @@ TEST(device_backend, managed_allocate)
   allocator::deallocate(a);
 }
 
-#ifdef GTENSOR_HAVE_DEVICE
-
 TEST(device_backend, is_device_address)
 {
   using T = double;
 
   gt::gtensor<T, 1> h_a(gt::shape(10));
   gt::gtensor_device<T, 1> d_a(gt::shape(10));
-  gt::gtensor_container<gt::space::managed_vector<T>, 1> m_a(gt::shape(10));
+  gt::gtensor<T, 1, gt::space::managed> m_a(gt::shape(10));
 
 #ifdef GTENSOR_DEVICE_SYCL
   // special case SYCL to handle the host backend, which says that
@@ -80,12 +78,16 @@ TEST(device_backend, is_device_address)
       gt::backend::is_device_address(gt::raw_pointer_cast(m_a.data())));
   }
 #else
+#if GTENSOR_HAVE_DEVICE
   ASSERT_FALSE(
     gt::backend::is_device_address(gt::raw_pointer_cast(h_a.data())));
+#endif
   ASSERT_TRUE(gt::backend::is_device_address(gt::raw_pointer_cast(d_a.data())));
   ASSERT_TRUE(gt::backend::is_device_address(gt::raw_pointer_cast(m_a.data())));
 #endif
 }
+
+#ifdef GTENSOR_HAVE_DEVICE
 
 TEST(device_backend, managed_prefetch)
 {

--- a/tests/test_device_backend.cxx
+++ b/tests/test_device_backend.cxx
@@ -49,7 +49,7 @@ TEST(device_backend, managed_allocate)
   allocator::deallocate(a);
 }
 
-TEST(device_backend, is_device_address)
+TEST(device_backend, is_device_accessible)
 {
   using T = double;
 
@@ -63,29 +63,29 @@ TEST(device_backend, is_device_address)
   // perspective, even if it's logically false in gtensor).
   sycl::device d = gt::backend::sycl::get_queue().get_device();
   if (d.is_gpu() || d.is_cpu()) {
-    ASSERT_FALSE(
-      gt::backend::clib::is_device_address(gt::raw_pointer_cast(h_a.data())));
-    ASSERT_TRUE(
-      gt::backend::clib::is_device_address(gt::raw_pointer_cast(d_a.data())));
-    ASSERT_TRUE(
-      gt::backend::clib::is_device_address(gt::raw_pointer_cast(m_a.data())));
+    ASSERT_FALSE(gt::backend::clib::is_device_accessible(
+      gt::raw_pointer_cast(h_a.data())));
+    ASSERT_TRUE(gt::backend::clib::is_device_accessible(
+      gt::raw_pointer_cast(d_a.data())));
+    ASSERT_TRUE(gt::backend::clib::is_device_accessible(
+      gt::raw_pointer_cast(m_a.data())));
   } else {
-    ASSERT_FALSE(
-      gt::backend::clib::is_device_address(gt::raw_pointer_cast(h_a.data())));
-    ASSERT_FALSE(
-      gt::backend::clib::is_device_address(gt::raw_pointer_cast(d_a.data())));
-    ASSERT_FALSE(
-      gt::backend::clib::is_device_address(gt::raw_pointer_cast(m_a.data())));
+    ASSERT_FALSE(gt::backend::clib::is_device_accessible(
+      gt::raw_pointer_cast(h_a.data())));
+    ASSERT_FALSE(gt::backend::clib::is_device_accessible(
+      gt::raw_pointer_cast(d_a.data())));
+    ASSERT_FALSE(gt::backend::clib::is_device_accessible(
+      gt::raw_pointer_cast(m_a.data())));
   }
 #else
 #if GTENSOR_HAVE_DEVICE
   ASSERT_FALSE(
-    gt::backend::clib::is_device_address(gt::raw_pointer_cast(h_a.data())));
+    gt::backend::clib::is_device_accessible(gt::raw_pointer_cast(h_a.data())));
 #endif
   ASSERT_TRUE(
-    gt::backend::clib::is_device_address(gt::raw_pointer_cast(d_a.data())));
+    gt::backend::clib::is_device_accessible(gt::raw_pointer_cast(d_a.data())));
   ASSERT_TRUE(
-    gt::backend::clib::is_device_address(gt::raw_pointer_cast(m_a.data())));
+    gt::backend::clib::is_device_accessible(gt::raw_pointer_cast(m_a.data())));
 #endif
 }
 

--- a/tests/test_device_backend.cxx
+++ b/tests/test_device_backend.cxx
@@ -12,7 +12,7 @@
 
 TEST(device_backend, list_devices)
 {
-  int n_devices = gt::backend::clib::device_get_count();
+  int n_devices = gt::backend::backend_ops_clib::device_get_count();
   uint32_t vendor_id[MAX_DEVICES];
 
   ASSERT_LE(n_devices, MAX_DEVICES);
@@ -23,7 +23,7 @@ TEST(device_backend, list_devices)
 #endif
 
   for (int i = 0; i < n_devices; i++) {
-    vendor_id[i] = gt::backend::clib::device_get_vendor_id(i);
+    vendor_id[i] = gt::backend::backend_ops_clib::device_get_vendor_id(i);
     GT_DEBUG_PRINTLN("device[" << i << "]: 0x" << std::setfill('0')
                                << std::setw(8) << std::hex << vendor_id[i]
                                << std::dec << std::endl);

--- a/tests/test_device_backend.cxx
+++ b/tests/test_device_backend.cxx
@@ -87,8 +87,6 @@ TEST(device_backend, is_device_address)
 #endif
 }
 
-#ifdef GTENSOR_HAVE_DEVICE
-
 TEST(device_backend, managed_prefetch)
 {
   using allocator = gt::backend::clib::gallocator<gt::space::clib_managed>;
@@ -154,5 +152,3 @@ TEST(device_backend, sycl_new_stream_queue)
 }
 
 #endif // GTENSOR_DEVICE_SYCL
-
-#endif // GTENSOR_HAVE_DEVICE

--- a/tests/test_device_backend.cxx
+++ b/tests/test_device_backend.cxx
@@ -112,7 +112,7 @@ TEST(device_backend, get_memory_type)
   gt::backend::host_storage<int> h(1);
   EXPECT_EQ(gt::backend::clib::get_memory_type(gt::raw_pointer_cast(h.data())),
             gt::backend::memory_type::host);
-#ifdef GTENSOR_HAVE_DEVICE
+#if defined(GTENSOR_HAVE_DEVICE) && !defined(GTENSOR_DEVICE_SYCL)
   gt::backend::device_storage<int> d(1);
   EXPECT_EQ(gt::backend::clib::get_memory_type(gt::raw_pointer_cast(d.data())),
             gt::backend::memory_type::device);

--- a/tests/test_device_backend.cxx
+++ b/tests/test_device_backend.cxx
@@ -8,6 +8,7 @@
 #include "test_debug.h"
 
 #define MAX_DEVICES 100
+#define N 10
 
 TEST(device_backend, list_devices)
 {
@@ -32,9 +33,6 @@ TEST(device_backend, list_devices)
   }
 }
 
-#ifdef GTENSOR_HAVE_DEVICE
-
-#define N 10
 TEST(device_backend, managed_allocate)
 {
   using allocator = gt::backend::clib::gallocator<gt::space::clib_managed>;
@@ -50,6 +48,8 @@ TEST(device_backend, managed_allocate)
   }
   allocator::deallocate(a);
 }
+
+#ifdef GTENSOR_HAVE_DEVICE
 
 TEST(device_backend, is_device_address)
 {

--- a/tests/test_device_backend.cxx
+++ b/tests/test_device_backend.cxx
@@ -105,6 +105,21 @@ TEST(device_backend, managed_prefetch)
   allocator::deallocate(a);
 }
 
+TEST(device_backend, get_memory_type)
+{
+  gt::backend::host_storage<int> h(1);
+  EXPECT_EQ(gt::backend::get_memory_type(gt::raw_pointer_cast(h.data())),
+            gt::backend::memory_type::host);
+#ifdef GTENSOR_HAVE_DEVICE
+  gt::backend::device_storage<int> d(1);
+  EXPECT_EQ(gt::backend::get_memory_type(gt::raw_pointer_cast(d.data())),
+            gt::backend::memory_type::device);
+  gt::backend::managed_storage<int> m(1);
+  EXPECT_EQ(gt::backend::get_memory_type(gt::raw_pointer_cast(m.data())),
+            gt::backend::memory_type::managed);
+#endif
+}
+
 #ifdef GTENSOR_DEVICE_SYCL
 
 TEST(device_backend, sycl_new_stream_queue)

--- a/tests/test_device_backend.cxx
+++ b/tests/test_device_backend.cxx
@@ -35,7 +35,7 @@ TEST(device_backend, list_devices)
 
 TEST(device_backend, managed_allocate)
 {
-  using allocator = gt::backend::clib::gallocator<gt::space::clib_managed>;
+  using allocator = gt::backend::gallocator<gt::space::clib_managed>;
   double* a = allocator::allocate<double>(N);
   for (int i = 0; i < N; i++) {
     a[i] = ((double)i) / N;
@@ -89,7 +89,7 @@ TEST(device_backend, is_device_address)
 
 TEST(device_backend, managed_prefetch)
 {
-  using allocator = gt::backend::clib::gallocator<gt::space::clib_managed>;
+  using allocator = gt::backend::gallocator<gt::space::clib_managed>;
   double* a = allocator::allocate<double>(N);
   gt::backend::prefetch_host(a, N);
   for (int i = 0; i < N; i++) {

--- a/tests/test_device_backend.cxx
+++ b/tests/test_device_backend.cxx
@@ -63,27 +63,29 @@ TEST(device_backend, is_device_address)
   // perspective, even if it's logically false in gtensor).
   sycl::device d = gt::backend::sycl::get_queue().get_device();
   if (d.is_gpu() || d.is_cpu()) {
-    ASSERT_FALSE(
-      gt::backend::is_device_address(gt::raw_pointer_cast(h_a.data())));
-    ASSERT_TRUE(
-      gt::backend::is_device_address(gt::raw_pointer_cast(d_a.data())));
-    ASSERT_TRUE(
-      gt::backend::is_device_address(gt::raw_pointer_cast(m_a.data())));
+    ASSERT_FALSE(gt::backend::backend_ops_clib::is_device_address(
+      gt::raw_pointer_cast(h_a.data())));
+    ASSERT_TRUE(gt::backend::backend_ops_clib::is_device_address(
+      gt::raw_pointer_cast(d_a.data())));
+    ASSERT_TRUE(gt::backend::backend_ops_clib::is_device_address(
+      gt::raw_pointer_cast(m_a.data())));
   } else {
-    ASSERT_FALSE(
-      gt::backend::is_device_address(gt::raw_pointer_cast(h_a.data())));
-    ASSERT_FALSE(
-      gt::backend::is_device_address(gt::raw_pointer_cast(d_a.data())));
-    ASSERT_FALSE(
-      gt::backend::is_device_address(gt::raw_pointer_cast(m_a.data())));
+    ASSERT_FALSE(gt::backend::backend_ops_clib::is_device_address(
+      gt::raw_pointer_cast(h_a.data())));
+    ASSERT_FALSE(gt::backend::backend_ops_clib::is_device_address(
+      gt::raw_pointer_cast(d_a.data())));
+    ASSERT_FALSE(gt::backend::backend_ops_clib::is_device_address(
+      gt::raw_pointer_cast(m_a.data())));
   }
 #else
 #if GTENSOR_HAVE_DEVICE
-  ASSERT_FALSE(
-    gt::backend::is_device_address(gt::raw_pointer_cast(h_a.data())));
+  ASSERT_FALSE(gt::backend::backend_ops_clib::is_device_address(
+    gt::raw_pointer_cast(h_a.data())));
 #endif
-  ASSERT_TRUE(gt::backend::is_device_address(gt::raw_pointer_cast(d_a.data())));
-  ASSERT_TRUE(gt::backend::is_device_address(gt::raw_pointer_cast(m_a.data())));
+  ASSERT_TRUE(gt::backend::backend_ops_clib::is_device_address(
+    gt::raw_pointer_cast(d_a.data())));
+  ASSERT_TRUE(gt::backend::backend_ops_clib::is_device_address(
+    gt::raw_pointer_cast(m_a.data())));
 #endif
 }
 
@@ -91,11 +93,11 @@ TEST(device_backend, managed_prefetch)
 {
   using allocator = gt::backend::gallocator<gt::space::clib_managed>;
   double* a = allocator::allocate<double>(N);
-  gt::backend::prefetch_host(a, N);
+  gt::backend::backend_ops_clib::prefetch_host(a, N);
   for (int i = 0; i < N; i++) {
     a[i] = ((double)i) / N;
   }
-  gt::backend::prefetch_device(a, N);
+  gt::backend::backend_ops_clib::prefetch_device(a, N);
   auto aview = gt::adapt_device(a, gt::shape(N));
   aview = aview + 1.0;
   gt::synchronize();
@@ -108,14 +110,17 @@ TEST(device_backend, managed_prefetch)
 TEST(device_backend, get_memory_type)
 {
   gt::backend::host_storage<int> h(1);
-  EXPECT_EQ(gt::backend::get_memory_type(gt::raw_pointer_cast(h.data())),
+  EXPECT_EQ(gt::backend::backend_ops_clib::get_memory_type(
+              gt::raw_pointer_cast(h.data())),
             gt::backend::memory_type::host);
 #ifdef GTENSOR_HAVE_DEVICE
   gt::backend::device_storage<int> d(1);
-  EXPECT_EQ(gt::backend::get_memory_type(gt::raw_pointer_cast(d.data())),
+  EXPECT_EQ(gt::backend::backend_ops_clib::get_memory_type(
+              gt::raw_pointer_cast(d.data())),
             gt::backend::memory_type::device);
   gt::backend::managed_storage<int> m(1);
-  EXPECT_EQ(gt::backend::get_memory_type(gt::raw_pointer_cast(m.data())),
+  EXPECT_EQ(gt::backend::backend_ops_clib::get_memory_type(
+              gt::raw_pointer_cast(m.data())),
             gt::backend::memory_type::managed);
 #endif
 }

--- a/tests/test_device_backend.cxx
+++ b/tests/test_device_backend.cxx
@@ -12,7 +12,7 @@
 
 TEST(device_backend, list_devices)
 {
-  int n_devices = gt::backend::backend_ops_clib::device_get_count();
+  int n_devices = gt::backend::clib::device_get_count();
   uint32_t vendor_id[MAX_DEVICES];
 
   ASSERT_LE(n_devices, MAX_DEVICES);
@@ -23,7 +23,7 @@ TEST(device_backend, list_devices)
 #endif
 
   for (int i = 0; i < n_devices; i++) {
-    vendor_id[i] = gt::backend::backend_ops_clib::device_get_vendor_id(i);
+    vendor_id[i] = gt::backend::clib::device_get_vendor_id(i);
     GT_DEBUG_PRINTLN("device[" << i << "]: 0x" << std::setfill('0')
                                << std::setw(8) << std::hex << vendor_id[i]
                                << std::dec << std::endl);
@@ -63,29 +63,29 @@ TEST(device_backend, is_device_address)
   // perspective, even if it's logically false in gtensor).
   sycl::device d = gt::backend::sycl::get_queue().get_device();
   if (d.is_gpu() || d.is_cpu()) {
-    ASSERT_FALSE(gt::backend::backend_ops_clib::is_device_address(
-      gt::raw_pointer_cast(h_a.data())));
-    ASSERT_TRUE(gt::backend::backend_ops_clib::is_device_address(
-      gt::raw_pointer_cast(d_a.data())));
-    ASSERT_TRUE(gt::backend::backend_ops_clib::is_device_address(
-      gt::raw_pointer_cast(m_a.data())));
+    ASSERT_FALSE(
+      gt::backend::clib::is_device_address(gt::raw_pointer_cast(h_a.data())));
+    ASSERT_TRUE(
+      gt::backend::clib::is_device_address(gt::raw_pointer_cast(d_a.data())));
+    ASSERT_TRUE(
+      gt::backend::clib::is_device_address(gt::raw_pointer_cast(m_a.data())));
   } else {
-    ASSERT_FALSE(gt::backend::backend_ops_clib::is_device_address(
-      gt::raw_pointer_cast(h_a.data())));
-    ASSERT_FALSE(gt::backend::backend_ops_clib::is_device_address(
-      gt::raw_pointer_cast(d_a.data())));
-    ASSERT_FALSE(gt::backend::backend_ops_clib::is_device_address(
-      gt::raw_pointer_cast(m_a.data())));
+    ASSERT_FALSE(
+      gt::backend::clib::is_device_address(gt::raw_pointer_cast(h_a.data())));
+    ASSERT_FALSE(
+      gt::backend::clib::is_device_address(gt::raw_pointer_cast(d_a.data())));
+    ASSERT_FALSE(
+      gt::backend::clib::is_device_address(gt::raw_pointer_cast(m_a.data())));
   }
 #else
 #if GTENSOR_HAVE_DEVICE
-  ASSERT_FALSE(gt::backend::backend_ops_clib::is_device_address(
-    gt::raw_pointer_cast(h_a.data())));
+  ASSERT_FALSE(
+    gt::backend::clib::is_device_address(gt::raw_pointer_cast(h_a.data())));
 #endif
-  ASSERT_TRUE(gt::backend::backend_ops_clib::is_device_address(
-    gt::raw_pointer_cast(d_a.data())));
-  ASSERT_TRUE(gt::backend::backend_ops_clib::is_device_address(
-    gt::raw_pointer_cast(m_a.data())));
+  ASSERT_TRUE(
+    gt::backend::clib::is_device_address(gt::raw_pointer_cast(d_a.data())));
+  ASSERT_TRUE(
+    gt::backend::clib::is_device_address(gt::raw_pointer_cast(m_a.data())));
 #endif
 }
 
@@ -93,11 +93,11 @@ TEST(device_backend, managed_prefetch)
 {
   using allocator = gt::backend::gallocator<gt::space::clib_managed>;
   double* a = allocator::allocate<double>(N);
-  gt::backend::backend_ops_clib::prefetch_host(a, N);
+  gt::backend::clib::prefetch_host(a, N);
   for (int i = 0; i < N; i++) {
     a[i] = ((double)i) / N;
   }
-  gt::backend::backend_ops_clib::prefetch_device(a, N);
+  gt::backend::clib::prefetch_device(a, N);
   auto aview = gt::adapt_device(a, gt::shape(N));
   aview = aview + 1.0;
   gt::synchronize();
@@ -110,17 +110,14 @@ TEST(device_backend, managed_prefetch)
 TEST(device_backend, get_memory_type)
 {
   gt::backend::host_storage<int> h(1);
-  EXPECT_EQ(gt::backend::backend_ops_clib::get_memory_type(
-              gt::raw_pointer_cast(h.data())),
+  EXPECT_EQ(gt::backend::clib::get_memory_type(gt::raw_pointer_cast(h.data())),
             gt::backend::memory_type::host);
 #ifdef GTENSOR_HAVE_DEVICE
   gt::backend::device_storage<int> d(1);
-  EXPECT_EQ(gt::backend::backend_ops_clib::get_memory_type(
-              gt::raw_pointer_cast(d.data())),
+  EXPECT_EQ(gt::backend::clib::get_memory_type(gt::raw_pointer_cast(d.data())),
             gt::backend::memory_type::device);
   gt::backend::managed_storage<int> m(1);
-  EXPECT_EQ(gt::backend::backend_ops_clib::get_memory_type(
-              gt::raw_pointer_cast(m.data())),
+  EXPECT_EQ(gt::backend::clib::get_memory_type(gt::raw_pointer_cast(m.data())),
             gt::backend::memory_type::managed);
 #endif
 }

--- a/tests/test_gtensor_storage.cxx
+++ b/tests/test_gtensor_storage.cxx
@@ -165,8 +165,6 @@ TEST(gtensor_storage, type_aliases)
     (std::is_same<decltype(h1)::const_pointer, const double*>::value));
 }
 
-#ifdef GTENSOR_HAVE_DEVICE
-
 TEST(gtensor_storage, device_copy_assign)
 {
   constexpr int N = 16;
@@ -363,8 +361,6 @@ TEST(gtensor_storage, host_raii)
   test_raii<gt::backend::host_storage<gt::complex<float>>>(100, 100);
 }
 
-#ifdef GTENSOR_HAVE_DEVICE
-
 TEST(gtensor_storage, device_raii)
 {
   test_raii<gt::backend::device_storage<double>>(100, 100);
@@ -376,7 +372,3 @@ TEST(gtensor_storage, managed_raii)
   test_raii<gt::backend::managed_storage<double>>(100, 100);
   test_raii<gt::backend::managed_storage<gt::complex<float>>>(100, 100);
 }
-
-#endif
-
-#endif // GTENSOR_HAVE_DEVICE


### PR DESCRIPTION
The main gtensor already mostly supports just using `<space::host>` but various `_device` functionality currently doesn't exist in this case. This starts making it available, where then, e.g. `adapt_device` just acts like `adapt<space::device>` and since `space::device == space::host`, it really just gives you a host gtensor_span, which makes it easier to write code that works with and with an actual gpu.