### PR TITLE
interface BLAS on the host

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,8 +424,9 @@ if (GTENSOR_ENABLE_BLAS)
     set(BLA_VENDOR OpenBLAS)
     find_package(BLAS REQUIRED)
     get_filename_component(BLAS_DIR ${BLAS_LIBRARIES} DIRECTORY)
-    find_path(BLAS_INCLUDE_DIRS cblas_openblas.h PATHS "${BLAS_DIR}/.." REQUIRED)
-    target_include_directories(BLAS::BLAS INTERFACE ${BLAS_INCLUDE_DIRS}) # HACK!
+    # Hack, see https://gitlab.kitware.com/cmake/cmake/-/issues/20268
+    find_path(BLAS_INCLUDE_DIRS cblas.h PATH_SUFFIXES openblas REQUIRED)
+    target_include_directories(BLAS::BLAS INTERFACE ${BLAS_INCLUDE_DIRS})
     find_package(LAPACK REQUIRED)
     target_link_libraries(gtblas INTERFACE BLAS::BLAS LAPACK::LAPACK)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,6 +418,16 @@ if (GTENSOR_ENABLE_BLAS)
     target_link_libraries(gtblas INTERFACE rocblas rocsolver)
   elseif (${GTENSOR_DEVICE} STREQUAL "sycl")
     target_link_libraries(gtblas INTERFACE oneapi_mkl_sycl)
+  elseif (${GTENSOR_DEVICE} STREQUAL "host")
+    # only openblas is supported at this time -- needs
+    # adaptations for the various cblas interfaces
+    set(BLA_VENDOR OpenBLAS)
+    find_package(BLAS REQUIRED)
+    get_filename_component(BLAS_DIR ${BLAS_LIBRARIES} DIRECTORY)
+    find_path(BLAS_INCLUDE_DIRS cblas_openblas.h PATHS "${BLAS_DIR}/.." REQUIRED)
+    target_include_directories(BLAS::BLAS INTERFACE ${BLAS_INCLUDE_DIRS}) # HACK!
+    find_package(LAPACK REQUIRED)
+    target_link_libraries(gtblas INTERFACE BLAS::BLAS LAPACK::LAPACK)
   endif()
 
   list(APPEND GTENSOR_TARGETS gtblas)

--- a/benchmarks/bench_getrf.cxx
+++ b/benchmarks/bench_getrf.cxx
@@ -211,8 +211,10 @@ static void BM_getrf(benchmark::State& state)
                               gt::raw_pointer_cast(d_piv.data()),
                               gt::raw_pointer_cast(d_info.data()), NBATCH);
     } else {
+#ifdef GTENSOR_HAVE_DEVICE
       gt::blas::getrf_npvt_batched(h, N, gt::raw_pointer_cast(d_Aptr.data()), N,
                                    gt::raw_pointer_cast(d_info.data()), NBATCH);
+#endif
     }
     gt::synchronize();
   };
@@ -240,13 +242,15 @@ static void BM_getrf(benchmark::State& state)
 // RealType, N, NBATCH, Pivot
 BENCHMARK(BM_getrf<float, 512, 64, true>)->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_getrf<double, 512, 64, true>)->Unit(benchmark::kMillisecond);
-BENCHMARK(BM_getrf<float, 512, 64, false>)->Unit(benchmark::kMillisecond);
-BENCHMARK(BM_getrf<double, 512, 64, false>)->Unit(benchmark::kMillisecond);
-
 BENCHMARK(BM_getrf<float, 210, 256, true>)->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_getrf<double, 210, 256, true>)->Unit(benchmark::kMillisecond);
