### PR TITLE
reductions: add specific thrust headers

### DIFF
--- a/include/gtensor/reductions.h
+++ b/include/gtensor/reductions.h
@@ -4,7 +4,9 @@
 #include "gtensor.h"
 
 #if defined(GTENSOR_DEVICE_CUDA) || defined(GTENSOR_DEVICE_HIP)
+#include <thrust/extrema.h>
 #include <thrust/reduce.h>
+#include <thrust/transform_reduce.h>
 #endif
 
 #include <algorithm>


### PR DESCRIPTION
As of rocthrust 5.3.0, the reduce.h header no longer include max_element and transform_reduce. The good news is that the fine grained headers appear to have existed in both cuda nad rocm thrust for a while, so adding them fixes 5.3.0 without breaking older releases.