### PR TITLE
Pr/sycl ext complex

### DIFF
--- a/.github/workflows/sycl.yml
+++ b/.github/workflows/sycl.yml
@@ -10,15 +10,15 @@ on:
 jobs:
   test-sycl:
     runs-on: ubuntu-latest
-    container: ghcr.io/wdmapp/oneapi-dpcpp-ubuntu-20.04:latest
+    container: ghcr.io/wdmapp/oneapi-dpcpp-ubuntu-20.04:20221119
     env:
       GTEST_VERSION: 1.10.0
       GTEST_ROOT: ${{ github.workspace }}/googletest
       SYCL_DEVICE_FILTER: host
       DEBIAN_FRONTEND: noninteractive
       GTENSOR_TEST_EXCLUDE: test_fft test_reductions
-      LD_LIBRARY_PATH: /opt/intel/oneapi/tbb/2021.5.1/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2022.0.2/lib/intel64:/opt/intel/oneapi/debugger/2021.5.0/gdb/intel64/lib:/opt/intel/oneapi/debugger/2021.5.0/libipt/intel64/lib:/opt/intel/oneapi/debugger/2021.5.0/dep/lib:/opt/intel/oneapi/compiler/2022.0.2/linux/lib:/opt/intel/oneapi/compiler/2022.0.2/linux/lib/x64:/opt/intel/oneapi/compiler/2022.0.2/linux/lib/oclfpga/host/linux64/lib:/opt/intel/oneapi/compiler/2022.0.2/linux/compiler/lib/intel64_lin
-      PATH: /opt/intel/oneapi/mkl/2022.0.2/bin/intel64:/opt/intel/oneapi/dev-utilities/2021.5.1/bin:/opt/intel/oneapi/debugger/2021.5.0/gdb/intel64/bin:/opt/intel/oneapi/compiler/2022.0.2/linux/lib/oclfpga/bin:/opt/intel/oneapi/compiler/2022.0.2/linux/bin/intel64:/opt/intel/oneapi/compiler/2022.0.2/linux/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      LD_LIBRARY_PATH: /opt/intel/oneapi/tbb/2021.7.1/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2022.2.1/lib/intel64:/opt/intel/oneapi/debugger/2021.7.1/gdb/intel64/lib:/opt/intel/oneapi/debugger/2021.7.1/libipt/intel64/lib:/opt/intel/oneapi/debugger/2021.7.1/dep/lib:/opt/intel/oneapi/compiler/2022.2.1/linux/lib:/opt/intel/oneapi/compiler/2022.2.1/linux/lib/x64:/opt/intel/oneapi/compiler/2022.2.1/linux/lib/oclfpga/host/linux64/lib:/opt/intel/oneapi/compiler/2022.2.1/linux/compiler/lib/intel64_lin
+      PATH: /opt/intel/oneapi/mkl/2022.2.1/bin/intel64:/opt/intel/oneapi/dev-utilities/2021.7.1/bin:/opt/intel/oneapi/debugger/2021.7.1/gdb/intel64/bin:/opt/intel/oneapi/compiler/2022.2.1/linux/lib/oclfpga/bin:/opt/intel/oneapi/compiler/2022.2.1/linux/bin/intel64:/opt/intel/oneapi/compiler/2022.2.1/linux/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
     - uses: actions/checkout@v2
     - name: clinfo
@@ -26,10 +26,14 @@ jobs:
         mkdir -p /etc/OpenCL/vendors
         echo "libintelocl.so" > /etc/OpenCL/vendors/intel-cpu.icd
         clinfo
+    - name: sycl-ls
+      run: |
+        which sycl-ls
+        SYCL_DEVICE_FILTER="*" sycl-ls
     - name: setup compiler env
       run: |
-        which dpcpp
-        echo "CXX=$(which dpcpp)" >> $GITHUB_ENV
+        which icpx
+        echo "CXX=$(which icpx)" >> $GITHUB_ENV
     - name: env check
       run: |
         env | grep oneapi
@@ -44,11 +48,11 @@ jobs:
       env:
         CXX: clang++-9
     - name: cmake host
-      run: cmake -S . -B build-sycl-host -DGTENSOR_DEVICE=sycl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGTENSOR_BUILD_EXAMPLES=ON -DGTENSOR_DEVICE_SYCL_SELECTOR=host -DGTEST_ROOT=${{ env.GTEST_ROOT }} -DGTENSOR_ENABLE_CLIB=ON -DGTENSOR_ENABLE_BLAS=On -DGTENSOR_ENABLE_FFT=ON -DGTENSOR_TEST_DEBUG=ON -DGTENSOR_DEVICE_SYCL_ILP64=ON
+      run: cmake -S . -B build-sycl-host -DGTENSOR_DEVICE=sycl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGTENSOR_BUILD_EXAMPLES=ON -DGTEST_ROOT=${{ env.GTEST_ROOT }} -DGTENSOR_ENABLE_CLIB=ON -DGTENSOR_ENABLE_BLAS=On -DGTENSOR_ENABLE_FFT=ON -DGTENSOR_TEST_DEBUG=ON -DGTENSOR_DEVICE_SYCL_ILP64=ON
     - name: cmake host build
       run: cmake --build build-sycl-host -v
     - name: cmake debug
-      run: cmake -S . -B build-sycl-debug -DGTENSOR_DEVICE=sycl -DCMAKE_BUILD_TYPE=Debug -DGTENSOR_BUILD_EXAMPLES=ON -DGTENSOR_DEVICE_SYCL_SELECTOR=host -DGTEST_ROOT=${{ env.GTEST_ROOT }} -DGTENSOR_ENABLE_CLIB=ON -DGTENSOR_ENABLE_BLAS=ON -DGTENSOR_ENABLE_FFT=ON -DGTENSOR_TEST_DEBUG=ON -DGTENSOR_DEVICE_SYCL_ILP64=ON
+      run: cmake -S . -B build-sycl-debug -DGTENSOR_DEVICE=sycl -DCMAKE_BUILD_TYPE=Debug -DGTENSOR_BUILD_EXAMPLES=ON -DGTEST_ROOT=${{ env.GTEST_ROOT }} -DGTENSOR_ENABLE_CLIB=ON -DGTENSOR_ENABLE_BLAS=ON -DGTENSOR_ENABLE_FFT=ON -DGTENSOR_TEST_DEBUG=ON -DGTENSOR_DEVICE_SYCL_ILP64=ON
     - name: cmake debug build
       run: cmake --build build-sycl-debug -v
     - name: cmake host run tests
@@ -66,7 +70,7 @@ jobs:
       run: mkdir -p external/gtensor &&  cp -R ../include external/gtensor/
       working-directory: ${{ github.workspace }}/examples
     - name: GNU make build
-      run: make GTENSOR_DEVICE=sycl GTENSOR_DEVICE_SYCL_SELECTOR=host
+      run: make GTENSOR_DEVICE=sycl
       working-directory: ${{ github.workspace }}/examples
     - name: GNU make run daxpy
       run: ./daxpy

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -14,7 +14,7 @@ GTENSOR_DEVICE_DEFINE := GTENSOR_DEVICE_$(shell echo $(GTENSOR_DEVICE) | tr a-z 
 GTENSOR_DEFINES = -D$(GTENSOR_DEVICE_DEFINE)
 GTENSOR_INCLUDES = -I$(GTENSOR_DIR)/include
 GTENSOR_LIBS =
-GTENSOR_OPTIONS = -std=c++14 -O3
+GTENSOR_OPTIONS = -std=c++14 -O2
 ifeq ($(GTENSOR_DEVICE),cuda)
   GTENSOR_CXX ?= nvcc
   GTENSOR_OPTIONS += -x cu --expt-extended-lambda --expt-relaxed-constexpr
@@ -35,11 +35,7 @@ else ifeq ($(GTENSOR_DEVICE),hip)
 else ifeq ($(GTENSOR_DEVICE),sycl)
   ONEAPI_PATH ?= /opt/intel/oneapi
   GTENSOR_CXX ?= $(ONEAPI_PATH)/compiler/latest/linux/bin/dpcpp
-  GTENSOR_OPTIONS += -fsycl
-
-  GTENSOR_DEVICE_SYCL_SELECTOR ?= gpu
-  GTENSOR_DEVICE_SYCL_SELECTOR_DEFINE := GTENSOR_DEVICE_SYCL_$(shell echo $(GTENSOR_DEVICE_SYCL_SELECTOR) | tr a-z A-Z)
-  GTENSOR_DEFINES += -D$(GTENSOR_DEVICE_SYCL_SELECTOR_DEFINE)
+  GTENSOR_OPTIONS = -fsycl -std=c++17 -O2
   # Note: SYCL doesn't support assert in device code
   GTENSOR_DEFINES += -DGTENSOR_HAVE_DEVICE -DNDEBUG
 else

--- a/include/gt-fft/backend/sycl.h
+++ b/include/gt-fft/backend/sycl.h
@@ -6,6 +6,8 @@
 #include <stdexcept>
 
 #include "gtensor/backend_sycl.h"
+#include "gtensor/complex.h"
+
 #include <oneapi/mkl.hpp>
 
 // Should be possible to use MKL_LONG, but for somereason it is not defined
@@ -31,8 +33,8 @@ struct fft_config<gt::fft::Domain::COMPLEX, double>
                                             oneapi::mkl::dft::domain::COMPLEX>;
   using Tin = gt::complex<double>;
   using Tout = gt::complex<double>;
-  using Bin = gt::complex<double>;
-  using Bout = gt::complex<double>;
+  using Bin = std::complex<double>;
+  using Bout = std::complex<double>;
 };
 
 template <>
@@ -42,8 +44,8 @@ struct fft_config<gt::fft::Domain::COMPLEX, float>
                                             oneapi::mkl::dft::domain::COMPLEX>;
   using Tin = gt::complex<float>;
   using Tout = gt::complex<float>;
-  using Bin = gt::complex<float>;
-  using Bout = gt::complex<float>;
+  using Bin = std::complex<float>;
+  using Bout = std::complex<float>;
 };
 
 template <>

--- a/include/gtensor/backend_sycl_device.h
+++ b/include/gtensor/backend_sycl_device.h
@@ -187,7 +187,11 @@ public:
     // Get devices from default platform, which for Intel implementation
     // can be controlled with SYCL_DEVICE_FILTER env variable. This
     // allows flexible selection at runtime.
+#if (__INTEL_CLANG_COMPILER && __INTEL_CLANG_COMPILER < 20230100)
     ::sycl::platform p{::sycl::default_selector()};
+#else
+    ::sycl::platform p{::sycl::default_selector_v};
+#endif
 
     devices_ = get_devices_with_numa_sub(p);
 

--- a/include/gtensor/complex.h
+++ b/include/gtensor/complex.h
@@ -28,7 +28,7 @@ using complex = thrust::complex<T>;
 
 // TODO: this will hopefully be standardized soon and be sycl::complex
 template <typename T>
-using complex = ::sycl::ext::cplx::complex<T>;
+using complex = gt::sycl_cplx::complex<T>;
 
 #else // fallback to std::complex, e.g. for host backend
 

--- a/include/gtensor/complex.h
+++ b/include/gtensor/complex.h
@@ -5,6 +5,7 @@
 #if defined(GTENSOR_DEVICE_CUDA) || defined(GTENSOR_DEVICE_HIP)
 #include <thrust/complex.h>
 #elif defined(GTENSOR_DEVICE_SYCL)