+
+#ifdef GTENSOR_HAVE_DEVICE
+BENCHMARK(BM_getrf<float, 512, 64, false>)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_getrf<double, 512, 64, false>)->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_getrf<float, 210, 256, false>)->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_getrf<double, 210, 256, false>)->Unit(benchmark::kMillisecond);
+#endif
 
 // small cases for debugging
 /*

--- a/benchmarks/bench_hypz.cxx
+++ b/benchmarks/bench_hypz.cxx
@@ -1,3 +1,4 @@
+#include <array>
 
 #include <benchmark/benchmark.h>
 

--- a/include/gt-blas/backend/host.h
+++ b/include/gt-blas/backend/host.h
@@ -3,7 +3,9 @@
 
 #include <gtensor/gtensor.h>
 
-#include <cblas_openblas.h>
+#include <complex.h>
+
+#include <cblas.h>
 extern "C" {
 #include <lapack.h>
 }
@@ -166,36 +168,40 @@ CREATE_DOT(cblas_sdot, float, float)
 template <typename T>
 inline T dotu(handle_t& h, int n, const T* x, int incx, const T* y, int incy);
 
-#define CREATE_DOTU(METHOD, GTTYPE, BLASTYPE)                                  \
+#define CREATE_DOTU(METHOD, GTTYPE, BLASTYPE, RPART, IPART)                    \
   template <>                                                                  \
   inline GTTYPE dotu<GTTYPE>(handle_t & h, int n, const GTTYPE* x, int incx,   \
                              const GTTYPE* y, int incy)                        \
   {                                                                            \
     BLASTYPE result = METHOD(n, reinterpret_cast<const BLASTYPE*>(x), incx,    \
                              reinterpret_cast<const BLASTYPE*>(y), incy);      \
-    return {result.real, result.imag};                                         \
+    return {RPART(result), IPART(result)};                                     \
   }
 
-CREATE_DOTU(cblas_zdotu, gt::complex<double>, openblas_complex_double)
-CREATE_DOTU(cblas_cdotu, gt::complex<float>, openblas_complex_float)
+CREATE_DOTU(cblas_zdotu, gt::complex<double>, openblas_complex_double, creal,
+            cimag)
+CREATE_DOTU(cblas_cdotu, gt::complex<float>, openblas_complex_float, crealf,
+            cimagf)
 
 #undef CREATE_DOTU
 
 template <typename T>
 inline T dotc(handle_t& h, int n, const T* x, int incx, const T* y, int incy);
 
-#define CREATE_DOTC(METHOD, GTTYPE, BLASTYPE)                                  \
+#define CREATE_DOTC(METHOD, GTTYPE, BLASTYPE, RPART, IPART)                    \
   template <>                                                                  \
   inline GTTYPE dotc<GTTYPE>(handle_t & h, int n, const GTTYPE* x, int incx,   \
                              const GTTYPE* y, int incy)                        \
   {                                                                            \
     BLASTYPE result = METHOD(n, reinterpret_cast<const BLASTYPE*>(x), incx,    \
                              reinterpret_cast<const BLASTYPE*>(y), incy);      \
-    return {result.real, result.imag};                                         \
+    return {RPART(result), IPART(result)};                                     \
   }
 
-CREATE_DOTC(cblas_zdotc, gt::complex<double>, openblas_complex_double)
-CREATE_DOTC(cblas_cdotc, gt::complex<float>, openblas_complex_float)
+CREATE_DOTC(cblas_zdotc, gt::complex<double>, openblas_complex_double, creal,
+            cimag)
+CREATE_DOTC(cblas_cdotc, gt::complex<float>, openblas_complex_float, crealf,
+            cimagf)
 
 #undef CREATE_DOTC
 

--- a/include/gt-blas/backend/host.h
+++ b/include/gt-blas/backend/host.h
@@ -178,10 +178,10 @@ inline T dotu(handle_t& h, int n, const T* x, int incx, const T* y, int incy);
     return {RPART(result), IPART(result)};                                     \
   }
 
-CREATE_DOTU(cblas_zdotu, gt::complex<double>, openblas_complex_double, creal,
-            cimag)
-CREATE_DOTU(cblas_cdotu, gt::complex<float>, openblas_complex_float, crealf,
-            cimagf)
+CREATE_DOTU(cblas_zdotu, gt::complex<double>, openblas_complex_double,
+            openblas_complex_double_real, openblas_complex_double_imag)
+CREATE_DOTU(cblas_cdotu, gt::complex<float>, openblas_complex_float,
+            openblas_complex_float_real, openblas_complex_float_imag)
 
 #undef CREATE_DOTU
 
@@ -198,10 +198,10 @@ inline T dotc(handle_t& h, int n, const T* x, int incx, const T* y, int incy);
     return {RPART(result), IPART(result)};                                     \
   }
 
-CREATE_DOTC(cblas_zdotc, gt::complex<double>, openblas_complex_double, creal,
-            cimag)
-CREATE_DOTC(cblas_cdotc, gt::complex<float>, openblas_complex_float, crealf,
-            cimagf)
+CREATE_DOTC(cblas_zdotc, gt::complex<double>, openblas_complex_double,
+            openblas_complex_double_real, openblas_complex_double_imag)
+CREATE_DOTC(cblas_cdotc, gt::complex<float>, openblas_complex_float,
+            openblas_complex_float_real, openblas_complex_float_imag)
 
 #undef CREATE_DOTC
 

--- a/include/gt-blas/backend/host.h
+++ b/include/gt-blas/backend/host.h
@@ -19,6 +19,8 @@ namespace blas
 
 using index_t = int;
 
+using stream_t = dummy_stream;
+
 // ======================================================================
 // handle and stream management
 
@@ -28,6 +30,9 @@ class dummy_handle
 class handle_host : public detail::handle_base<handle_host, dummy_handle>
 {
 public:
+  handle_host() {}
+  ~handle_host() {}
+
   void set_stream(gt::stream_view sview) {}
 
   gt::stream_view get_stream() { return gt::stream_view{}; }

--- a/include/gt-blas/backend/host.h
+++ b/include/gt-blas/backend/host.h
@@ -1,0 +1,412 @@
+#ifndef GTENSOR_BLAS_HOST_H
+#define GTENSOR_BLAS_HOST_H
+
+#include <gtensor/gtensor.h>
+
+#include <cblas_openblas.h>
+extern "C" {
+#include <lapack.h>
+}
+
+namespace gt
+{
+
+namespace blas
+{
+
+// ======================================================================
+// types aliases
+
+using index_t = int;
+
+// ======================================================================
+// handle and stream management
+
+class dummy_handle
+{};
+
+class handle_host : public detail::handle_base<handle_host, dummy_handle>
+{
+public:
+  void set_stream(gt::stream_view sview) {}
+
+  gt::stream_view get_stream() { return gt::stream_view{}; }
+};
+
+using handle_t = handle_host;
+
+// ======================================================================
+// axpy
+
+template <typename T>
+inline void axpy(handle_t& h, int n, T a, const T* x, int incx, T* y, int incy);
+
+#define CREATE_AXPY(METHOD, GTTYPE, BLASTYPE)                                  \
+  template <>                                                                  \
+  inline void axpy<GTTYPE>(handle_t & h, int n, GTTYPE a, const GTTYPE* x,     \
+                           int incx, GTTYPE* y, int incy)                      \
+  {                                                                            \
+    METHOD(n, a, reinterpret_cast<const BLASTYPE*>(x), incx,                   \
+           reinterpret_cast<BLASTYPE*>(y), incy);                              \
+  }
+
+#define CREATE_AXPY_CMPLX(METHOD, GTTYPE, BLASTYPE)                            \
+  template <>                                                                  \
+  inline void axpy<GTTYPE>(handle_t & h, int n, GTTYPE a, const GTTYPE* x,     \
+                           int incx, GTTYPE* y, int incy)                      \
+  {                                                                            \
+    METHOD(n, reinterpret_cast<BLASTYPE*>(&a),                                 \
+           reinterpret_cast<const BLASTYPE*>(x), incx,                         \
+           reinterpret_cast<BLASTYPE*>(y), incy);                              \
+  }
+
+CREATE_AXPY_CMPLX(cblas_zaxpy, gt::complex<double>, openblas_complex_double)
+CREATE_AXPY_CMPLX(cblas_caxpy, gt::complex<float>, openblas_complex_float)
+CREATE_AXPY(cblas_daxpy, double, double)
+CREATE_AXPY(cblas_saxpy, float, float)
+
+#undef CREATE_AXPY
+
+// ======================================================================
+// scal
+
+template <typename S, typename T>
+inline void scal(handle_t& h, int n, S fac, T* arr, const int incx);
+
+#define CREATE_SCAL(METHOD, GTTYPE, BLASTYPE)                                  \
+  template <>                                                                  \
+  inline void scal<GTTYPE, GTTYPE>(handle_t & h, int n, GTTYPE fac,            \
+                                   GTTYPE* arr, const int incx)                \
+  {                                                                            \
+    METHOD(n, fac, reinterpret_cast<BLASTYPE*>(arr), incx);                    \
+  }
+
+#define CREATE_SCAL_CMPLX(METHOD, GTTYPE, BLASTYPE)                            \
+  template <>                                                                  \
+  inline void scal<GTTYPE, GTTYPE>(handle_t & h, int n, GTTYPE fac,            \
+                                   GTTYPE* arr, const int incx)                \
+  {                                                                            \
+    METHOD(n, reinterpret_cast<BLASTYPE*>(&fac),                               \
+           reinterpret_cast<BLASTYPE*>(arr), incx);                            \
+  }
+
+CREATE_SCAL_CMPLX(cblas_zscal, gt::complex<double>, openblas_complex_double)
+CREATE_SCAL_CMPLX(cblas_cscal, gt::complex<float>, openblas_complex_float)
+CREATE_SCAL(cblas_dscal, double, double)
+CREATE_SCAL(cblas_sscal, float, float)
+
+#undef CREATE_SCAL
+
+// ======================================================================
+// (zd|cs)scal
+
+template <>
+inline void scal<double, gt::complex<double>>(handle_t& h, int n, double fac,
+                                              gt::complex<double>* arr,
+                                              const int incx)
+{
+  cblas_zdscal(n, fac, reinterpret_cast<openblas_complex_double*>(arr), incx);
+}
+
+template <>
+inline void scal<float, gt::complex<float>>(handle_t& h, int n, float fac,
+                                            gt::complex<float>* arr,
+                                            const int incx)
+{
+  cblas_csscal(n, fac, reinterpret_cast<openblas_complex_float*>(arr), incx);
+}
+
+// ======================================================================
+// copy
+
+template <typename T>
+inline void copy(handle_t& h, int n, const T* x, int incx, T* y, int incy);
+
+#define CREATE_COPY(METHOD, GTTYPE, BLASTYPE)                                  \
+  template <>                                                                  \
+  inline void copy<GTTYPE>(handle_t & h, int n, const GTTYPE* x, int incx,     \
+                           GTTYPE* y, int incy)                                \
+  {                                                                            \
+    METHOD(n, reinterpret_cast<const BLASTYPE*>(x), incx,                      \
+           reinterpret_cast<BLASTYPE*>(y), incy);                              \
+  }
+
+CREATE_COPY(cblas_zcopy, gt::complex<double>, openblas_complex_double)
+CREATE_COPY(cblas_ccopy, gt::complex<float>, openblas_complex_float)
+CREATE_COPY(cblas_dcopy, double, double)
+CREATE_COPY(cblas_scopy, float, float)
+
+#undef CREATE_COPY
+
+// ======================================================================
+// dot, dotc (conjugate)
+
+template <typename T>
+inline T dot(handle_t& h, int n, const T* x, int incx, const T* y, int incy);
+
+#define CREATE_DOT(METHOD, GTTYPE, BLASTYPE)                                   \
+  template <>                                                                  \
+  inline GTTYPE dot<GTTYPE>(handle_t & h, int n, const GTTYPE* x, int incx,    \
+                            const GTTYPE* y, int incy)                         \
+  {                                                                            \
+    return METHOD(n, reinterpret_cast<const BLASTYPE*>(x), incx,               \
+                  reinterpret_cast<const BLASTYPE*>(y), incy);                 \
+  }
+
+CREATE_DOT(cblas_ddot, double, double)
+CREATE_DOT(cblas_sdot, float, float)
+
+#undef CREATE_DOT
+
+template <typename T>
+inline T dotu(handle_t& h, int n, const T* x, int incx, const T* y, int incy);
+
+#define CREATE_DOTU(METHOD, GTTYPE, BLASTYPE)                                  \
+  template <>                                                                  \
+  inline GTTYPE dotu<GTTYPE>(handle_t & h, int n, const GTTYPE* x, int incx,   \
+                             const GTTYPE* y, int incy)                        \
+  {                                                                            \
+    BLASTYPE result = METHOD(n, reinterpret_cast<const BLASTYPE*>(x), incx,    \
+                             reinterpret_cast<const BLASTYPE*>(y), incy);      \
+    return {result.real, result.imag};                                         \
+  }
+
+CREATE_DOTU(cblas_zdotu, gt::complex<double>, openblas_complex_double)
+CREATE_DOTU(cblas_cdotu, gt::complex<float>, openblas_complex_float)
+
+#undef CREATE_DOTU
+
+template <typename T>
+inline T dotc(handle_t& h, int n, const T* x, int incx, const T* y, int incy);
+
+#define CREATE_DOTC(METHOD, GTTYPE, BLASTYPE)                                  \
+  template <>                                                                  \
+  inline GTTYPE dotc<GTTYPE>(handle_t & h, int n, const GTTYPE* x, int incx,   \
+                             const GTTYPE* y, int incy)                        \
+  {                                                                            \
+    BLASTYPE result = METHOD(n, reinterpret_cast<const BLASTYPE*>(x), incx,    \
+                             reinterpret_cast<const BLASTYPE*>(y), incy);      \
+    return {result.real, result.imag};                                         \
+  }
+
+CREATE_DOTC(cblas_zdotc, gt::complex<double>, openblas_complex_double)
+CREATE_DOTC(cblas_cdotc, gt::complex<float>, openblas_complex_float)
+
+#undef CREATE_DOTC
+
+// ======================================================================
+// gemv
+
+template <typename T>
+inline void gemv(handle_t& h, int m, int n, T alpha, const T* A, int lda,
+                 const T* x, int incx, T beta, T* y, int incy);
+
+#define CREATE_GEMV(METHOD, GTTYPE, BLASTYPE)                                  \
+  template <>                                                                  \
+  inline void gemv<GTTYPE>(handle_t & h, int m, int n, GTTYPE alpha,           \
+                           const GTTYPE* A, int lda, const GTTYPE* x,          \
+                           int incx, GTTYPE beta, GTTYPE* y, int incy)         \
+  {                                                                            \
+    METHOD(CblasColMajor, CblasNoTrans, m, n, alpha,                           \
+           reinterpret_cast<const BLASTYPE*>(A), lda,                          \
+           reinterpret_cast<const BLASTYPE*>(x), incx, beta,                   \
+           reinterpret_cast<BLASTYPE*>(y), incy);                              \
+  }
+
+#define CREATE_GEMV_CMPLX(METHOD, GTTYPE, BLASTYPE)                            \
+  template <>                                                                  \
+  inline void gemv<GTTYPE>(handle_t & h, int m, int n, GTTYPE alpha,           \
+                           const GTTYPE* A, int lda, const GTTYPE* x,          \
+                           int incx, GTTYPE beta, GTTYPE* y, int incy)         \
+  {                                                                            \
+    METHOD(CblasColMajor, CblasNoTrans, m, n,                                  \
+           reinterpret_cast<const BLASTYPE*>(&alpha),                          \
+           reinterpret_cast<const BLASTYPE*>(A), lda,                          \
+           reinterpret_cast<const BLASTYPE*>(x), incx,                         \
+           reinterpret_cast<BLASTYPE*>(&beta), reinterpret_cast<BLASTYPE*>(y), \
+           incy);                                                              \
+  }
+
+CREATE_GEMV_CMPLX(cblas_zgemv, gt::complex<double>, openblas_complex_double)
+CREATE_GEMV_CMPLX(cblas_cgemv, gt::complex<float>, openblas_complex_float)
+CREATE_GEMV(cblas_dgemv, double, double)
+CREATE_GEMV(cblas_sgemv, float, float)
+
+#undef CREATE_GEMV
+
+// ======================================================================
+// getrf batched
+
+template <typename T>
+inline void getrf_batched(handle_t& h, int n, T** d_Aarray, int lda,
+                          gt::blas::index_t* d_PivotArray, int* d_infoArray,
+                          int batchSize);
+
+#define CREATE_GETRF_BATCHED(METHOD, GTTYPE, BLASTYPE)                         \
+  template <>                                                                  \
+  inline void getrf_batched<GTTYPE>(handle_t & h, int n, GTTYPE** d_Aarray,    \
+                                    int lda, gt::blas::index_t* d_PivotArray,  \
+                                    int* d_infoArray, int batchSize)           \
+  {                                                                            \
+    for (int b = 0; b < batchSize; b++) {                                      \
+      METHOD(&n, &n, reinterpret_cast<BLASTYPE*>(d_Aarray[b]), &lda,           \
+             &d_PivotArray[b * n], &d_infoArray[b]);                           \
+    }                                                                          \
+  }
+
+CREATE_GETRF_BATCHED(LAPACK_zgetrf, gt::complex<double>, _Complex double)
+CREATE_GETRF_BATCHED(LAPACK_cgetrf, gt::complex<float>, _Complex float)
+CREATE_GETRF_BATCHED(LAPACK_dgetrf, double, double)
+CREATE_GETRF_BATCHED(LAPACK_sgetrf, float, float)
+
+#undef CREATE_GETRF_BATCHED
+
+#if 0
+// ======================================================================
+// getrf_npvt batched
+
+template <typename T>
+inline void getrf_npvt_batched(handle_t& h, int n, T** d_Aarray, int lda,
+                               int* d_infoArray, int batchSize);
+
+#define CREATE_GETRF_NPVT_BATCHED(METHOD, GTTYPE, BLASTYPE)                    \
+  template <>                                                                  \
+  inline void getrf_npvt_batched<GTTYPE>(handle_t & h, int n,                  \
+                                         GTTYPE** d_Aarray, int lda,           \
+                                         int* d_infoArray, int batchSize)      \
+  {                                                                            \
+    for (int b = 0; b < batchSize; b++) {                                      \
+      METHOD(&n, &n, reinterpret_cast<BLASTYPE*>(d_Aarray[b]), &lda, NULL,     \
+             &d_infoArray[b]);                                                 \
+    }                                                                          \
+  }
+
+CREATE_GETRF_NPVT_BATCHED(LAPACK_zgetrf, gt::complex<double>, _Complex double)
+CREATE_GETRF_NPVT_BATCHED(LAPACK_cgetrf, gt::complex<float>, _Complex float)
+
+#undef CREATE_GETRF_NPVT_BATCHED
+#endif
+
+// ======================================================================
+// getrs batched
+
+template <typename T>
+inline void getrs_batched(handle_t& h, int n, int nrhs, T* const* d_Aarray,
+                          int lda, gt::blas::index_t* devIpiv, T** d_Barray,
+                          int ldb, int batchSize);
+
+#define CREATE_GETRS_BATCHED(METHOD, GTTYPE, BLASTYPE)                         \
+  template <>                                                                  \
+  inline void getrs_batched<GTTYPE>(                                           \
+    handle_t & h, int n, int nrhs, GTTYPE* const* d_Aarray, int lda,           \
+    gt::blas::index_t* devIpiv, GTTYPE** d_Barray, int ldb, int batchSize)     \
+  {                                                                            \
+    static const char op_N = 'N';                                              \
+    int info;                                                                  \
+    for (int b = 0; b < batchSize; b++) {                                      \
+      METHOD(&op_N, &n, &nrhs, reinterpret_cast<BLASTYPE*>(d_Aarray[b]), &lda, \
+             &devIpiv[b * n], reinterpret_cast<BLASTYPE*>(d_Barray[b]), &ldb,  \
+             &info);                                                           \
+      if (info != 0) {                                                         \
+        fprintf(stderr, "METHOD failed, info=%d at %s %d\n", info, __FILE__,   \
+                __LINE__);                                                     \
+        abort();                                                               \
+      }                                                                        \
+    }                                                                          \
+  }
+
+CREATE_GETRS_BATCHED(LAPACK_zgetrs, gt::complex<double>, _Complex double)
+CREATE_GETRS_BATCHED(LAPACK_cgetrs, gt::complex<float>, _Complex float)
+CREATE_GETRS_BATCHED(LAPACK_dgetrs, double, double)
+CREATE_GETRS_BATCHED(LAPACK_sgetrs, float, float)
+
+#undef CREATE_GETRS_BATCHED
+
+// ======================================================================
+// getri batched
+
+template <typename T>
+inline void getri_batched(handle_t& h, int n, T* const* d_Aarray, int lda,
+                          gt::blas::index_t* devIpiv, T** d_Carray, int ldc,
+                          int* d_infoArray, int batchSize);
+
+#define CREATE_GETRI_BATCHED(METHOD, GTTYPE, BLASTYPE)                         \
+  template <>                                                                  \
+  inline void getri_batched<GTTYPE>(                                           \
+    handle_t & h, int n, GTTYPE* const* d_Aarray, int lda,                     \
+    gt::blas::index_t* devIpiv, GTTYPE** d_Carray, int ldc, int* d_infoArray,  \
+    int batchSize)                                                             \
+  {                                                                            \
+    int lwork = n * n;                                                         \
+    auto work = gt::empty<GTTYPE>({lwork});                                    \
+    for (int b = 0; b < batchSize; b++) {                                      \
+      for (int i = 0; i < n * n; i++) {                                        \
+        d_Carray[b][i] = d_Aarray[b][i];                                       \
+      }                                                                        \
+      METHOD(&n, reinterpret_cast<BLASTYPE*>(d_Carray[b]), &lda,               \
+             &devIpiv[b * n], reinterpret_cast<BLASTYPE*>(work.data()),        \
+             &lwork, &d_infoArray[b]);                                         \
+    }                                                                          \
+  }
+
+CREATE_GETRI_BATCHED(LAPACK_zgetri, gt::complex<double>, _Complex double)
+CREATE_GETRI_BATCHED(LAPACK_cgetri, gt::complex<float>, _Complex float)
+CREATE_GETRI_BATCHED(LAPACK_dgetri, double, double)
+CREATE_GETRI_BATCHED(LAPACK_sgetri, float, float)
+
+#undef CREATE_GETRI_BATCHED
+
+// ======================================================================
+// gemm batched
+
+template <typename T>
+inline void gemm_batched(handle_t& h, int m, int n, int k, T alpha,
+                         T** d_Aarray, int lda, T** d_Barray, int ldb, T beta,
+                         T** d_Carray, int ldc, int batchSize);
+
+#define CREATE_GEMM_BATCHED_CMPLX(METHOD, GTTYPE, BLASTYPE)                    \
+  template <>                                                                  \
+  inline void gemm_batched<GTTYPE>(handle_t & h, int m, int n, int k,          \
+                                   GTTYPE alpha, GTTYPE** d_Aarray, int lda,   \
+                                   GTTYPE** d_Barray, int ldb, GTTYPE beta,    \
+                                   GTTYPE** d_Carray, int ldc, int batchSize)  \
+  {                                                                            \
+    for (int b = 0; b < batchSize; b++) {                                      \
+      METHOD(CblasColMajor, CblasNoTrans, CblasNoTrans, m, n, k,               \
+             reinterpret_cast<BLASTYPE*>(&alpha),                              \
+             reinterpret_cast<BLASTYPE*>(d_Aarray[b]), lda,                    \
+             reinterpret_cast<BLASTYPE*>(d_Barray[b]), ldb,                    \
+             reinterpret_cast<BLASTYPE*>(&beta),                               \
+             reinterpret_cast<BLASTYPE*>(d_Carray[b]), ldc);                   \
+    }                                                                          \
+  }
+
+#define CREATE_GEMM_BATCHED(METHOD, GTTYPE, BLASTYPE)                          \
+  template <>                                                                  \
+  inline void gemm_batched<GTTYPE>(handle_t & h, int m, int n, int k,          \
+                                   GTTYPE alpha, GTTYPE** d_Aarray, int lda,   \
+                                   GTTYPE** d_Barray, int ldb, GTTYPE beta,    \
+                                   GTTYPE** d_Carray, int ldc, int batchSize)  \
+  {                                                                            \
+    for (int b = 0; b < batchSize; b++) {                                      \
+      METHOD(CblasColMajor, CblasNoTrans, CblasNoTrans, m, n, k, alpha,        \
+             reinterpret_cast<BLASTYPE*>(d_Aarray[b]), lda,                    \
+             reinterpret_cast<BLASTYPE*>(d_Barray[b]), ldb, beta,              \
+             reinterpret_cast<BLASTYPE*>(d_Carray[b]), ldc);                   \
+    }                                                                          \
+  }
+
+CREATE_GEMM_BATCHED_CMPLX(cblas_zgemm, gt::complex<double>,
+                          openblas_complex_double)
+CREATE_GEMM_BATCHED_CMPLX(cblas_cgemm, gt::complex<float>,
+                          openblas_complex_float)
+CREATE_GEMM_BATCHED(cblas_dgemm, double, double);
+CREATE_GEMM_BATCHED(cblas_sgemm, float, float);
+
+#undef CREATE_GEMM_BATCHED
+
+} // namespace blas
+
+} // namespace gt
+
+#endif

--- a/include/gt-blas/blas.h
+++ b/include/gt-blas/blas.h
@@ -57,6 +57,8 @@ private:
 #include "backend/hip.h"
 #elif defined(GTENSOR_DEVICE_SYCL)
 #include "backend/sycl.h"
+#else
+#include "backend/host.h"
 #endif
 
 #include "bandsolver.h"

--- a/include/gtensor/backend_host.h
+++ b/include/gtensor/backend_host.h
@@ -97,17 +97,26 @@ inline void fill(gt::space::host tag, Ptr first, Ptr last, const T& value)
 
 #ifndef GTENSOR_HAVE_DEVICE
 
+class dummy_stream
+{};
+
 // streams are no-op on host (could use threads in the future)
 class stream_view
 {
+  using stream_t = dummy_stream;
+
 public:
   stream_view() {}
+  stream_view(stream_t) {}
 
-  auto get_backend_stream() { return nullptr; }
+  stream_t& get_backend_stream() { return stream_; }
 
   bool is_default() { return true; }
 
   void synchronize() {}
+
+private:
+  stream_t stream_;
 };
 
 class stream

--- a/include/gtensor/space.h
+++ b/include/gtensor/space.h
@@ -71,14 +71,12 @@ using managed_vector =
 template <typename T, typename A = GTENSOR_DEFAULT_HOST_ALLOCATOR(T)>
 using host_vector = gt::backend::host_storage<T, A>;
 
-#ifdef GTENSOR_HAVE_DEVICE
 template <typename T, typename A = GTENSOR_DEFAULT_DEVICE_ALLOCATOR(T)>
 using device_vector = gt::backend::device_storage<T, A>;
 
 template <typename T>
 using managed_vector =
   gt::backend::device_storage<T, GTENSOR_DEFAULT_MANAGED_ALLOCATOR(T)>;
-#endif
 
 #endif // GTENSOR_USE_THRUST
 

--- a/src/cgtblas.cxx
+++ b/src/cgtblas.cxx
@@ -341,6 +341,8 @@ CREATE_C_GET_MAX_BANDWIDTH(gtblas_zget_max_bandwidth, f2c_complex<double>)
 
 // ======================================================================
 // gtblas_Xgetrf_npvt_batched
+#ifdef GTENSOR_HAVE_DEVICE
+
 #define CREATE_C_GETRF_NPVT_BATCHED(CNAME, CPPTYPE)                            \
   void CNAME(int n, CPPTYPE** d_Aarray, int lda, int* d_infoArray,             \
              int batchSize)                                                    \
@@ -353,6 +355,8 @@ CREATE_C_GETRF_NPVT_BATCHED(gtblas_cgetrf_npvt_batched, f2c_complex<float>)
 CREATE_C_GETRF_NPVT_BATCHED(gtblas_zgetrf_npvt_batched, f2c_complex<double>)
 
 #undef CREATE_C_GETRF_NPVT_BATCHED
+
+#endif
 
 // ======================================================================
 // gtblas_Xgemm_batched

--- a/tests/test_blas.cxx
+++ b/tests/test_blas.cxx
@@ -416,70 +416,59 @@ TEST(blas, zgemv)
 template <typename R>
 void test_gemm_batched_real()
 {
-  constexpr int N = 32;
-  constexpr int NRHS = 3;
+  // FIXME, all square diagonal matrices isn't exactly very general test
+  constexpr int M = 3, K = 3, N = 3;
   constexpr int batch_size = 5;
-  int m = N;
-  int n = NRHS;
-  int k = N;
-  // m x k (NxN)
-  auto h_mat = gt::zeros<R>(gt::shape(N, N, batch_size));
-  gt::gtensor_device<R, 3> d_mat(gt::shape(N, N, batch_size));
 
-  // k x n (NxNRHS)
-  gt::gtensor<R, 3> h_X({N, NRHS, batch_size});
-  gt::gtensor_device<R, 3> d_X({N, NRHS, batch_size});
+  auto h_A = gt::zeros<R>(gt::shape(M, K, batch_size));
+  auto d_A = gt::zeros_device<R>(gt::shape(M, K, batch_size));
 
-  // m x n (NxNRHS)
-  gt::gtensor<R, 3> h_Y({N, NRHS, batch_size});
-  gt::gtensor_device<R, 3> d_Y({N, NRHS, batch_size});
+  auto h_B = gt::zeros<R>(gt::shape(K, N, batch_size));
+  auto d_B = gt::zeros_device<R>(gt::shape(K, N, batch_size));
 
-  gt::gtensor<R*, 1> h_yptr(batch_size);
-  gt::gtensor_device<R*, 1> d_yptr(batch_size);
-  gt::gtensor<R*, 1> h_xptr(batch_size);
-  gt::gtensor_device<R*, 1> d_xptr(batch_size);
-  gt::gtensor<R*, 1> h_matptr(batch_size);
-  gt::gtensor_device<R*, 1> d_matptr(batch_size);
+  auto h_C = gt::zeros<R>(gt::shape(M, N, batch_size));
+  auto d_C = gt::zeros_device<R>(gt::shape(M, N, batch_size));
+
+  gt::gtensor<R*, 1> h_Aptr(batch_size);
+  gt::gtensor_device<R*, 1> d_Aptr(batch_size);
+  gt::gtensor<R*, 1> h_Bptr(batch_size);
+  gt::gtensor_device<R*, 1> d_Bptr(batch_size);
+  gt::gtensor<R*, 1> h_Cptr(batch_size);
+  gt::gtensor_device<R*, 1> d_Cptr(batch_size);
 
   R a = R(0.5);
   R b = R(-1.0);
 
   for (int t = 0; t < batch_size; t++) {
     for (int i = 0; i < N; i++) {
-      // identity matrix
-      h_mat(i, i, t) = R(1.0);
-      for (int rhs = 0; rhs < NRHS; rhs++) {
-        // all rhs are the same, to simplify validation
-        h_X(i, rhs, t) = R(2 * i);
-        h_Y(i, rhs, t) = R(0.5 * i);
-      }
+      h_A(i, i, t) = R(3 * i + t);
+      h_B(i, i, t) = R(2 * i);
+      h_C(i, i, t) = R(0.5 * i + t);
     }
-    h_xptr(t) = gt::raw_pointer_cast(d_X.data()) + t * N * NRHS;
-    h_yptr(t) = gt::raw_pointer_cast(d_Y.data()) + t * N * NRHS;
-    h_matptr(t) = gt::raw_pointer_cast(d_mat.data()) + t * N * N;
+    h_Aptr(t) = gt::raw_pointer_cast(&d_A(0, 0, t));
+    h_Bptr(t) = gt::raw_pointer_cast(&d_B(0, 0, t));
+    h_Cptr(t) = gt::raw_pointer_cast(&d_C(0, 0, t));
   }
 
-  gt::copy(h_X, d_X);
-  gt::copy(h_Y, d_Y);
-  gt::copy(h_mat, d_mat);
-  gt::copy(h_xptr, d_xptr);
-  gt::copy(h_yptr, d_yptr);
-  gt::copy(h_matptr, d_matptr);
+  gt::copy(h_A, d_A);
+  gt::copy(h_B, d_B);
+  gt::copy(h_C, d_C);
+  gt::copy(h_Aptr, d_Aptr);
+  gt::copy(h_Bptr, d_Bptr);
+  gt::copy(h_Cptr, d_Cptr);
 
   gt::blas::handle_t h;
 
-  gt::blas::gemm_batched<R>(h, m, n, k, a,
-                            gt::raw_pointer_cast(d_matptr.data()), N,
-                            gt::raw_pointer_cast(d_xptr.data()), N, b,
-                            gt::raw_pointer_cast(d_yptr.data()), N, batch_size);
+  gt::blas::gemm_batched<R>(
+    h, M, N, K, a, gt::raw_pointer_cast(d_Aptr.data()), d_A.strides()[1],
+    gt::raw_pointer_cast(d_Bptr.data()), d_B.strides()[1], b,
+    gt::raw_pointer_cast(d_Cptr.data()), d_C.strides()[1], batch_size);
 
-  gt::copy(d_Y, h_Y);
-
+  gt::copy(d_C, h_C);
   for (int t = 0; t < batch_size; t++) {
-    for (int rhs = 0; rhs < NRHS; rhs++) {
-      for (int i = 0; i < N; i++) {
-        EXPECT_EQ(h_Y(i, rhs, t), i / 2.0);
-      }
+    for (int i = 0; i < N; i++) {
+      EXPECT_EQ(h_C(i, i, t), a * R(3 * i + t) * R(2 * i) + b * R(.5 * i + t))
+        << "i = " << i << " t = " << t;
     }
   }
 }

--- a/tests/test_lapack.cxx
+++ b/tests/test_lapack.cxx
@@ -381,6 +381,7 @@ TEST(lapack, zgetrf_batch)
   test_getrf_batch_complex<double>();
 }
 
+#ifdef GTENSOR_HAVE_DEVICE
 template <typename R>
 void test_getrf_npvt_batch_complex()
 {
@@ -459,6 +460,7 @@ TEST(lapack, zgetrf_npvt_batch)
 {
   test_getrf_npvt_batch_complex<double>();
 }
+#endif
 
 namespace test
 {

--- a/tests/test_lapack.cxx
+++ b/tests/test_lapack.cxx
@@ -624,7 +624,6 @@ void test_getri_batch_complex()
   gt::copy(h_A, d_A);
   gt::copy(h_Cptr, d_Cptr);
   gt::copy(h_C, d_C);
-  gt::copy(h_C, d_C);
   gt::copy(h_p, d_p);
 
   gt::blas::handle_t h;


### PR DESCRIPTION
This provides the BLAS interface C++ and C abstractions when compiled host-only. This required quite a bit of
boilerplate code, but oh well...

It only supports OpenBLAS right now, and it's missing `getrf_npvt_batched`, since I can't find anything like that in BLAS/LAPACK.