### PR TITLE
add gt::host_mirror

### DIFF
--- a/include/gtensor/backend_host.h
+++ b/include/gtensor/backend_host.h
@@ -96,7 +96,12 @@ template <typename InputPtr, typename OutputPtr>
 inline void copy_n(gt::space::host tag_in, gt::space::host tag_out, InputPtr in,
                    size_type count, OutputPtr out)
 {
-  std::copy_n(in, count, out);
+  // This may be used to copy between a gtensor and its host mirror, which are
+  // the same object if compiling for host only, so in that case, we don't need
+  // to actually copy anything
+  if (in != out) {
+    std::copy_n(in, count, out);
+  }
 }
 } // namespace copy_impl
 

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -870,6 +870,16 @@ inline auto arange(T start, T end, T step = 1)
   return generator<1, T>(shape, detail::arange_generator_1d<T>(start, step));
 }
 
+// ======================================================================
+// host_mirror
+
+template <typename E>
+auto host_mirror(const E& e)
+{
+  // FIXME, empty_like with space would be helpful
+  return gt::empty<gt::expr_value_type<E>>(e.shape());
+}
+
 } // namespace gt
 
 #endif

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -808,7 +808,14 @@ TYPED_TEST(gtensor_space, host_mirror)
 
   auto a = gt::zeros<double, space_type>({3, 2});
   // initialize on host
-  auto h_a = gt::host_mirror(a);
+  auto&& h_a = gt::host_mirror(a);
+
+  if (std::is_same<space_type, gt::space::host>::value) {
+    // make sure if a is already on the host, we're not actually allocating a
+    // mirror
+    EXPECT_EQ(gt::raw_pointer_cast(a.data()), h_a.data());
+  }
+
   h_a = gt::gtensor<double, 2>{{11., 12., 13.}, {21., 22., 23.}};
   gt::copy(h_a, a);
 
@@ -817,7 +824,7 @@ TYPED_TEST(gtensor_space, host_mirror)
   b = a;
 
   // check result on host
-  auto h_b = gt::host_mirror(b);
+  auto&& h_b = gt::host_mirror(b);
   gt::copy(b, h_b);
   EXPECT_EQ(h_b, h_a);
 }


### PR DESCRIPTION
All it does is allocate a gtensor on the host with matching size.
    
It does not copy either way, that needs to be done explicitly -- that's one way to allow the user to specify whether they're reading from, or writing to the mirrored gtensor.