+#define _SYCL_CPLX_NAMESPACE gt::sycl_cplx
 #include "sycl_ext_complex.hpp"
 #else
 #include <complex>

--- a/include/gtensor/complex.h
+++ b/include/gtensor/complex.h
@@ -4,6 +4,8 @@
 
 #if defined(GTENSOR_DEVICE_CUDA) || defined(GTENSOR_DEVICE_HIP)
 #include <thrust/complex.h>
+#elif defined(GTENSOR_DEVICE_SYCL)
+#include "sycl_ext_complex.hpp"
 #else
 #include <complex>
 #endif
@@ -21,7 +23,13 @@ namespace gt
 template <typename T>
 using complex = thrust::complex<T>;
 
-#else // not CUDA or HIP
+#elif defined(GTENSOR_DEVICE_SYCL)
+
+// TODO: this will hopefully be standardized soon and be sycl::complex
+template <typename T>
+using complex = ::sycl::ext::cplx::complex<T>;
+
+#else // fallback to std::complex, e.g. for host backend
 
 template <typename T>
 using complex = std::complex<T>;

--- a/include/gtensor/complex_ops.h
+++ b/include/gtensor/complex_ops.h
@@ -59,10 +59,10 @@ GT_INLINE complex<T> exp(thrust::device_reference<const thrust::complex<T>> a)
 
 #elif defined(GTENSOR_DEVICE_SYCL)
 
-using ::sycl::ext::cplx::abs;
-using ::sycl::ext::cplx::conj;
-using ::sycl::ext::cplx::exp;
-using ::sycl::ext::cplx::norm;
+using gt::sycl_cplx::abs;
+using gt::sycl_cplx::conj;
+using gt::sycl_cplx::exp;
+using gt::sycl_cplx::norm;
 
 // real version from stdlib
 using std::abs;

--- a/include/gtensor/complex_ops.h
+++ b/include/gtensor/complex_ops.h
@@ -57,7 +57,18 @@ GT_INLINE complex<T> exp(thrust::device_reference<const thrust::complex<T>> a)
   return thrust::exp(thrust::raw_reference_cast(a));
 }
 
-#else // not CUDA and GTENSOR_USE_THRUST not defined
+#elif defined(GTENSOR_DEVICE_SYCL)
+
+using ::sycl::ext::cplx::abs;
+using ::sycl::ext::cplx::conj;
+using ::sycl::ext::cplx::exp;
+using ::sycl::ext::cplx::norm;
+
+// real version from stdlib
+using std::abs;
+using std::exp;
+
+#else // host, use std lib
 
 template <typename T>
 GT_INLINE T norm(const complex<T>& a)

--- a/include/gtensor/sycl_ext_complex.hpp
+++ b/include/gtensor/sycl_ext_complex.hpp
@@ -244,14 +244,29 @@ template<class T> complex<T> tanh (const complex<T>&);
 
 // clang-format on
 
-#define _SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD namespace gt::sycl_cplx {
+#ifndef _SYCL_CPLX_NAMESPACE
+#ifdef __HIPSYCL__
+#define _SYCL_CPLX_NAMESPACE hipsycl::sycl::ext::cplx
+#else
+#define _SYCL_CPLX_NAMESPACE sycl::ext::cplx
+#endif
+#endif
+
+#define _SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD namespace _SYCL_CPLX_NAMESPACE {
 #define _SYCL_EXT_CPLX_END_NAMESPACE_STD }
 #define _SYCL_EXT_CPLX_INLINE_VISIBILITY                                       \
-  inline __attribute__((__visibility__("hidden"), __always_inline__))
+  [[gnu::always_inline]] [[clang::always_inline]] inline
 
 #include <complex>
 #include <sstream> // for std::basic_ostringstream
-#include "backend_sycl_compat.h"
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#elif __has_include(<CL/sycl.hpp>)
+// support oneAPI 2022.X and earlier
+#include <CL/sycl.hpp>
+#else
+#error "SYCL header not found"
+#endif
 #include <type_traits>
 
 _SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD
