### PR TITLE
test: improved test predicates

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ add_gtensor_test(test_sarray)
 add_gtensor_test(test_assign)
 add_gtensor_test(test_space)
 add_gtensor_test(test_stream)
+add_gtensor_test(test_gtest_predicates)
 
 if (GTENSOR_ENABLE_CLIB)
   add_executable(test_clib)

--- a/tests/gtest_predicates.h
+++ b/tests/gtest_predicates.h
@@ -57,9 +57,15 @@ pred_near3(const char* xname, const char* yname, const char* mname, R1 x, R2 y,
   }
   R actual_err = std::abs(x - y);
   if (actual_err > max_err) {
-    return testing::AssertionFailure()
-           << xname << " and " << yname << " are not near, err " << actual_err
-           << " > " << max_err;
+    auto af = testing::AssertionFailure();
+    if (max_err == 0) {
+      af << "Expected equal values:\n";
+    } else {
+      af << "Expected near values (err=" << actual_err << " > " << max_err
+         << "):\n";
+    }
+    return af << "  " << xname << "\n    Which is: " << x << "\n"
+              << "  " << yname << "\n    Which is: " << y << "\n";
   }
   return testing::AssertionSuccess();
 }
@@ -77,9 +83,15 @@ pred_near3(const char* xname, const char* yname, const char* mname,
   }
   double actual_err = gt::abs(x - y);
   if (actual_err > max_err) {
-    return testing::AssertionFailure()
-           << xname << " and " << yname << " are not near, err " << actual_err
-           << " > " << max_err;
+    auto af = testing::AssertionFailure();
+    if (max_err == 0) {
+      af << "Expected equal values:\n";
+    } else {
+      af << "Expected near values (err=" << actual_err << " > " << max_err
+         << "):\n";
+    }
+    return af << "  " << xname << "\n    Which is: " << x << "\n"
+              << "  " << yname << "\n    Which is: " << y << "\n";
   }
   return testing::AssertionSuccess();
 }