@@ -982,13 +997,12 @@ template <class _Tp> struct __libcpp_complex_overload_traits<_Tp, false, true> {
 // real
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr _Tp
-real(const complex<_Tp> &__c) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr _Tp real(const complex<_Tp> &__c) {
   return __c.real();
 }
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
+_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
     typename __libcpp_complex_overload_traits<_Tp>::_ValueType
     real(_Tp __re) {
   return __re;
@@ -997,13 +1011,12 @@ SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
 // imag
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr _Tp
-imag(const complex<_Tp> &__c) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr _Tp imag(const complex<_Tp> &__c) {
   return __c.imag();
 }
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
+_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
     typename __libcpp_complex_overload_traits<_Tp>::_ValueType
     imag(_Tp) {
   return 0;
@@ -1012,21 +1025,19 @@ SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
 // abs
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp
-abs(const complex<_Tp> &__c) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp abs(const complex<_Tp> &__c) {
   return sycl::hypot(__c.real(), __c.imag());
 }
 
 // arg
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp
-arg(const complex<_Tp> &__c) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp arg(const complex<_Tp> &__c) {
   return sycl::atan2(__c.imag(), __c.real());
 }
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+_SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename std::enable_if<std::is_integral<_Tp>::value ||
                                 std::is_same<_Tp, double>::value,
                             double>::type
@@ -1035,7 +1046,7 @@ SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 }
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+_SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename std::enable_if<std::is_same<_Tp, float>::value, float>::type
     arg(_Tp __re) {
   return sycl::atan2(0.F, __re);
@@ -1044,8 +1055,7 @@ SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 // norm
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp
-norm(const complex<_Tp> &__c) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp norm(const complex<_Tp> &__c) {
   if (sycl::isinf(__c.real()))
     return sycl::fabs(__c.real());
   if (sycl::isinf(__c.imag()))
@@ -1054,7 +1064,7 @@ norm(const complex<_Tp> &__c) {
 }
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+_SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename __libcpp_complex_overload_traits<_Tp>::_ValueType
     norm(_Tp __re) {
   typedef typename __libcpp_complex_overload_traits<_Tp>::_ValueType _ValueType;
@@ -1064,13 +1074,12 @@ SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 // conj
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-conj(const complex<_Tp> &__c) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> conj(const complex<_Tp> &__c) {
   return complex<_Tp>(__c.real(), -__c.imag());
 }
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+_SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename __libcpp_complex_overload_traits<_Tp>::_ComplexType
     conj(_Tp __re) {
   typedef
@@ -1081,8 +1090,7 @@ SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 // proj
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-proj(const complex<_Tp> &__c) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> proj(const complex<_Tp> &__c) {
   complex<_Tp> __r = __c;
   if (sycl::isinf(__c.real()) || sycl::isinf(__c.imag()))
     __r = complex<_Tp>(INFINITY, sycl::copysign(_Tp(0), __c.imag()));
@@ -1090,7 +1098,7 @@ proj(const complex<_Tp> &__c) {
 }
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY typename std::enable_if<
+_SYCL_EXT_CPLX_INLINE_VISIBILITY typename std::enable_if<
     std::is_floating_point<_Tp>::value,
     typename __libcpp_complex_overload_traits<_Tp>::_ComplexType>::type
 proj(_Tp __re) {
@@ -1100,7 +1108,7 @@ proj(_Tp __re) {
 }
 
 template <class _Tp>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY typename std::enable_if<
+_SYCL_EXT_CPLX_INLINE_VISIBILITY typename std::enable_if<
     std::is_integral<_Tp>::value,
     typename __libcpp_complex_overload_traits<_Tp>::_ComplexType>::type
 proj(_Tp __re) {
@@ -1112,7 +1120,7 @@ proj(_Tp __re) {
 // polar
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> polar(const _Tp &__rho, const _Tp &__theta = _Tp()) {
+complex<_Tp> polar(const _Tp &__rho, const _Tp &__theta = _Tp()) {
   if (sycl::isnan(__rho) || sycl::signbit(__rho))
     return complex<_Tp>(_Tp(NAN), _Tp(NAN));
   if (sycl::isnan(__theta)) {
@@ -1137,23 +1145,21 @@ SYCL_EXTERNAL complex<_Tp> polar(const _Tp &__rho, const _Tp &__theta = _Tp()) {
 // log
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-log(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> log(const complex<_Tp> &__x) {
   return complex<_Tp>(sycl::log(abs(__x)), arg(__x));
 }
 
 // log10
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-log10(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> log10(const complex<_Tp> &__x) {
   return log(__x) / sycl::log(_Tp(10));
 }
 
 // sqrt
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> sqrt(const complex<_Tp> &__x) {
+complex<_Tp> sqrt(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.imag()))
     return complex<_Tp>(_Tp(INFINITY), __x.imag());
   if (sycl::isinf(__x.real())) {
@@ -1170,7 +1176,7 @@ SYCL_EXTERNAL complex<_Tp> sqrt(const complex<_Tp> &__x) {
 // exp
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> exp(const complex<_Tp> &__x) {
+complex<_Tp> exp(const complex<_Tp> &__x) {
   _Tp __i = __x.imag();
   if (__i == 0) {
     return complex<_Tp>(sycl::exp(__x.real()),
@@ -1193,23 +1199,22 @@ SYCL_EXTERNAL complex<_Tp> exp(const complex<_Tp> &__x) {
 // pow
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-pow(const complex<_Tp> &__x, const complex<_Tp> &__y) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> pow(const complex<_Tp> &__x,
+                                                  const complex<_Tp> &__y) {
   return exp(__y * log(__x));
 }
 
 template <class _Tp, class _Up,
           class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL
-    _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<typename __promote<_Tp, _Up>::type>
-    pow(const complex<_Tp> &__x, const complex<_Up> &__y) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<typename __promote<_Tp, _Up>::type>
+pow(const complex<_Tp> &__x, const complex<_Up> &__y) {
   typedef complex<typename __promote<_Tp, _Up>::type> result_type;
   return pow(result_type(__x), result_type(__y));
 }
 
 template <class _Tp, class _Up,
           class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+_SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename std::enable_if<is_genfloat<_Up>::value,
                             complex<typename __promote<_Tp, _Up>::type>>::type
     pow(const complex<_Tp> &__x, const _Up &__y) {
@@ -1219,7 +1224,7 @@ SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp, class _Up,
           class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+_SYCL_EXT_CPLX_INLINE_VISIBILITY
     typename std::enable_if<is_genfloat<_Up>::value,
                             complex<typename __promote<_Tp, _Up>::type>>::type
     pow(const _Tp &__x, const complex<_Up> &__y) {
@@ -1238,7 +1243,7 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> __sqr(const complex<_Tp> &__x) {
 // asinh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> asinh(const complex<_Tp> &__x) {
+complex<_Tp> asinh(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(+0., -0.));
   if (sycl::isinf(__x.real())) {
     if (sycl::isnan(__x.imag()))
@@ -1266,7 +1271,7 @@ SYCL_EXTERNAL complex<_Tp> asinh(const complex<_Tp> &__x) {
 // acosh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> acosh(const complex<_Tp> &__x) {
+complex<_Tp> acosh(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(+0., -0.));
   if (sycl::isinf(__x.real())) {
     if (sycl::isnan(__x.imag()))
@@ -1299,7 +1304,7 @@ SYCL_EXTERNAL complex<_Tp> acosh(const complex<_Tp> &__x) {
 // atanh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> atanh(const complex<_Tp> &__x) {
+complex<_Tp> atanh(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(+0., -0.));
   if (sycl::isinf(__x.imag())) {
     return complex<_Tp>(sycl::copysign(_Tp(0), __x.real()),
@@ -1329,7 +1334,7 @@ SYCL_EXTERNAL complex<_Tp> atanh(const complex<_Tp> &__x) {
 // sinh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> sinh(const complex<_Tp> &__x) {
+complex<_Tp> sinh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.real()) && !sycl::isfinite(__x.imag()))
     return complex<_Tp>(__x.real(), _Tp(NAN));
   if (__x.real() == 0 && !sycl::isfinite(__x.imag()))
@@ -1343,7 +1348,7 @@ SYCL_EXTERNAL complex<_Tp> sinh(const complex<_Tp> &__x) {
 // cosh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> cosh(const complex<_Tp> &__x) {
+complex<_Tp> cosh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.real()) && !sycl::isfinite(__x.imag()))
     return complex<_Tp>(sycl::fabs(__x.real()), _Tp(NAN));
   if (__x.real() == 0 && !sycl::isfinite(__x.imag()))
@@ -1359,7 +1364,7 @@ SYCL_EXTERNAL complex<_Tp> cosh(const complex<_Tp> &__x) {
 // tanh
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> tanh(const complex<_Tp> &__x) {
+complex<_Tp> tanh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.real())) {
     if (!sycl::isfinite(__x.imag()))
       return complex<_Tp>(sycl::copysign(_Tp(1), __x.real()), _Tp(0));
@@ -1381,7 +1386,7 @@ SYCL_EXTERNAL complex<_Tp> tanh(const complex<_Tp> &__x) {
 // asin
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> asin(const complex<_Tp> &__x) {
+complex<_Tp> asin(const complex<_Tp> &__x) {
   complex<_Tp> __z = asinh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());
 }
@@ -1389,7 +1394,7 @@ SYCL_EXTERNAL complex<_Tp> asin(const complex<_Tp> &__x) {
 // acos
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL complex<_Tp> acos(const complex<_Tp> &__x) {
+complex<_Tp> acos(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(+0., -0.));
   if (sycl::isinf(__x.real())) {
     if (sycl::isnan(__x.imag()))
@@ -1423,8 +1428,7 @@ SYCL_EXTERNAL complex<_Tp> acos(const complex<_Tp> &__x) {
 // atan
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-atan(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> atan(const complex<_Tp> &__x) {
   complex<_Tp> __z = atanh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());
 }
@@ -1432,8 +1436,7 @@ atan(const complex<_Tp> &__x) {
 // sin
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-sin(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> sin(const complex<_Tp> &__x) {
   complex<_Tp> __z = sinh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());
 }
@@ -1441,16 +1444,14 @@ sin(const complex<_Tp> &__x) {
 // cos
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-cos(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> cos(const complex<_Tp> &__x) {
   return cosh(complex<_Tp>(-__x.imag(), __x.real()));
 }
 
 // tan
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-tan(const complex<_Tp> &__x) {
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> tan(const complex<_Tp> &__x) {
   complex<_Tp> __z = tanh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());
 }
@@ -1513,7 +1514,7 @@ operator<<(std::basic_ostream<_CharT, _Traits> &__os, const complex<_Tp> &__x) {
 }
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY const sycl::stream &
+_SYCL_EXT_CPLX_INLINE_VISIBILITY const sycl::stream &
 operator<<(const sycl::stream &__ss, const complex<_Tp> &_x) {
   return __ss << "(" << _x.real() << "," << _x.imag() << ")";
 }

--- a/include/gtensor/sycl_ext_complex.hpp
+++ b/include/gtensor/sycl_ext_complex.hpp
@@ -1,0 +1,1527 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Adapted from the LLVM Project, under the Apache License v2.0 with LLVM
+// Exceptions. See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _SYCL_EXT_CPLX_COMPLEX
+#define _SYCL_EXT_CPLX_COMPLEX
+
+// clang-format off
+
+// Last time synced SyclCPLX with llvm-project
+// https://github.com/llvm/llvm-project/commit/385cc25a531a72c393cee44689e2c3194615bcec
+
+/*
+    complex synopsis
+
+namespace sycl::ext::cplx
+{
+
+template<class T>
+class complex
+{
+public:
+    typedef T value_type;
+
+    complex(const T& re = T(), const T& im = T()); // constexpr in C++14
+    complex(const complex&);  // constexpr in C++14
+    template<class X> complex(const complex<X>&);  // constexpr in C++14
+
+    T real() const; // constexpr in C++14
+    T imag() const; // constexpr in C++14
+
+    void real(T);
+    void imag(T);
+
+    complex<T>& operator= (const T&);
+    complex<T>& operator+=(const T&);
+    complex<T>& operator-=(const T&);
+    complex<T>& operator*=(const T&);
+    complex<T>& operator/=(const T&);
+
+    complex& operator=(const complex&);
+    template<class X> complex<T>& operator= (const complex<X>&);
+    template<class X> complex<T>& operator+=(const complex<X>&);
+    template<class X> complex<T>& operator-=(const complex<X>&);
+    template<class X> complex<T>& operator*=(const complex<X>&);
+    template<class X> complex<T>& operator/=(const complex<X>&);
+};
+
+template<>
+class complex<sycl::half>
+{
+public:
+    typedef sycl::half value_type;
+
+    constexpr complex(sycl::half re = 0.0f, sycl::half im = 0.0f);
+    explicit constexpr complex(const complex<float>&);
+    explicit constexpr complex(const complex<double>&);
+
+    constexpr operator std::complex<sycl::half>();
+
+    constexpr sycl::half real() const;
+    void real(sycl::half);
+    constexpr sycl::half imag() const;
+    void imag(sycl::half);
+
+    complex<sycl::half>& operator= (sycl::half);
+    complex<sycl::half>& operator+=(sycl::half);
+    complex<sycl::half>& operator-=(sycl::half);
+    complex<sycl::half>& operator*=(sycl::half);
+    complex<sycl::half>& operator/=(sycl::half);
+
+    complex<sycl::half>& operator=(const complex<sycl::half>&);
+    template<class X> complex<sycl::half>& operator= (const complex<X>&);
+    template<class X> complex<sycl::half>& operator+=(const complex<X>&);
+    template<class X> complex<sycl::half>& operator-=(const complex<X>&);
+    template<class X> complex<sycl::half>& operator*=(const complex<X>&);
+    template<class X> complex<sycl::half>& operator/=(const complex<X>&);
+};
+
+template<>
+class complex<float>
+{
+public:
+    typedef float value_type;
+
+    constexpr complex(float re = 0.0f, float im = 0.0f);
+    constexpr complex(const complex<sycl::half>&);
+    explicit constexpr complex(const complex<double>&);
+
+    constexpr complex(const std::complex<float>&);
+    constexpr operator std::complex<float>();
+
+    constexpr float real() const;
+    void real(float);
+    constexpr float imag() const;
+    void imag(float);
+
+    complex<float>& operator= (float);
+    complex<float>& operator+=(float);
+    complex<float>& operator-=(float);
+    complex<float>& operator*=(float);
+    complex<float>& operator/=(float);
+
+    complex<float>& operator=(const complex<float>&);
+    template<class X> complex<float>& operator= (const complex<X>&);
+    template<class X> complex<float>& operator+=(const complex<X>&);
+    template<class X> complex<float>& operator-=(const complex<X>&);
+    template<class X> complex<float>& operator*=(const complex<X>&);
+    template<class X> complex<float>& operator/=(const complex<X>&);
+};
+
+template<>
+class complex<double>
+{
+public:
+    typedef double value_type;
+
+    constexpr complex(double re = 0.0, double im = 0.0);
+    constexpr complex(const complex<sycl::half>&);
+    constexpr complex(const complex<float>&);
+
+    constexpr complex(const std::complex<double>&);
+    constexpr operator std::complex<double>();
+
+    constexpr double real() const;
+    void real(double);
+    constexpr double imag() const;
+    void imag(double);
+
+    complex<double>& operator= (double);
+    complex<double>& operator+=(double);
+    complex<double>& operator-=(double);
+    complex<double>& operator*=(double);
+    complex<double>& operator/=(double);
+    complex<double>& operator=(const complex<double>&);
+
+    template<class X> complex<double>& operator= (const complex<X>&);
+    template<class X> complex<double>& operator+=(const complex<X>&);
+    template<class X> complex<double>& operator-=(const complex<X>&);
+    template<class X> complex<double>& operator*=(const complex<X>&);
+    template<class X> complex<double>& operator/=(const complex<X>&);
+};
+
+
+// 26.3.6 operators:
+template<class T> complex<T> operator+(const complex<T>&, const complex<T>&);
+template<class T> complex<T> operator+(const complex<T>&, const T&);
+template<class T> complex<T> operator+(const T&, const complex<T>&);
+template<class T> complex<T> operator-(const complex<T>&, const complex<T>&);
+template<class T> complex<T> operator-(const complex<T>&, const T&);
+template<class T> complex<T> operator-(const T&, const complex<T>&);
+template<class T> complex<T> operator*(const complex<T>&, const complex<T>&);
+template<class T> complex<T> operator*(const complex<T>&, const T&);
+template<class T> complex<T> operator*(const T&, const complex<T>&);
+template<class T> complex<T> operator/(const complex<T>&, const complex<T>&);
+template<class T> complex<T> operator/(const complex<T>&, const T&);
+template<class T> complex<T> operator/(const T&, const complex<T>&);
+template<class T> complex<T> operator+(const complex<T>&);
+template<class T> complex<T> operator-(const complex<T>&);
+template<class T> bool operator==(const complex<T>&, const complex<T>&); // constexpr in C++14
+template<class T> bool operator==(const complex<T>&, const T&); // constexpr in C++14
+template<class T> bool operator==(const T&, const complex<T>&); // constexpr in C++14
+template<class T> bool operator!=(const complex<T>&, const complex<T>&); // constexpr in C++14
+template<class T> bool operator!=(const complex<T>&, const T&); // constexpr in C++14
+template<class T> bool operator!=(const T&, const complex<T>&); // constexpr in C++14
+
+template<class T, class charT, class traits>
+  basic_istream<charT, traits>&
+  operator>>(basic_istream<charT, traits>&, complex<T>&);
+template<class T, class charT, class traits>
+  basic_ostream<charT, traits>&
+  operator<<(basic_ostream<charT, traits>&, const complex<T>&);
+template<class T>
+  const sycl::stream&
+  operator<<(const sycl::stream&, const complex<T>&);
+
+// 26.3.7 values:
+
+template<class T>              T real(const complex<T>&); // constexpr in C++14
+                          double real(double);            // constexpr in C++14
+template<Integral T>      double real(T);                 // constexpr in C++14
+                          float  real(float);             // constexpr in C++14
+
+template<class T>              T imag(const complex<T>&); // constexpr in C++14
+                          double imag(double);            // constexpr in C++14
+template<Integral T>      double imag(T);                 // constexpr in C++14
+                          float  imag(float);             // constexpr in C++14
+
+template<class T> T abs(const complex<T>&);
+
+template<class T>              T arg(const complex<T>&);
+                          double arg(double);
+template<Integral T>      double arg(T);
+                          float  arg(float);
+
+template<class T>              T norm(const complex<T>&);
+                          double norm(double);
+template<Integral T>      double norm(T);
+                          float  norm(float);
+
+template<class T>      complex<T>           conj(const complex<T>&);
+                       complex<double>      conj(double);
+template<Integral T>   complex<double>      conj(T);
+                       complex<float>       conj(float);
+
+template<class T>    complex<T>           proj(const complex<T>&);
+                     complex<double>      proj(double);
+template<Integral T> complex<double>      proj(T);
+                     complex<float>       proj(float);
+
+template<class T> complex<T> polar(const T&, const T& = T());
+
+// 26.3.8 transcendentals:
+template<class T> complex<T> acos(const complex<T>&);
+template<class T> complex<T> asin(const complex<T>&);
+template<class T> complex<T> atan(const complex<T>&);
+template<class T> complex<T> acosh(const complex<T>&);
+template<class T> complex<T> asinh(const complex<T>&);
+template<class T> complex<T> atanh(const complex<T>&);
+template<class T> complex<T> cos (const complex<T>&);
+template<class T> complex<T> cosh (const complex<T>&);
+template<class T> complex<T> exp (const complex<T>&);
+template<class T> complex<T> log (const complex<T>&);
+template<class T> complex<T> log10(const complex<T>&);
+
+template<class T> complex<T> pow(const complex<T>&, const T&);
+template<class T> complex<T> pow(const complex<T>&, const complex<T>&);
+template<class T> complex<T> pow(const T&, const complex<T>&);
+
+template<class T> complex<T> sin (const complex<T>&);
+template<class T> complex<T> sinh (const complex<T>&);
+template<class T> complex<T> sqrt (const complex<T>&);
+template<class T> complex<T> tan (const complex<T>&);
+template<class T> complex<T> tanh (const complex<T>&);
+
+}  // sycl::ext::cplx
+
+*/
+
+// clang-format on
+
+#define _SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD namespace sycl::ext::cplx {
+#define _SYCL_EXT_CPLX_END_NAMESPACE_STD }
+#define _SYCL_EXT_CPLX_INLINE_VISIBILITY                                       \
+  inline __attribute__((__visibility__("hidden"), __always_inline__))
+
+#include <complex>
+#include <sstream> // for std::basic_ostringstream
+#include "backend_sycl_compat.h" // changed from upstream for old oneAPI
+#include <type_traits>
+
+_SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD
+
+template <class _Tp> struct __numeric_type {
+  static void __test(...);
+  static sycl::half __test(sycl::half);
+  static float __test(float);
+  static double __test(char);
+  static double __test(int);
+  static double __test(unsigned);
+  static double __test(long);
+  static double __test(unsigned long);
+  static double __test(long long);
+  static double __test(unsigned long long);
+  static double __test(double);
+
+  typedef decltype(__test(std::declval<_Tp>())) type;
+  static const bool value = !std::is_same<type, void>::value;
+};
+
+template <> struct __numeric_type<void> { static const bool value = true; };
+
+template <class _A1, class _A2 = void, class _A3 = void,
+          bool = __numeric_type<_A1>::value &&__numeric_type<_A2>::value
+              &&__numeric_type<_A3>::value>
+class __promote_imp {
+public:
+  static const bool value = false;
+};
+
+template <class _A1, class _A2, class _A3>
+class __promote_imp<_A1, _A2, _A3, true> {
+private:
+  typedef typename __promote_imp<_A1>::type __type1;
+  typedef typename __promote_imp<_A2>::type __type2;
+  typedef typename __promote_imp<_A3>::type __type3;
+
+public:
+  typedef decltype(__type1() + __type2() + __type3()) type;
+  static const bool value = true;
+};
+
+template <class _A1, class _A2> class __promote_imp<_A1, _A2, void, true> {
+private:
+  typedef typename __promote_imp<_A1>::type __type1;
+  typedef typename __promote_imp<_A2>::type __type2;
+
+public:
+  typedef decltype(__type1() + __type2()) type;
+  static const bool value = true;
+};
+
+template <class _A1> class __promote_imp<_A1, void, void, true> {
+public:
+  typedef typename __numeric_type<_A1>::type type;
+  static const bool value = true;
+};
+
+template <class _A1, class _A2 = void, class _A3 = void>
+class __promote : public __promote_imp<_A1, _A2, _A3> {};
+
+template <class _Tp> class complex;
+
+template <class _Tp>
+struct is_gencomplex
+    : std::integral_constant<bool,
+                             std::is_same_v<_Tp, complex<double>> ||
+                                 std::is_same_v<_Tp, complex<float>> ||
+                                 std::is_same_v<_Tp, complex<sycl::half>>> {};
+
+template <class _Tp>
+struct is_genfloat
+    : std::integral_constant<bool, std::is_same_v<_Tp, double> ||
+                                       std::is_same_v<_Tp, float> ||
+                                       std::is_same_v<_Tp, sycl::half>> {};
+
+template <class _Tp>
+complex<_Tp> operator*(const complex<_Tp> &__z, const complex<_Tp> &__w);
+template <class _Tp>
+complex<_Tp> operator/(const complex<_Tp> &__x, const complex<_Tp> &__y);
+
+template <class _Tp> class complex {
+public:
+  typedef _Tp value_type;
+
+private:
+  value_type __re_;
+  value_type __im_;
+
+public:
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(
+      const value_type &__re = value_type(),
+      const value_type &__im = value_type())
+      : __re_(__re), __im_(__im) {}
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(const complex<_Xp> &__c)
+      : __re_(__c.real()), __im_(__c.imag()) {}
+
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(
+      const std::complex<_Xp> &__c)
+      : __re_(__c.real()), __im_(__c.imag()) {}
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY operator std::complex<_Xp>() {
+    return std::complex<_Xp>(__re_, __im_);
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr value_type real() const {
+    return __re_;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr value_type imag() const {
+    return __im_;
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY void real(value_type __re) { __re_ = __re; }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY void imag(value_type __im) { __im_ = __im; }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(const value_type &__re) {
+    __re_ = __re;
+    __im_ = value_type();
+    return *this;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator+=(const value_type &__re) {
+    __re_ += __re;
+    return *this;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator-=(const value_type &__re) {
+    __re_ -= __re;
+    return *this;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator*=(const value_type &__re) {
+    __re_ *= __re;
+    __im_ *= __re;
+    return *this;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator/=(const value_type &__re) {
+    __re_ /= __re;
+    __im_ /= __re;
+    return *this;
+  }
+
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(const complex<_Xp> &__c) {
+    __re_ = __c.real();
+    __im_ = __c.imag();
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator=(const std::complex<_Xp> &__c) {
+    __re_ = __c.real();
+    __im_ = __c.imag();
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator+=(const complex<_Xp> &__c) {
+    __re_ += __c.real();
+    __im_ += __c.imag();
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator-=(const complex<_Xp> &__c) {
+    __re_ -= __c.real();
+    __im_ -= __c.imag();
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator*=(const complex<_Xp> &__c) {
+    *this = *this * complex(__c.real(), __c.imag());
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator/=(const complex<_Xp> &__c) {
+    *this = *this / complex(__c.real(), __c.imag());
+    return *this;
+  }
+};
+
+template <> class complex<float>;
+template <> class complex<double>;
+
+template <> class complex<sycl::half> {
+  sycl::half __re_;
+  sycl::half __im_;
+
+public:
+  typedef sycl::half value_type;
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(
+      sycl::half __re = sycl::half{}, sycl::half __im = sycl::half{})
+      : __re_(__re), __im_(__im) {}
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY
+  explicit constexpr complex(const complex<float> &__c);
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY
+  explicit constexpr complex(const complex<double> &__c);
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY
+  constexpr operator std::complex<sycl::half>() {
+    return std::complex<sycl::half>(__re_, __im_);
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr sycl::half real() const {
+    return __re_;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr sycl::half imag() const {
+    return __im_;
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY void real(value_type __re) { __re_ = __re; }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY void imag(value_type __im) { __im_ = __im; }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(sycl::half __re) {
+    __re_ = __re;
+    __im_ = value_type();
+    return *this;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator+=(sycl::half __re) {
+    __re_ += __re;
+    return *this;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator-=(sycl::half __re) {
+    __re_ -= __re;
+    return *this;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator*=(sycl::half __re) {
+    __re_ *= __re;
+    __im_ *= __re;
+    return *this;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator/=(sycl::half __re) {
+    __re_ /= __re;
+    __im_ /= __re;
+    return *this;
+  }
+
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(const complex<_Xp> &__c) {
+    __re_ = __c.real();
+    __im_ = __c.imag();
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator=(const std::complex<_Xp> &__c) {
+    __re_ = __c.real();
+    __im_ = __c.imag();
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator+=(const complex<_Xp> &__c) {
+    __re_ += __c.real();
+    __im_ += __c.imag();
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator-=(const complex<_Xp> &__c) {
+    __re_ -= __c.real();
+    __im_ -= __c.imag();
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator*=(const complex<_Xp> &__c) {
+    *this = *this * complex(__c.real(), __c.imag());
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator/=(const complex<_Xp> &__c) {
+    *this = *this / complex(__c.real(), __c.imag());
+    return *this;
+  }
+};
+
+template <> class complex<float> {
+  float __re_;
+  float __im_;
+
+public:
+  typedef float value_type;
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(float __re = 0.0f,
+                                                     float __im = 0.0f)
+      : __re_(__re), __im_(__im) {}
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY
+  constexpr complex(const complex<sycl::half> &__c);
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY
+  explicit constexpr complex(const complex<double> &__c);
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY
+  constexpr complex(const std::complex<float> &__c)
+      : __re_(__c.real()), __im_(__c.imag()) {}
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY
+  constexpr operator std::complex<float>() {
+    return std::complex<float>(__re_, __im_);
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr float real() const {
+    return __re_;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr float imag() const {
+    return __im_;
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY void real(value_type __re) { __re_ = __re; }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY void imag(value_type __im) { __im_ = __im; }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(float __re) {
+    __re_ = __re;
+    __im_ = value_type();
+    return *this;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator+=(float __re) {
+    __re_ += __re;
+    return *this;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator-=(float __re) {
+    __re_ -= __re;
+    return *this;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator*=(float __re) {
+    __re_ *= __re;
+    __im_ *= __re;
+    return *this;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator/=(float __re) {
+    __re_ /= __re;
+    __im_ /= __re;
+    return *this;
+  }
+
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(const complex<_Xp> &__c) {
+    __re_ = __c.real();
+    __im_ = __c.imag();
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator=(const std::complex<_Xp> &__c) {
+    __re_ = __c.real();
+    __im_ = __c.imag();
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator+=(const complex<_Xp> &__c) {
+    __re_ += __c.real();
+    __im_ += __c.imag();
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator-=(const complex<_Xp> &__c) {
+    __re_ -= __c.real();
+    __im_ -= __c.imag();
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator*=(const complex<_Xp> &__c) {
+    *this = *this * complex(__c.real(), __c.imag());
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator/=(const complex<_Xp> &__c) {
+    *this = *this / complex(__c.real(), __c.imag());
+    return *this;
+  }
+};
+
+template <> class complex<double> {
+  double __re_;
+  double __im_;
+
+public:
+  typedef double value_type;
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(double __re = 0.0,
+                                                     double __im = 0.0)
+      : __re_(__re), __im_(__im) {}
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY
+  constexpr complex(const complex<sycl::half> &__c);
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY
+  constexpr complex(const complex<float> &__c);
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY
+  constexpr complex(const std::complex<double> &__c)
+      : __re_(__c.real()), __im_(__c.imag()) {}
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY
+  constexpr operator std::complex<double>() {
+    return std::complex<double>(__re_, __im_);
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr double real() const {
+    return __re_;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr double imag() const {
+    return __im_;
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY void real(value_type __re) { __re_ = __re; }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY void imag(value_type __im) { __im_ = __im; }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(double __re) {
+    __re_ = __re;
+    __im_ = value_type();
+    return *this;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator+=(double __re) {
+    __re_ += __re;
+    return *this;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator-=(double __re) {
+    __re_ -= __re;
+    return *this;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator*=(double __re) {
+    __re_ *= __re;
+    __im_ *= __re;
+    return *this;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator/=(double __re) {
+    __re_ /= __re;
+    __im_ /= __re;
+    return *this;
+  }
+
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(const complex<_Xp> &__c) {
+    __re_ = __c.real();
+    __im_ = __c.imag();
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator=(const std::complex<_Xp> &__c) {
+    __re_ = __c.real();
+    __im_ = __c.imag();
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator+=(const complex<_Xp> &__c) {
+    __re_ += __c.real();
+    __im_ += __c.imag();
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator-=(const complex<_Xp> &__c) {
+    __re_ -= __c.real();
+    __im_ -= __c.imag();
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator*=(const complex<_Xp> &__c) {
+    *this = *this * complex(__c.real(), __c.imag());
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &
+  operator/=(const complex<_Xp> &__c) {
+    *this = *this / complex(__c.real(), __c.imag());
+    return *this;
+  }
+};
+
+inline constexpr complex<sycl::half>::complex(const complex<float> &__c)
+    : __re_(__c.real()), __im_(__c.imag()) {}
+
+inline constexpr complex<sycl::half>::complex(const complex<double> &__c)
+    : __re_(__c.real()), __im_(__c.imag()) {}
+
+inline constexpr complex<float>::complex(const complex<sycl::half> &__c)
+    : __re_(__c.real()), __im_(__c.imag()) {}
+
+inline constexpr complex<float>::complex(const complex<double> &__c)
+    : __re_(__c.real()), __im_(__c.imag()) {}
+
+inline constexpr complex<double>::complex(const complex<sycl::half> &__c)
+    : __re_(__c.real()), __im_(__c.imag()) {}
+
+inline constexpr complex<double>::complex(const complex<float> &__c)
+    : __re_(__c.real()), __im_(__c.imag()) {}
+
+// 26.3.6 operators:
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
+operator+(const complex<_Tp> &__x, const complex<_Tp> &__y) {
+  complex<_Tp> __t(__x);
+  __t += __y;
+  return __t;
+}
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> operator+(const complex<_Tp> &__x,
+                                                        const _Tp &__y) {
+  complex<_Tp> __t(__x);
+  __t += __y;
+  return __t;
+}
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
+operator+(const _Tp &__x, const complex<_Tp> &__y) {
+  complex<_Tp> __t(__y);
+  __t += __x;
+  return __t;
+}
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
+operator-(const complex<_Tp> &__x, const complex<_Tp> &__y) {
+  complex<_Tp> __t(__x);
+  __t -= __y;
+  return __t;
+}
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> operator-(const complex<_Tp> &__x,
+                                                        const _Tp &__y) {
+  complex<_Tp> __t(__x);
+  __t -= __y;
+  return __t;
+}
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
+operator-(const _Tp &__x, const complex<_Tp> &__y) {
+  complex<_Tp> __t(-__y);
+  __t += __x;
+  return __t;
+}
+
+template <class _Tp>
+complex<_Tp> operator*(const complex<_Tp> &__z, const complex<_Tp> &__w) {
+  _Tp __a = __z.real();
+  _Tp __b = __z.imag();
+  _Tp __c = __w.real();
+  _Tp __d = __w.imag();
+  _Tp __ac = __a * __c;
+  _Tp __bd = __b * __d;
+  _Tp __ad = __a * __d;
+  _Tp __bc = __b * __c;
+  _Tp __x = __ac - __bd;
+  _Tp __y = __ad + __bc;
+  if (sycl::isnan(__x) && sycl::isnan(__y)) {
+    bool __recalc = false;
+    if (sycl::isinf(__a) || sycl::isinf(__b)) {
+      __a = sycl::copysign(sycl::isinf(__a) ? _Tp(1) : _Tp(0), __a);
+      __b = sycl::copysign(sycl::isinf(__b) ? _Tp(1) : _Tp(0), __b);
+      if (sycl::isnan(__c))
+        __c = sycl::copysign(_Tp(0), __c);
+      if (sycl::isnan(__d))
+        __d = sycl::copysign(_Tp(0), __d);
+      __recalc = true;
+    }
+    if (sycl::isinf(__c) || sycl::isinf(__d)) {
+      __c = sycl::copysign(sycl::isinf(__c) ? _Tp(1) : _Tp(0), __c);
+      __d = sycl::copysign(sycl::isinf(__d) ? _Tp(1) : _Tp(0), __d);
+      if (sycl::isnan(__a))
+        __a = sycl::copysign(_Tp(0), __a);
+      if (sycl::isnan(__b))
+        __b = sycl::copysign(_Tp(0), __b);
+      __recalc = true;
+    }
+    if (!__recalc && (sycl::isinf(__ac) || sycl::isinf(__bd) ||
+                      sycl::isinf(__ad) || sycl::isinf(__bc))) {
+      if (sycl::isnan(__a))
+        __a = sycl::copysign(_Tp(0), __a);
+      if (sycl::isnan(__b))
+        __b = sycl::copysign(_Tp(0), __b);
+      if (sycl::isnan(__c))
+        __c = sycl::copysign(_Tp(0), __c);
+      if (sycl::isnan(__d))
+        __d = sycl::copysign(_Tp(0), __d);
+      __recalc = true;
+    }
+    if (__recalc) {
+      __x = _Tp(INFINITY) * (__a * __c - __b * __d);
+      __y = _Tp(INFINITY) * (__a * __d + __b * __c);
+    }
+  }
+  return complex<_Tp>(__x, __y);
+}
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> operator*(const complex<_Tp> &__x,
+                                                        const _Tp &__y) {
+  complex<_Tp> __t(__x);
+  __t *= __y;
+  return __t;
+}
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
+operator*(const _Tp &__x, const complex<_Tp> &__y) {
+  complex<_Tp> __t(__y);
+  __t *= __x;
+  return __t;
+}
+
+template <class _Tp>
+complex<_Tp> operator/(const complex<_Tp> &__z, const complex<_Tp> &__w) {
+  int __ilogbw = 0;
+  _Tp __a = __z.real();
+  _Tp __b = __z.imag();
+  _Tp __c = __w.real();
+  _Tp __d = __w.imag();
+  _Tp __logbw = sycl::logb(sycl::fmax(sycl::fabs(__c), sycl::fabs(__d)));
+  if (sycl::isfinite(__logbw)) {
+    __ilogbw = static_cast<int>(__logbw);
+    __c = sycl::ldexp(__c, -__ilogbw);
+    __d = sycl::ldexp(__d, -__ilogbw);
+  }
+  _Tp __denom = __c * __c + __d * __d;
+  _Tp __x = sycl::ldexp((__a * __c + __b * __d) / __denom, -__ilogbw);
+  _Tp __y = sycl::ldexp((__b * __c - __a * __d) / __denom, -__ilogbw);
+  if (sycl::isnan(__x) && sycl::isnan(__y)) {
+    if ((__denom == _Tp(0)) && (!sycl::isnan(__a) || !sycl::isnan(__b))) {
+      __x = sycl::copysign(_Tp(INFINITY), __c) * __a;
+      __y = sycl::copysign(_Tp(INFINITY), __c) * __b;
+    } else if ((sycl::isinf(__a) || sycl::isinf(__b)) && sycl::isfinite(__c) &&
+               sycl::isfinite(__d)) {
+      __a = sycl::copysign(sycl::isinf(__a) ? _Tp(1) : _Tp(0), __a);
+      __b = sycl::copysign(sycl::isinf(__b) ? _Tp(1) : _Tp(0), __b);
+      __x = _Tp(INFINITY) * (__a * __c + __b * __d);
+      __y = _Tp(INFINITY) * (__b * __c - __a * __d);
+    } else if (sycl::isinf(__logbw) && __logbw > _Tp(0) &&
+               sycl::isfinite(__a) && sycl::isfinite(__b)) {
+      __c = sycl::copysign(sycl::isinf(__c) ? _Tp(1) : _Tp(0), __c);
+      __d = sycl::copysign(sycl::isinf(__d) ? _Tp(1) : _Tp(0), __d);
+      __x = _Tp(0) * (__a * __c + __b * __d);
+      __y = _Tp(0) * (__b * __c - __a * __d);
+    }
+  }
+  return complex<_Tp>(__x, __y);
+}
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> operator/(const complex<_Tp> &__x,
+                                                        const _Tp &__y) {
+  return complex<_Tp>(__x.real() / __y, __x.imag() / __y);
+}
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
+operator/(const _Tp &__x, const complex<_Tp> &__y) {
+  complex<_Tp> __t(__x);
+  __t /= __y;
+  return __t;
+}
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
+operator+(const complex<_Tp> &__x) {
+  return __x;
+}
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
+operator-(const complex<_Tp> &__x) {
+  return complex<_Tp>(-__x.real(), -__x.imag());
+}
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool
+operator==(const complex<_Tp> &__x, const complex<_Tp> &__y) {
+  return __x.real() == __y.real() && __x.imag() == __y.imag();
+}
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool
+operator==(const complex<_Tp> &__x, const _Tp &__y) {
+  return __x.real() == __y && __x.imag() == 0;
+}
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool
+operator==(const _Tp &__x, const complex<_Tp> &__y) {
+  return __x == __y.real() && 0 == __y.imag();
+}
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool
+operator!=(const complex<_Tp> &__x, const complex<_Tp> &__y) {
+  return !(__x == __y);
+}
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool
+operator!=(const complex<_Tp> &__x, const _Tp &__y) {
+  return !(__x == __y);
+}
+
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr bool
+operator!=(const _Tp &__x, const complex<_Tp> &__y) {
+  return !(__x == __y);
+}
+
+// 26.3.7 values:
+
+template <class _Tp, bool = std::is_integral<_Tp>::value,
+          bool = std::is_floating_point<_Tp>::value>
+struct __libcpp_complex_overload_traits {};
+
+// Integral Types
+template <class _Tp> struct __libcpp_complex_overload_traits<_Tp, true, false> {
+  typedef double _ValueType;
+  typedef complex<double> _ComplexType;
+};
+
+// Floating point types
+template <class _Tp> struct __libcpp_complex_overload_traits<_Tp, false, true> {
+  typedef _Tp _ValueType;
+  typedef complex<_Tp> _ComplexType;
+};
+
+// real
+
+template <class _Tp>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr _Tp
+real(const complex<_Tp> &__c) {
+  return __c.real();
+}
+
+template <class _Tp>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
+    typename __libcpp_complex_overload_traits<_Tp>::_ValueType
+    real(_Tp __re) {
+  return __re;
+}
+
+// imag
+
+template <class _Tp>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr _Tp
+imag(const complex<_Tp> &__c) {
+  return __c.imag();
+}
+
+template <class _Tp>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
+    typename __libcpp_complex_overload_traits<_Tp>::_ValueType
+    imag(_Tp) {
+  return 0;
+}
+
+// abs
+
+template <class _Tp>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp
+abs(const complex<_Tp> &__c) {
+  return sycl::hypot(__c.real(), __c.imag());
+}
+
+// arg
+
+template <class _Tp>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp
+arg(const complex<_Tp> &__c) {
+  return sycl::atan2(__c.imag(), __c.real());
+}
+
+template <class _Tp>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    typename std::enable_if<std::is_integral<_Tp>::value ||
+                                std::is_same<_Tp, double>::value,
+                            double>::type
+    arg(_Tp __re) {
+  return sycl::atan2(0., __re);
+}
+
+template <class _Tp>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    typename std::enable_if<std::is_same<_Tp, float>::value, float>::type
+    arg(_Tp __re) {
+  return sycl::atan2(0.F, __re);
+}
+
+// norm
+
+template <class _Tp>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp
+norm(const complex<_Tp> &__c) {
+  if (sycl::isinf(__c.real()))
+    return sycl::fabs(__c.real());
+  if (sycl::isinf(__c.imag()))
+    return sycl::fabs(__c.imag());
+  return __c.real() * __c.real() + __c.imag() * __c.imag();
+}
+
+template <class _Tp>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    typename __libcpp_complex_overload_traits<_Tp>::_ValueType
+    norm(_Tp __re) {
+  typedef typename __libcpp_complex_overload_traits<_Tp>::_ValueType _ValueType;
+  return static_cast<_ValueType>(__re) * __re;
+}
+
+// conj
+
+template <class _Tp>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
+conj(const complex<_Tp> &__c) {
+  return complex<_Tp>(__c.real(), -__c.imag());
+}
+
+template <class _Tp>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    typename __libcpp_complex_overload_traits<_Tp>::_ComplexType
+    conj(_Tp __re) {
+  typedef
+      typename __libcpp_complex_overload_traits<_Tp>::_ComplexType _ComplexType;
+  return _ComplexType(__re);
+}
+
+// proj
+
+template <class _Tp>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
+proj(const complex<_Tp> &__c) {
+  complex<_Tp> __r = __c;
+  if (sycl::isinf(__c.real()) || sycl::isinf(__c.imag()))
+    __r = complex<_Tp>(INFINITY, sycl::copysign(_Tp(0), __c.imag()));
+  return __r;
+}
+
+template <class _Tp>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY typename std::enable_if<
+    std::is_floating_point<_Tp>::value,
+    typename __libcpp_complex_overload_traits<_Tp>::_ComplexType>::type
+proj(_Tp __re) {
+  if (sycl::isinf(__re))
+    __re = sycl::fabs(__re);
+  return complex<_Tp>(__re);
+}
+
+template <class _Tp>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY typename std::enable_if<
+    std::is_integral<_Tp>::value,
+    typename __libcpp_complex_overload_traits<_Tp>::_ComplexType>::type
+proj(_Tp __re) {
+  typedef
+      typename __libcpp_complex_overload_traits<_Tp>::_ComplexType _ComplexType;
+  return _ComplexType(__re);
+}
+
+// polar
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL complex<_Tp> polar(const _Tp &__rho, const _Tp &__theta = _Tp()) {
+  if (sycl::isnan(__rho) || sycl::signbit(__rho))
+    return complex<_Tp>(_Tp(NAN), _Tp(NAN));
+  if (sycl::isnan(__theta)) {
+    if (sycl::isinf(__rho))
+      return complex<_Tp>(__rho, __theta);
+    return complex<_Tp>(__theta, __theta);
+  }
+  if (sycl::isinf(__theta)) {
+    if (sycl::isinf(__rho))
+      return complex<_Tp>(__rho, _Tp(NAN));
+    return complex<_Tp>(_Tp(NAN), _Tp(NAN));
+  }
+  _Tp __x = __rho * sycl::cos(__theta);
+  if (sycl::isnan(__x))
+    __x = 0;
+  _Tp __y = __rho * sycl::sin(__theta);
+  if (sycl::isnan(__y))
+    __y = 0;
+  return complex<_Tp>(__x, __y);
+}
+
+// log
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
+log(const complex<_Tp> &__x) {
+  return complex<_Tp>(sycl::log(abs(__x)), arg(__x));
+}
+
+// log10
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
+log10(const complex<_Tp> &__x) {
+  return log(__x) / sycl::log(_Tp(10));
+}
+
+// sqrt
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL complex<_Tp> sqrt(const complex<_Tp> &__x) {
+  if (sycl::isinf(__x.imag()))
+    return complex<_Tp>(_Tp(INFINITY), __x.imag());
+  if (sycl::isinf(__x.real())) {
+    if (__x.real() > _Tp(0))
+      return complex<_Tp>(__x.real(), sycl::isnan(__x.imag())
+                                          ? __x.imag()
+                                          : sycl::copysign(_Tp(0), __x.imag()));
+    return complex<_Tp>(sycl::isnan(__x.imag()) ? __x.imag() : _Tp(0),
+                        sycl::copysign(__x.real(), __x.imag()));
+  }
+  return polar(sycl::sqrt(abs(__x)), arg(__x) / _Tp(2));
+}
+
+// exp
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL complex<_Tp> exp(const complex<_Tp> &__x) {
+  _Tp __i = __x.imag();
+  if (__i == 0) {
+    return complex<_Tp>(sycl::exp(__x.real()),
+                        sycl::copysign(_Tp(0), __x.imag()));
+  }
+  if (sycl::isinf(__x.real())) {
+    if (__x.real() < _Tp(0)) {
+      if (!sycl::isfinite(__i))
+        __i = _Tp(1);
+    } else if (__i == 0 || !sycl::isfinite(__i)) {
+      if (sycl::isinf(__i))
+        __i = _Tp(NAN);
+      return complex<_Tp>(__x.real(), __i);
+    }
+  }
+  _Tp __e = sycl::exp(__x.real());
+  return complex<_Tp>(__e * sycl::cos(__i), __e * sycl::sin(__i));
+}
+
+// pow
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
+pow(const complex<_Tp> &__x, const complex<_Tp> &__y) {
+  return exp(__y * log(__x));
+}
+
+template <class _Tp, class _Up,
+          class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL
+    _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<typename __promote<_Tp, _Up>::type>
+    pow(const complex<_Tp> &__x, const complex<_Up> &__y) {
+  typedef complex<typename __promote<_Tp, _Up>::type> result_type;
+  return sycl::ext::cplx::pow(result_type(__x), result_type(__y));
+}
+
+template <class _Tp, class _Up,
+          class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    typename std::enable_if<is_genfloat<_Up>::value,
+                            complex<typename __promote<_Tp, _Up>::type>>::type
+    pow(const complex<_Tp> &__x, const _Up &__y) {
+  typedef complex<typename __promote<_Tp, _Up>::type> result_type;
+  return sycl::ext::cplx::pow(result_type(__x), result_type(__y));
+}
+
+template <class _Tp, class _Up,
+          class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    typename std::enable_if<is_genfloat<_Up>::value,
+                            complex<typename __promote<_Tp, _Up>::type>>::type
+    pow(const _Tp &__x, const complex<_Up> &__y) {
+  typedef complex<typename __promote<_Tp, _Up>::type> result_type;
+  return sycl::ext::cplx::pow(result_type(__x), result_type(__y));
+}
+
+// __sqr, computes pow(x, 2)
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> __sqr(const complex<_Tp> &__x) {
+  return complex<_Tp>((__x.real() - __x.imag()) * (__x.real() + __x.imag()),
+                      _Tp(2) * __x.real() * __x.imag());
+}
+
+// asinh
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL complex<_Tp> asinh(const complex<_Tp> &__x) {
+  const _Tp __pi(sycl::atan2(+0., -0.));
+  if (sycl::isinf(__x.real())) {
+    if (sycl::isnan(__x.imag()))
+      return __x;
+    if (sycl::isinf(__x.imag()))
+      return complex<_Tp>(__x.real(),
+                          sycl::copysign(__pi * _Tp(0.25), __x.imag()));
+    return complex<_Tp>(__x.real(), sycl::copysign(_Tp(0), __x.imag()));
+  }
+  if (sycl::isnan(__x.real())) {
+    if (sycl::isinf(__x.imag()))
+      return complex<_Tp>(__x.imag(), __x.real());
+    if (__x.imag() == 0)
+      return __x;
+    return complex<_Tp>(__x.real(), __x.real());
+  }
+  if (sycl::isinf(__x.imag()))
+    return complex<_Tp>(sycl::copysign(__x.imag(), __x.real()),
+                        sycl::copysign(__pi / _Tp(2), __x.imag()));
+  complex<_Tp> __z = log(__x + sqrt(__sqr(__x) + _Tp(1)));
+  return complex<_Tp>(sycl::copysign(__z.real(), __x.real()),
+                      sycl::copysign(__z.imag(), __x.imag()));
+}
+
+// acosh
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL complex<_Tp> acosh(const complex<_Tp> &__x) {
+  const _Tp __pi(sycl::atan2(+0., -0.));
+  if (sycl::isinf(__x.real())) {
+    if (sycl::isnan(__x.imag()))
+      return complex<_Tp>(sycl::fabs(__x.real()), __x.imag());
+    if (sycl::isinf(__x.imag())) {
+      if (__x.real() > 0)
+        return complex<_Tp>(__x.real(),
+                            sycl::copysign(__pi * _Tp(0.25), __x.imag()));
+      else
+        return complex<_Tp>(-__x.real(),
+                            sycl::copysign(__pi * _Tp(0.75), __x.imag()));
+    }
+    if (__x.real() < 0)
+      return complex<_Tp>(-__x.real(), sycl::copysign(__pi, __x.imag()));
+    return complex<_Tp>(__x.real(), sycl::copysign(_Tp(0), __x.imag()));
+  }
+  if (sycl::isnan(__x.real())) {
+    if (sycl::isinf(__x.imag()))
+      return complex<_Tp>(sycl::fabs(__x.imag()), __x.real());
+    return complex<_Tp>(__x.real(), __x.real());
+  }
+  if (sycl::isinf(__x.imag()))
+    return complex<_Tp>(sycl::fabs(__x.imag()),
+                        sycl::copysign(__pi / _Tp(2), __x.imag()));
+  complex<_Tp> __z = log(__x + sqrt(__sqr(__x) - _Tp(1)));
+  return complex<_Tp>(sycl::copysign(__z.real(), _Tp(0)),
+                      sycl::copysign(__z.imag(), __x.imag()));
+}
+
+// atanh
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL complex<_Tp> atanh(const complex<_Tp> &__x) {
+  const _Tp __pi(sycl::atan2(+0., -0.));
+  if (sycl::isinf(__x.imag())) {
+    return complex<_Tp>(sycl::copysign(_Tp(0), __x.real()),
+                        sycl::copysign(__pi / _Tp(2), __x.imag()));
+  }
+  if (sycl::isnan(__x.imag())) {
+    if (sycl::isinf(__x.real()) || __x.real() == 0)
+      return complex<_Tp>(sycl::copysign(_Tp(0), __x.real()), __x.imag());
+    return complex<_Tp>(__x.imag(), __x.imag());
+  }
+  if (sycl::isnan(__x.real())) {
+    return complex<_Tp>(__x.real(), __x.real());
+  }
+  if (sycl::isinf(__x.real())) {
+    return complex<_Tp>(sycl::copysign(_Tp(0), __x.real()),
+                        sycl::copysign(__pi / _Tp(2), __x.imag()));
+  }
+  if (sycl::fabs(__x.real()) == _Tp(1) && __x.imag() == _Tp(0)) {
+    return complex<_Tp>(sycl::copysign(_Tp(INFINITY), __x.real()),
+                        sycl::copysign(_Tp(0), __x.imag()));
+  }
+  complex<_Tp> __z = log((_Tp(1) + __x) / (_Tp(1) - __x)) / _Tp(2);
+  return complex<_Tp>(sycl::copysign(__z.real(), __x.real()),
+                      sycl::copysign(__z.imag(), __x.imag()));
+}
+
+// sinh
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL complex<_Tp> sinh(const complex<_Tp> &__x) {
+  if (sycl::isinf(__x.real()) && !sycl::isfinite(__x.imag()))
+    return complex<_Tp>(__x.real(), _Tp(NAN));
+  if (__x.real() == 0 && !sycl::isfinite(__x.imag()))
+    return complex<_Tp>(__x.real(), _Tp(NAN));
+  if (__x.imag() == 0 && !sycl::isfinite(__x.real()))
+    return __x;
+  return complex<_Tp>(sycl::sinh(__x.real()) * sycl::cos(__x.imag()),
+                      sycl::cosh(__x.real()) * sycl::sin(__x.imag()));
+}
+
+// cosh
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL complex<_Tp> cosh(const complex<_Tp> &__x) {
+  if (sycl::isinf(__x.real()) && !sycl::isfinite(__x.imag()))
+    return complex<_Tp>(sycl::fabs(__x.real()), _Tp(NAN));
+  if (__x.real() == 0 && !sycl::isfinite(__x.imag()))
+    return complex<_Tp>(_Tp(NAN), __x.real());
+  if (__x.real() == 0 && __x.imag() == 0)
+    return complex<_Tp>(_Tp(1), __x.imag());
+  if (__x.imag() == 0 && !sycl::isfinite(__x.real()))
+    return complex<_Tp>(sycl::fabs(__x.real()), __x.imag());
+  return complex<_Tp>(sycl::cosh(__x.real()) * sycl::cos(__x.imag()),
+                      sycl::sinh(__x.real()) * sycl::sin(__x.imag()));
+}
+
+// tanh
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL complex<_Tp> tanh(const complex<_Tp> &__x) {
+  if (sycl::isinf(__x.real())) {
+    if (!sycl::isfinite(__x.imag()))
+      return complex<_Tp>(sycl::copysign(_Tp(1), __x.real()), _Tp(0));
+    return complex<_Tp>(sycl::copysign(_Tp(1), __x.real()),
+                        sycl::copysign(_Tp(0), sycl::sin(_Tp(2) * __x.imag())));
+  }
+  if (sycl::isnan(__x.real()) && __x.imag() == 0)
+    return __x;
+  _Tp __2r(_Tp(2) * __x.real());
+  _Tp __2i(_Tp(2) * __x.imag());
+  _Tp __d(sycl::cosh(__2r) + sycl::cos(__2i));
+  _Tp __2rsh(sycl::sinh(__2r));
+  if (sycl::isinf(__2rsh) && sycl::isinf(__d))
+    return complex<_Tp>(__2rsh > _Tp(0) ? _Tp(1) : _Tp(-1),
+                        __2i > _Tp(0) ? _Tp(0) : _Tp(-0.));
+  return complex<_Tp>(__2rsh / __d, sycl::sin(__2i) / __d);
+}
+
+// asin
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL complex<_Tp> asin(const complex<_Tp> &__x) {
+  complex<_Tp> __z = asinh(complex<_Tp>(-__x.imag(), __x.real()));
+  return complex<_Tp>(__z.imag(), -__z.real());
+}
+
+// acos
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL complex<_Tp> acos(const complex<_Tp> &__x) {
+  const _Tp __pi(sycl::atan2(+0., -0.));
+  if (sycl::isinf(__x.real())) {
+    if (sycl::isnan(__x.imag()))
+      return complex<_Tp>(__x.imag(), __x.real());
+    if (sycl::isinf(__x.imag())) {
+      if (__x.real() < _Tp(0))
+        return complex<_Tp>(_Tp(0.75) * __pi, -__x.imag());
+      return complex<_Tp>(_Tp(0.25) * __pi, -__x.imag());
+    }
+    if (__x.real() < _Tp(0))
+      return complex<_Tp>(__pi,
+                          sycl::signbit(__x.imag()) ? -__x.real() : __x.real());
+    return complex<_Tp>(_Tp(0),
+                        sycl::signbit(__x.imag()) ? __x.real() : -__x.real());
+  }
+  if (sycl::isnan(__x.real())) {
+    if (sycl::isinf(__x.imag()))
+      return complex<_Tp>(__x.real(), -__x.imag());
+    return complex<_Tp>(__x.real(), __x.real());
+  }
+  if (sycl::isinf(__x.imag()))
+    return complex<_Tp>(__pi / _Tp(2), -__x.imag());
+  if (__x.real() == 0 && (__x.imag() == 0 || isnan(__x.imag())))
+    return complex<_Tp>(__pi / _Tp(2), -__x.imag());
+  complex<_Tp> __z = log(__x + sqrt(__sqr(__x) - _Tp(1)));
+  if (sycl::signbit(__x.imag()))
+    return complex<_Tp>(sycl::fabs(__z.imag()), sycl::fabs(__z.real()));
+  return complex<_Tp>(sycl::fabs(__z.imag()), -sycl::fabs(__z.real()));
+}
+
+// atan
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
+atan(const complex<_Tp> &__x) {
+  complex<_Tp> __z = atanh(complex<_Tp>(-__x.imag(), __x.real()));
+  return complex<_Tp>(__z.imag(), -__z.real());
+}
+
+// sin
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
+sin(const complex<_Tp> &__x) {
+  complex<_Tp> __z = sinh(complex<_Tp>(-__x.imag(), __x.real()));
+  return complex<_Tp>(__z.imag(), -__z.real());
+}
+
+// cos
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
+cos(const complex<_Tp> &__x) {
+  return cosh(complex<_Tp>(-__x.imag(), __x.real()));
+}
+
+// tan
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
+tan(const complex<_Tp> &__x) {
+  complex<_Tp> __z = tanh(complex<_Tp>(-__x.imag(), __x.real()));
+  return complex<_Tp>(__z.imag(), -__z.real());
+}
+
+template <class _Tp, class _CharT, class _Traits>
+std::basic_istream<_CharT, _Traits> &
+operator>>(std::basic_istream<_CharT, _Traits> &__is, complex<_Tp> &__x) {
+  if (__is.good()) {
+    ws(__is);
+    if (__is.peek() == _CharT('(')) {
+      __is.get();
+      _Tp __r;
+      __is >> __r;
+      if (!__is.fail()) {
+        ws(__is);
+        _CharT __c = __is.peek();
+        if (__c == _CharT(',')) {
+          __is.get();
+          _Tp __i;
+          __is >> __i;
+          if (!__is.fail()) {
+            ws(__is);
+            __c = __is.peek();
+            if (__c == _CharT(')')) {
+              __is.get();
+              __x = complex<_Tp>(__r, __i);
+            } else
+              __is.setstate(__is.failbit);
+          } else
+            __is.setstate(__is.failbit);
+        } else if (__c == _CharT(')')) {
+          __is.get();
+          __x = complex<_Tp>(__r, _Tp(0));
+        } else
+          __is.setstate(__is.failbit);
+      } else
+        __is.setstate(__is.failbit);
+    } else {
+      _Tp __r;
+      __is >> __r;
+      if (!__is.fail())
+        __x = complex<_Tp>(__r, _Tp(0));
+      else
+        __is.setstate(__is.failbit);
+    }
+  } else
+    __is.setstate(__is.failbit);
+  return __is;
+}
+
+template <class _Tp, class _CharT, class _Traits>
+std::basic_ostream<_CharT, _Traits> &
+operator<<(std::basic_ostream<_CharT, _Traits> &__os, const complex<_Tp> &__x) {
+  std::basic_ostringstream<_CharT, _Traits> __s;
+  __s.flags(__os.flags());
+  __s.imbue(__os.getloc());
+  __s.precision(__os.precision());
+  __s << '(' << __x.real() << ',' << __x.imag() << ')';
+  return __os << __s.str();
+}
+
+template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
+SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY const sycl::stream &
+operator<<(const sycl::stream &__ss, const complex<_Tp> &_x) {
+  return __ss << "(" << _x.real() << "," << _x.imag() << ")";
+}
+
+_SYCL_EXT_CPLX_END_NAMESPACE_STD
+
+#undef _SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD
+#undef _SYCL_EXT_CPLX_END_NAMESPACE_STD
+#undef _SYCL_EXT_CPLX_INLINE_VISIBILITY
+
+#endif // _SYCL_EXT_CPLX_COMPLEX

--- a/include/gtensor/sycl_ext_complex.hpp
+++ b/include/gtensor/sycl_ext_complex.hpp
@@ -244,14 +244,14 @@ template<class T> complex<T> tanh (const complex<T>&);
 
 // clang-format on
 
-#define _SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD namespace sycl::ext::cplx {
+#define _SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD namespace gt::sycl_cplx {
 #define _SYCL_EXT_CPLX_END_NAMESPACE_STD }
 #define _SYCL_EXT_CPLX_INLINE_VISIBILITY                                       \
   inline __attribute__((__visibility__("hidden"), __always_inline__))
 
 #include <complex>
 #include <sstream> // for std::basic_ostringstream
-#include "backend_sycl_compat.h" // changed from upstream for old oneAPI
+#include "backend_sycl_compat.h"
 #include <type_traits>
 
 _SYCL_EXT_CPLX_BEGIN_NAMESPACE_STD
@@ -1204,7 +1204,7 @@ SYCL_EXTERNAL
     _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<typename __promote<_Tp, _Up>::type>
     pow(const complex<_Tp> &__x, const complex<_Up> &__y) {
   typedef complex<typename __promote<_Tp, _Up>::type> result_type;
-  return sycl::ext::cplx::pow(result_type(__x), result_type(__y));
+  return pow(result_type(__x), result_type(__y));
 }
 
 template <class _Tp, class _Up,
@@ -1214,7 +1214,7 @@ SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
                             complex<typename __promote<_Tp, _Up>::type>>::type
     pow(const complex<_Tp> &__x, const _Up &__y) {
   typedef complex<typename __promote<_Tp, _Up>::type> result_type;
-  return sycl::ext::cplx::pow(result_type(__x), result_type(__y));
+  return pow(result_type(__x), result_type(__y));
 }
 
 template <class _Tp, class _Up,
@@ -1224,7 +1224,7 @@ SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
                             complex<typename __promote<_Tp, _Up>::type>>::type
     pow(const _Tp &__x, const complex<_Up> &__y) {
   typedef complex<typename __promote<_Tp, _Up>::type> result_type;
-  return sycl::ext::cplx::pow(result_type(__x), result_type(__y));
+  return pow(result_type(__x), result_type(__y));
 }
 
 // __sqr, computes pow(x, 2)

--- a/src/gtsolver.cxx
+++ b/src/gtsolver.cxx
@@ -2,6 +2,8 @@
 
 #include "gt-solver/solver.h"
 
+using namespace gt::complex_cast;
+
 namespace gt
 {
 
@@ -58,17 +60,17 @@ SolverDense<T>::SolverDense(gt::blas::handle_t& h, int n, int nbatches,
       h, n, n, n, nrhs, nbatches)),
     scratch_(scratch_count_)
 {
+  using T2 = typename make_std<T>::type;
   detail::copy_batch_data(matrix_batches, matrix_data_);
 
   // factor using strided API
   auto prep_scratch_count =
-    gt::blas::getrf_strided_batched_scratchpad_size<T>(h_, n_, n_, nbatches_);
-  gt::space::device_vector<T> prep_scratch(prep_scratch_count);
+    gt::blas::getrf_strided_batched_scratchpad_size<T2>(h_, n_, n_, nbatches_);
+  gt::space::device_vector<T2> prep_scratch(prep_scratch_count);
 
-  gt::blas::getrf_strided_batched<T>(
-    h_, n_, gt::raw_pointer_cast(matrix_data_.data()), n_,
-    gt::raw_pointer_cast(pivot_data_.data()), nbatches_,
-    gt::raw_pointer_cast(prep_scratch.data()), prep_scratch_count);
+  gt::blas::getrf_strided_batched<T2>(
+    h_, n_, std_cast(matrix_data_.data()), n_, std_cast(pivot_data_.data()),
+    nbatches_, std_cast(prep_scratch.data()), prep_scratch_count);
   // Note: synchronize so it's safe to destroy scratch
   gt::synchronize();
 }
@@ -76,13 +78,13 @@ SolverDense<T>::SolverDense(gt::blas::handle_t& h, int n, int nbatches,
 template <typename T>
 void SolverDense<T>::solve(T* rhs, T* result)
 {
+  using T2 = typename make_std<T>::type;
   gt::copy_n(gt::device_pointer_cast(rhs), n_ * nrhs_ * nbatches_,
              rhs_data_.data());
-  gt::blas::getrs_strided_batched<T>(
-    h_, n_, nrhs_, gt::raw_pointer_cast(matrix_data_.data()), n_,
-    gt::raw_pointer_cast(pivot_data_.data()),
-    gt::raw_pointer_cast(rhs_data_.data()), n_, nbatches_,
-    gt::raw_pointer_cast(scratch_.data()), scratch_count_);
+  gt::blas::getrs_strided_batched<T2>(
+    h_, n_, nrhs_, std_cast(matrix_data_.data()), n_,
+    std_cast(pivot_data_.data()), std_cast(rhs_data_.data()), n_, nbatches_,
+    std_cast(scratch_.data()), scratch_count_);
   gt::copy_n(rhs_data_.data(), n_ * nrhs_ * nbatches_,
              gt::device_pointer_cast(result));
 }
@@ -109,10 +111,9 @@ SolverDense<T>::SolverDense(gt::blas::handle_t& h, int n, int nbatches,
   detail::init_device_pointer_array(rhs_pointers_, rhs_data_);
 
   // dense LU factor with pivot
-  gt::blas::getrf_batched<T>(h_, n_,
-                             gt::raw_pointer_cast(matrix_pointers_.data()), n_,
-                             gt::raw_pointer_cast(pivot_data_.data()),
-                             gt::raw_pointer_cast(info_.data()), nbatches_);
+  gt::blas::getrf_batched<T>(h_, n_, std_cast(matrix_pointers_.data()), n_,
+                             std_cast(pivot_data_.data()),
+                             std_cast(info_.data()), nbatches_);
   // Note: synchronize for consistency with other implementations
   gt::synchronize();
 }
@@ -122,10 +123,9 @@ void SolverDense<T>::solve(T* rhs, T* result)
 {
   gt::copy_n(gt::device_pointer_cast(rhs), n_ * nrhs_ * nbatches_,
              rhs_data_.data());
-  gt::blas::getrs_batched<T>(
-    h_, n_, nrhs_, gt::raw_pointer_cast(matrix_pointers_.data()), n_,
-    gt::raw_pointer_cast(pivot_data_.data()),
-    gt::raw_pointer_cast(rhs_pointers_.data()), n_, nbatches_);
+  gt::blas::getrs_batched<T>(h_, n_, nrhs_, std_cast(matrix_pointers_.data()),
+                             n_, std_cast(pivot_data_.data()),
+                             std_cast(rhs_pointers_.data()), n_, nbatches_);
   gt::copy_n(rhs_data_.data(), n_ * nrhs_ * nbatches_,
              gt::device_pointer_cast(result));
 }
@@ -159,10 +159,9 @@ SolverInvert<T>::SolverInvert(gt::blas::handle_t& h, int n, int nbatches,
   detail::init_device_pointer_array(rhs_input_pointers_, rhs_input_data_);
 
   // LU factor with pivot into matrix_data_
-  gt::blas::getrf_batched<T>(h_, n_,
-                             gt::raw_pointer_cast(matrix_pointers_.data()), n_,
-                             gt::raw_pointer_cast(pivot_data_.data()),
-                             gt::raw_pointer_cast(info_.data()), nbatches_);
+  gt::blas::getrf_batched<T>(h_, n_, std_cast(matrix_pointers_.data()), n_,
+                             std_cast(pivot_data_.data()),
+                             std_cast(info_.data()), nbatches_);
 
   // invert using LU factors with getri.
   // Note: getri is not in place, so we copy input data to temporary and have
@@ -171,10 +170,9 @@ SolverInvert<T>::SolverInvert(gt::blas::handle_t& h, int n, int nbatches,
   gt::gtensor_device<T*, 1> d_Aptr(matrix_pointers_.shape());
   detail::init_device_pointer_array(d_Aptr, d_A);
   gt::copy(matrix_data_, d_A);
-  gt::blas::getri_batched<T>(h_, n_, gt::raw_pointer_cast(d_Aptr.data()), n_,
-                             gt::raw_pointer_cast(pivot_data_.data()),
-                             gt::raw_pointer_cast(matrix_pointers_.data()), n_,
-                             gt::raw_pointer_cast(info_.data()), nbatches_);
+  gt::blas::getri_batched<T>(
+    h_, n_, std_cast(d_Aptr.data()), n_, std_cast(pivot_data_.data()),
+    std_cast(matrix_pointers_.data()), n_, std_cast(info_.data()), nbatches_);
   // Note: synchronize so it's safe to destroy temporaries
   gt::synchronize();
 }
@@ -184,10 +182,10 @@ void SolverInvert<T>::solve(T* rhs, T* result)
 {
   gt::copy_n(gt::device_pointer_cast(rhs), n_ * nrhs_ * nbatches_,
              rhs_input_data_.data());
-  gt::blas::gemm_batched<T>(
-    h_, n_, nrhs_, n_, 1.0, gt::raw_pointer_cast(matrix_pointers_.data()), n_,
-    gt::raw_pointer_cast(rhs_input_pointers_.data()), n_, 0.0,
-    gt::raw_pointer_cast(rhs_pointers_.data()), n_, nbatches_);
+  gt::blas::gemm_batched<T>(h_, n_, nrhs_, n_, 1.0,
+                            std_cast(matrix_pointers_.data()), n_,
+                            std_cast(rhs_input_pointers_.data()), n_, 0.0,
+                            std_cast(rhs_pointers_.data()), n_, nbatches_);
   gt::copy_n(rhs_data_.data(), n_ * nrhs_ * nbatches_,
              gt::device_pointer_cast(result));
 }

--- a/tests/test_complex.cxx
+++ b/tests/test_complex.cxx
@@ -2,6 +2,8 @@
 
 #include <gtensor/gtensor.h>
 
+#include "test_debug.h"
+
 TEST(complex, complex_ops)
 {
   using T = gt::complex<double>;
@@ -396,5 +398,56 @@ TEST(complex, device_exp)
 }
 
 #endif // CUDA or HIP
+
+#ifdef GTENSOR_DEVICE_SYCL
+
+TEST(complex, sycl_std_cast)
+{
+  using namespace gt::complex_cast;
+
+  gt::complex<double>* a_complex_double_p;
+  auto a_casted = std_cast(a_complex_double_p);
+  GT_DEBUG_TYPE(a_casted);
+  EXPECT_TRUE((std::is_same<decltype(a_casted), std::complex<double>*>::value));
+
+  double* b_double_p;
+  auto b_casted = std_cast(b_double_p);
+  GT_DEBUG_TYPE(b_casted);
+  EXPECT_TRUE((std::is_same<decltype(b_casted), double*>::value));
+
+  gt::backend::device_ptr<gt::complex<double>> c_complex_double_dp;
+  auto c_casted = std_cast(c_complex_double_dp);
+  GT_DEBUG_TYPE(c_casted);
+  EXPECT_TRUE((std::is_same<decltype(c_casted), std::complex<double>*>::value));
+
+  gt::complex<double>** d_complex_double_pp;
+  auto d_casted = std_cast(d_complex_double_pp);
+  GT_DEBUG_TYPE(d_casted);
+  EXPECT_TRUE(
+    (std::is_same<decltype(d_casted), std::complex<double>**>::value));
+
+  const gt::complex<double>* e_complex_double_p_const;
+  auto e_casted = std_cast(e_complex_double_p_const);
+  GT_DEBUG_TYPE(e_casted);
+  EXPECT_TRUE(
+    (std::is_same<decltype(e_casted), const std::complex<double>*>::value));
+}
+
+TEST(complex, sycl_make_std)
+{
+  using namespace gt::complex_cast;
+
+  using T1 = gt::complex<double>;
+  using T1std = typename make_std<T1>::type;
+  GT_DEBUG_TYPE_NAME(T1std);
+  EXPECT_TRUE((std::is_same<T1std, std::complex<double>>::value));
+
+  using T2 = float;
+  using T2std = typename make_std<float>::type;
+  GT_DEBUG_TYPE_NAME(T2std);
+  EXPECT_TRUE((std::is_same<T2std, float>::value));
+}
+
+#endif // GTENSOR_DEVICE_SYCL
 
 #endif


### PR DESCRIPTION
ALCF is working to standardize `sycl::complex`, and has a library implementation available with `sycl::ext::cplx::complex`. This work nicely in gtensor, except when passing pointers around, see https://github.com/argonne-lcf/SyclCPLX/issues/19. This PR includes a lightly modified version of the library header from SyclCPLX, along with some template meta programming ugliness to convert to std::complex in gt-blas, gt-fft, and gt-solver. Once this is standardized and oneMKL is updated, we should be able to remove the hacks. In the meantime, this allows us to contribute towards the standardization process by providing a real world test case.