@@ -105,7 +117,7 @@ pred_near3(const char* xname, const char* yname, const char* mname, E1&& x,
   using V = gt::expr_value_type<E1>;
   bool equal = true;
   int i;
-  double err;
+  double actual_err;
 
   if (max_err == -1.0) {
     max_err = gt::test::detail::max_err<V>::value;
@@ -118,8 +130,8 @@ pred_near3(const char* xname, const char* yname, const char* mname, E1&& x,
   int n = xflat.shape(0);
 
   for (i = 0; i < n; i++) {
-    err = gt::abs(xflat(i) - yflat(i));
-    if (err > max_err) {
+    actual_err = gt::abs(xflat(i) - yflat(i));
+    if (actual_err > max_err) {
       equal = false;
       break;
     }
@@ -134,13 +146,17 @@ pred_near3(const char* xname, const char* yname, const char* mname, E1&& x,
     }
     int end = std::min(start + max_view, n);
     auto xs = gt::slice(start, end);
-    return testing::AssertionFailure()
-           << "Arrays not close (max " << max_err << ") "
-           << " err " << err << " at [" << i << "]" << std::endl
-           << " " << xname << ":" << std::endl
-           << "  " << xflat.view(xs) << std::endl
-           << " " << yname << ":" << std::endl
-           << "  " << yflat.view(xs) << std::endl;
+
+    auto af = testing::AssertionFailure();
+    if (max_err == 0) {
+      af << "Expected equal values";
+    } else {
+      af << "Expected near values (err=" << actual_err << " > " << max_err
+         << ")";
+    }
+    af << " at [" << i << "]:\n";
+    return af << "  " << xname << "\n    Which is: " << xflat.view(xs) << "\n"
+              << "  " << yname << "\n    Which is: " << yflat.view(xs) << "\n";
   }
 
   return testing::AssertionSuccess();
@@ -155,7 +171,7 @@ pred_near3(const char* xname, const char* yname, const char* mname, E1&& x, R y,
   using V = gt::expr_value_type<E1>;
   bool equal = true;
   int i, n;
-  double err;
+  double actual_err;
 
   if (max_err == -1.0) {
     max_err = gt::test::detail::max_err<V>::value;
@@ -165,8 +181,8 @@ pred_near3(const char* xname, const char* yname, const char* mname, E1&& x, R y,
   n = xflat.shape(0);
 
   for (i = 0; i < n; i++) {
-    err = std::abs(gt::abs(xflat(i)) - y);
-    if (err > max_err) {
+    actual_err = std::abs(gt::abs(xflat(i)) - y);
+    if (actual_err > max_err) {
       equal = false;
       break;
     }
@@ -181,10 +197,17 @@ pred_near3(const char* xname, const char* yname, const char* mname, E1&& x, R y,
     }
     int end = std::min(start + max_view, n);
     auto xs = gt::slice(start, end);
-    return testing::AssertionFailure()
-           << "Array entries not close to value " << y << ", err " << err
-           << " at [" << i << "]" << std::endl
-           << " " << xname << ":" << xflat.view(xs) << std::endl;
+
+    auto af = testing::AssertionFailure();
+    if (max_err == 0) {
+      af << "Expected equal values";
+    } else {
+      af << "Expected near values (err=" << actual_err << " > " << max_err
+         << ")";
+    }
+    af << " at [" << i << "]:\n";
+    return af << "  " << xname << "\n    Which is: " << xflat.view(xs) << "\n"
+              << "  " << yname << "\n    Which is: " << y << "\n";
   }
 
   return testing::AssertionSuccess();

--- a/tests/gtest_predicates.h
+++ b/tests/gtest_predicates.h
@@ -1,0 +1,203 @@
+#include <algorithm>
+#include <iostream>
+#include <type_traits>
+
+#include <gtensor/gtensor.h>
+
+#include <gtest/gtest.h>
+
+#include "test_debug.h"
+
+namespace gt
+{
+
+namespace test
+{
+
+namespace detail
+{
+template <typename Real>
+struct max_err;
+
+template <>
+struct max_err<double>
+{
+  static constexpr double value = 1e-14;
+};
+
+template <>
+struct max_err<float>
+{
+  static constexpr double value = 1e-5;
+};
+
+template <>
+struct max_err<gt::complex<double>>
+{
+  static constexpr double value = 1e-14;
+};
+
+template <>
+struct max_err<gt::complex<float>>
+{
+  static constexpr double value = 1e-5;
+};
+
+} // namespace detail
+
+template <typename R1, typename R2>
+std::enable_if_t<std::is_arithmetic<R1>::value && std::is_arithmetic<R2>::value,
+                 testing::AssertionResult>
+pred_near3(const char* xname, const char* yname, const char* mname, R1 x, R2 y,
+           double max_err = -1.0)
+{
+  using R = decltype(x - y);
+  if (max_err == -1.0) {
+    max_err = gt::test::detail::max_err<R>::value;
+  }
+  R actual_err = std::abs(x - y);
+  if (actual_err > max_err) {
+    return testing::AssertionFailure()
+           << xname << " and " << yname << " are not near, err " << actual_err
+           << " > " << max_err;
+  }
+  return testing::AssertionSuccess();
+}
+
+template <typename R1, typename R2>
+std::enable_if_t<std::is_floating_point<R1>::value &&
+                   std::is_floating_point<R2>::value,
+                 testing::AssertionResult>
+pred_near3(const char* xname, const char* yname, const char* mname,
+           gt::complex<R1> x, gt::complex<R2> y, double max_err = -1.0)
+{
+  using R = decltype(std::declval<R1>() - std::declval<R2>());
+  if (max_err == -1.0) {
+    max_err = gt::test::detail::max_err<R>::value;
+  }
+  double actual_err = gt::abs(x - y);
+  if (actual_err > max_err) {
+    return testing::AssertionFailure()
+           << xname << " and " << yname << " are not near, err " << actual_err
+           << " > " << max_err;
+  }
+  return testing::AssertionSuccess();
+}
+
+template <typename R1, typename R2>
+std::enable_if_t<std::is_floating_point<R1>::value &&
+                   std::is_arithmetic<R2>::value,
+                 testing::AssertionResult>
+pred_near3(const char* xname, const char* yname, const char* mname,
+           gt::complex<R1> x, R2 y, double max_err = -1.0)
+{
+  return pred_near3(xname, yname, mname,
+                    gt::complex<double>(x.real(), x.imag()),
+                    gt::complex<double>(y, 0.0), max_err);
+}
+
+template <typename E1, typename E2>
+std::enable_if_t<gt::is_expression<E1>::value && gt::is_expression<E2>::value,
+                 testing::AssertionResult>
+pred_near3(const char* xname, const char* yname, const char* mname, E1&& x,
+           E2&& y, double max_err = -1.0)
+{
+  using V = gt::expr_value_type<E1>;
+  bool equal = true;
+  int i;
+  double err;
+
+  if (max_err == -1.0) {
+    max_err = gt::test::detail::max_err<V>::value;
+  }
+  auto xflat = gt::flatten(x);
+  auto yflat = gt::flatten(y);
+
+  assert(xflat.shape(0) == yflat.shape(0));
+
+  int n = xflat.shape(0);
+
+  for (i = 0; i < n; i++) {
+    err = gt::abs(xflat(i) - yflat(i));
+    if (err > max_err) {
+      equal = false;
+      break;
+    }
+  }
+
+  if (!equal) {
+    const int max_view = 10;
+    int start = i;
+    int tail = start + max_view - n;
+    if (tail > 0) {
+      start = std::max(start - tail, 0);
+    }
+    int end = std::min(start + max_view, n);
+    auto xs = gt::slice(start, end);
+    return testing::AssertionFailure()
+           << "Arrays not close (max " << max_err << ") "
+           << " err " << err << " at [" << i << "]" << std::endl
+           << " " << xname << ":" << std::endl
+           << "  " << xflat.view(xs) << std::endl
+           << " " << yname << ":" << std::endl
+           << "  " << yflat.view(xs) << std::endl;
+  }
+
+  return testing::AssertionSuccess();
+}
+
+template <typename E1, typename R>
+std::enable_if_t<gt::is_expression<E1>::value && !gt::is_expression<R>::value,
+                 testing::AssertionResult>
+pred_near3(const char* xname, const char* yname, const char* mname, E1&& x, R y,
+           double max_err = -1.0)
+{
+  using V = gt::expr_value_type<E1>;
+  bool equal = true;
+  int i, n;
+  double err;
+
+  if (max_err == -1.0) {
+    max_err = gt::test::detail::max_err<V>::value;
+  }
+
+  auto xflat = gt::flatten(x);
+  n = xflat.shape(0);
+
+  for (i = 0; i < n; i++) {
+    err = std::abs(gt::abs(xflat(i)) - y);
+    if (err > max_err) {
+      equal = false;
+      break;
+    }
+  }
+
+  if (!equal) {
+    const int max_view = 10;
+    int start = i;
+    int tail = start + max_view - n;
+    if (tail > 0) {
+      start = std::max(start - tail, 0);
+    }
+    int end = std::min(start + max_view, n);
+    auto xs = gt::slice(start, end);
+    return testing::AssertionFailure()
+           << "Array entries not close to value " << y << ", err " << err
+           << " at [" << i << "]" << std::endl
+           << " " << xname << ":" << xflat.view(xs) << std::endl;
+  }
+
+  return testing::AssertionSuccess();
+}
+
+} // namespace test
+
+} // namespace gt
+
+#define GT_EXPECT_NEAR(a, b)                                                   \
+  EXPECT_PRED_FORMAT3(gt::test::pred_near3, a, b, -1.0)
+
+#define GT_EXPECT_NEAR_MAXERR(a, b, max)                                       \
+  EXPECT_PRED_FORMAT3(gt::test::pred_near3, a, b, static_cast<double>(max))
+
+#define GT_EXPECT_EQ(a, b) EXPECT_PRED_FORMAT3(gt::test::pred_near3, a, b, 0.0)

--- a/tests/test_fft.cxx
+++ b/tests/test_fft.cxx
@@ -8,7 +8,7 @@
 
 #include "gt-fft/fft.h"
 
-#include "test_helpers.h"
+#include "gtest_predicates.h"
 
 constexpr double PI = 3.141592653589793;
 
@@ -60,15 +60,15 @@ void fft_r2c_1d()
   plan.inverse(d_B, d_A2);
   gt::copy(d_A2, h_A2);
 
-  EXPECT_EQ(h_A, h_A2 / N);
+  GT_EXPECT_EQ(h_A, h_A2 / N);
 
-  expect_complex_near(h_B(0, 0), T(8, 0));
-  expect_complex_near(h_B(1, 0), T(3, 1));
-  expect_complex_near(h_B(2, 0), T(-6, 0));
+  GT_EXPECT_NEAR(h_B(0, 0), T(8, 0));
+  GT_EXPECT_NEAR(h_B(1, 0), T(3, 1));
+  GT_EXPECT_NEAR(h_B(2, 0), T(-6, 0));
 
-  expect_complex_near(h_B(0, 1), T(-2, 0));
-  expect_complex_near(h_B(1, 1), T(-4, 22));
-  expect_complex_near(h_B(2, 1), T(38, 0));
+  GT_EXPECT_NEAR(h_B(0, 1), T(-2, 0));
+  GT_EXPECT_NEAR(h_B(1, 1), T(-4, 22));
+  GT_EXPECT_NEAR(h_B(2, 1), T(38, 0));
 
   // reset input and output arrays and repeat with alternate ctor
   gt::copy(h_A, d_A);
@@ -84,15 +84,15 @@ void fft_r2c_1d()
   plan2.inverse(d_B, d_A2);
   gt::copy(d_A2, h_A2);
 
-  EXPECT_EQ(h_A, h_A2 / N);
+  GT_EXPECT_EQ(h_A, h_A2 / N);
 
-  expect_complex_near(h_B(0, 0), T(8, 0));
-  expect_complex_near(h_B(1, 0), T(3, 1));
-  expect_complex_near(h_B(2, 0), T(-6, 0));
+  GT_EXPECT_NEAR(h_B(0, 0), T(8, 0));
+  GT_EXPECT_NEAR(h_B(1, 0), T(3, 1));
+  GT_EXPECT_NEAR(h_B(2, 0), T(-6, 0));
 
-  expect_complex_near(h_B(0, 1), T(-2, 0));
-  expect_complex_near(h_B(1, 1), T(-4, 22));
-  expect_complex_near(h_B(2, 1), T(38, 0));
+  GT_EXPECT_NEAR(h_B(0, 1), T(-2, 0));
+  GT_EXPECT_NEAR(h_B(1, 1), T(-4, 22));
+  GT_EXPECT_NEAR(h_B(2, 1), T(38, 0));
 }
 
 TEST(fft, d2z_1d)
@@ -165,8 +165,8 @@ void fft_r2c_1d_strided()
   plan.inverse(d_B, d_A2);
   gt::copy(d_A2, h_A2);
 
-  GT_EXPECT_NEAR_ARRAY(h_B_expected, h_B);
-  GT_EXPECT_NEAR_ARRAY(h_A, h_A2 / N);
+  GT_EXPECT_EQ(h_B_expected, h_B);
+  GT_EXPECT_EQ(h_A, h_A2 / N);
 }
 
 TEST(fft, d2z_1d_strided)
@@ -271,15 +271,15 @@ void fft_c2c_1d_forward()
 
   gt::copy(d_B, h_B);
 
-  expect_complex_near(h_B(0, 0), T(8, 0));
-  expect_complex_near(h_B(1, 0), T(3, 1));
-  expect_complex_near(h_B(2, 0), T(-6, 0));
-  expect_complex_near(h_B(3, 0), T(3, -1));
+  GT_EXPECT_NEAR(h_B(0, 0), T(8, 0));
+  GT_EXPECT_NEAR(h_B(1, 0), T(3, 1));
+  GT_EXPECT_NEAR(h_B(2, 0), T(-6, 0));
+  GT_EXPECT_NEAR(h_B(3, 0), T(3, -1));
 
-  expect_complex_near(h_B(0, 1), T(-2, 0));
-  expect_complex_near(h_B(1, 1), T(-4, 22));
-  expect_complex_near(h_B(2, 1), T(38, 0));
-  expect_complex_near(h_B(3, 1), T(-4, -22));
+  GT_EXPECT_NEAR(h_B(0, 1), T(-2, 0));
+  GT_EXPECT_NEAR(h_B(1, 1), T(-4, 22));
+  GT_EXPECT_NEAR(h_B(2, 1), T(38, 0));
+  GT_EXPECT_NEAR(h_B(3, 1), T(-4, -22));
 
   // test round trip
   plan.inverse(d_B, d_A2);
@@ -287,7 +287,7 @@ void fft_c2c_1d_forward()
 
   for (int i = 0; i < h_A.shape(1); i++) {
     for (int j = 0; j < h_A.shape(0); j++) {
-      expect_complex_near(h_A(j, i), h_A2(j, i) / T(N, 0));
+      GT_EXPECT_NEAR(h_A(j, i), h_A2(j, i) / T(N, 0));
     }
   }
 }
@@ -361,8 +361,8 @@ void fft_c2c_1d_forward_strided()
   plan.inverse(d_B, d_A2);
   gt::copy(d_A2, h_A2);
 
-  GT_EXPECT_NEAR_ARRAY(h_B_expected, h_B);
-  GT_EXPECT_NEAR_ARRAY(h_A, h_A2 / T(N, 0));
+  GT_EXPECT_NEAR(h_B_expected, h_B);
+  GT_EXPECT_NEAR(h_A, h_A2 / T(N, 0));
 }
 
 TEST(fft, z2z_1d_forward_strided)
@@ -411,15 +411,15 @@ void fft_c2c_1d_inverse()
 
   // required when using std::complex, int multiply is not defined
   auto dN = static_cast<E>(N);
-  expect_complex_near(h_B(0, 0), dN * T(2, 0));
-  expect_complex_near(h_B(1, 0), dN * T(3, 0));
-  expect_complex_near(h_B(2, 0), dN * T(-1, 0));
-  expect_complex_near(h_B(3, 0), dN * T(4, 0));
+  GT_EXPECT_NEAR(h_B(0, 0), dN * T(2, 0));
+  GT_EXPECT_NEAR(h_B(1, 0), dN * T(3, 0));
+  GT_EXPECT_NEAR(h_B(2, 0), dN * T(-1, 0));
+  GT_EXPECT_NEAR(h_B(3, 0), dN * T(4, 0));
 
-  expect_complex_near(h_B(0, 1), dN * T(7, 0));
-  expect_complex_near(h_B(1, 1), dN * T(-21, 0));
-  expect_complex_near(h_B(2, 1), dN * T(11, 0));
-  expect_complex_near(h_B(3, 1), dN * T(1, 0));
+  GT_EXPECT_NEAR(h_B(0, 1), dN * T(7, 0));
+  GT_EXPECT_NEAR(h_B(1, 1), dN * T(-21, 0));
+  GT_EXPECT_NEAR(h_B(2, 1), dN * T(11, 0));
+  GT_EXPECT_NEAR(h_B(3, 1), dN * T(1, 0));
 }
 
 TEST(fft, z2z_1d_inverse)
@@ -477,9 +477,9 @@ TEST(fft, move_only)
 
   gt::copy(d_B, h_B);
 
-  expect_complex_near(h_B(0, 0), T(8, 0));
-  expect_complex_near(h_B(1, 0), T(3, 1));
-  expect_complex_near(h_B(2, 0), T(-6, 0));
+  GT_EXPECT_NEAR(h_B(0, 0), T(8, 0));
+  GT_EXPECT_NEAR(h_B(1, 0), T(3, 1));
+  GT_EXPECT_NEAR(h_B(2, 0), T(-6, 0));
 }
 
 template <typename E>
@@ -531,12 +531,12 @@ void fft_r2c_2d()
     }
   }
 
-  GT_EXPECT_NEAR_ARRAY_ERR(h_B_expected, h_B, max_err);
+  GT_EXPECT_NEAR_MAXERR(h_B_expected, h_B, max_err);
 
   // test roundtripping data, with normalization
   plan.inverse(d_B, d_A2);
   gt::copy(d_A2, h_A2);
-  GT_EXPECT_NEAR_ARRAY(h_A, h_A2 / (Nx * Ny));
+  GT_EXPECT_NEAR(h_A, h_A2 / (Nx * Ny));
 }
 
 TEST(fft, r2c_2d)
@@ -587,7 +587,7 @@ void fft_c2c_2d()
   gt::copy(d_A2, h_A2);
   for (int i = 0; i < h_A.shape(0); i++) {
     for (int j = 0; j < h_A.shape(1); j++) {
-      expect_complex_near(h_A(i, j, 0), h_A2(i, j, 0) / T(Nx * Ny, 0));
+      GT_EXPECT_NEAR(h_A(i, j, 0), h_A2(i, j, 0) / T(Nx * Ny, 0));
     }
   }
 }
@@ -630,12 +630,12 @@ void fft_r2c_3d()
   gt::copy(d_B, h_B);
 
   // FFT of delta function is all ones in magnitude
-  GT_EXPECT_NEAR_ARRAY_ABS(h_B, 1.0);
+  GT_EXPECT_NEAR(h_B, 1.0);
 
   // test roundtripping data, with normalization
   plan.inverse(d_B, d_A2);
   gt::copy(d_A2, h_A2);
-  GT_EXPECT_NEAR_ARRAY(h_A, h_A2 / (Nx * Ny * Nz));
+  GT_EXPECT_NEAR(h_A, h_A2 / (Nx * Ny * Nz));
 }
 
 TEST(fft, r2c_3d)

--- a/tests/test_gtest_predicates.cxx
+++ b/tests/test_gtest_predicates.cxx
@@ -1,0 +1,69 @@
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "gtensor/gtensor.h"
+
+#include "gtest_predicates.h"
+#include "test_debug.h"
+
+using namespace gt::placeholders;
+
+TEST(gtest_predicates, fp)
+{
+  double a = 1.0;
+  double b = 0.5;
+  GT_EXPECT_EQ(a, 2 * b);
+
+  float af = 1.0;
+  float bf = 0.5;
+  GT_EXPECT_EQ(af, 2 * bf);
+}
+
+TEST(gtest_predicates, complex)
+{
+  using D = gt::complex<double>;
+  D a = D(-1.0, 0.0);
+  D b = D(0.0, 1.0);
+  GT_EXPECT_EQ(a, b * b);
+
+  using F = gt::complex<float>;
+  F af = F(-1.0, 0.0);
+  F bf = F(0.0, 1.0);
+  GT_EXPECT_EQ(a, b * b);
+}
+
+TEST(gtest_predicates, complex_fp)
+{
+  using D = gt::complex<double>;
+  D im_d = D(0.0, -1.0);
+  GT_EXPECT_EQ(im_d * im_d, -1.0);
+
+  using F = gt::complex<float>;
+  F im_f = F(0.0, -1.0);
+  GT_EXPECT_EQ(im_f * im_f, -1.0);
+}
+
+TEST(gtest_predicates, gtensor_expr)
+{
+  gt::gtensor<double, 1> a{1, 2, 3};
+  gt::gtensor<double, 1> b{0.5, 1, 1.5};
+  gt::gtensor<double, 1> c{0.5, -1, 1.5};
+
+  GT_EXPECT_NEAR(a, 2 * b);
+
+  auto ar = gt::test::pred_near3("a", "c", "err", a, 2 * c, 0.0001);
+  EXPECT_FALSE(ar);
+  EXPECT_NE(std::string(ar.message()).find("at [1]"), std::string::npos);
+}
+
+TEST(gtest_predicates, gtensor_value)
+{
+  gt::gtensor<double, 1> a{1.001, 1.000001, 1.000000000001};
+
+  GT_EXPECT_NEAR_MAXERR(a, 1.0, 0.01);
+
+  auto ar = gt::test::pred_near3("a", "1", "err", a, 1.0, 0.0001);
+  EXPECT_FALSE(ar);
+  EXPECT_NE(std::string(ar.message()).find("at [0]"), std::string::npos);
+}

--- a/tests/test_gtest_predicates.cxx
+++ b/tests/test_gtest_predicates.cxx
@@ -15,6 +15,10 @@ TEST(gtest_predicates, fp)
   double b = 0.5;
   GT_EXPECT_EQ(a, 2 * b);
 
+  auto ar = gt::test::pred_near3("a", "1.1", "err", a, 1.1, 0);
+  std::cout << "a = 1.1 message:\n" << ar.message() << std::endl;
+  EXPECT_FALSE(ar);
+
   float af = 1.0;
   float bf = 0.5;
   GT_EXPECT_EQ(af, 2 * bf);
@@ -39,6 +43,10 @@ TEST(gtest_predicates, complex_fp)
   D im_d = D(0.0, -1.0);
   GT_EXPECT_EQ(im_d * im_d, -1.0);
 
+  auto ar = gt::test::pred_near3("im_d", "-1.0", "err", im_d, -1.0, 0.5);
+  std::cout << "im_d == -1 message:\n" << ar.message() << std::endl;
+  EXPECT_FALSE(ar);
+
   using F = gt::complex<float>;
   F im_f = F(0.0, -1.0);
   GT_EXPECT_EQ(im_f * im_f, -1.0);
@@ -53,6 +61,7 @@ TEST(gtest_predicates, gtensor_expr)
   GT_EXPECT_NEAR(a, 2 * b);
 
   auto ar = gt::test::pred_near3("a", "c", "err", a, 2 * c, 0.0001);
+  std::cout << "a near 2*c message:" << std::endl << ar.message() << std::endl;
   EXPECT_FALSE(ar);
   EXPECT_NE(std::string(ar.message()).find("at [1]"), std::string::npos);
 }
@@ -64,6 +73,7 @@ TEST(gtest_predicates, gtensor_value)
   GT_EXPECT_NEAR_MAXERR(a, 1.0, 0.01);
 
   auto ar = gt::test::pred_near3("a", "1", "err", a, 1.0, 0.0001);
+  std::cout << "a near 1.0 message:" << std::endl << ar.message() << std::endl;
   EXPECT_FALSE(ar);
   EXPECT_NE(std::string(ar.message()).find("at [0]"), std::string::npos);
 }


### PR DESCRIPTION
Adds overloaded GT_EXPECT_EQ(a, b), GT_EXPECT_NEAR(a, b), and GT_EXPECT_NEAR_MAXERR(a, b, max_err) macros that work with scalars, gtensor expressions, and combinations of the two (expressions must be in first position). The idea is for this to replace the confusingly named test_helpers.h header.