### PR TITLE
improve gt::copy

### DIFF
--- a/include/gtensor/backend_common.h
+++ b/include/gtensor/backend_common.h
@@ -248,6 +248,13 @@ GT_INLINE auto device_pointer_cast(T* p)
   return pointer(p);
 }
 
+template <typename S = gt::space::device, typename T>
+GT_INLINE auto space_pointer_cast(T* p)
+{
+  using pointer = typename gt::device_ptr<T, S>;
+  return pointer(p);
+}
+
 namespace backend
 {
 namespace allocator_impl

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -851,6 +851,18 @@ copy(const SRC& src, DST& dst)
   }
 }
 
+template <typename SRC, typename DST>
+std::enable_if_t<!gt::has_data_and_size<SRC>::value &&
+                 gt::has_data_and_size<DST>::value>
+copy(const SRC& src, DST& dst)
+{
+  if (dst.is_f_contiguous()) {
+    gt::copy(gt::eval(src), dst);
+  } else {
+    assert(0);
+  }
+}
+
 // ======================================================================
 // arange
 

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -843,7 +843,11 @@ copy(const SRC& src, DST& dst)
       assert(0);
     }
   } else {
-    assert(0);
+    if (dst.is_f_contiguous()) {
+      gt::copy(gt::eval(src), dst);
+    } else {
+      assert(0);
+    }
   }
 }
 

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -848,7 +848,9 @@ copy(const SRC& src, DST& dst)
     if (dst.is_f_contiguous()) {
       gt::copy(gt::eval(src), dst);
     } else {
-      assert(0);
+      auto dst_tmp = gt::empty_like(dst);
+      gt::copy(src, dst_tmp);
+      dst = dst_tmp;
     }
   }
 }

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -866,11 +866,7 @@ std::enable_if_t<
   (!gt::has_data_and_size<SRC>::value && gt::has_data_and_size<DST>::value)>
 copy(const SRC& src, DST&& dst)
 {
-  if (dst.is_f_contiguous()) {
-    gt::copy(gt::eval(src), dst);
-  } else {
-    assert(0);
-  }
+  gt::copy(gt::eval(src), dst);
 }
 
 // different spaces, destination is not storage-like

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -81,6 +81,8 @@ public:
 
   std::string typestr() const&;
 
+  bool is_f_contiguous() const;
+
 private:
   GT_INLINE const storage_type& storage_impl() const;
   GT_INLINE storage_type& storage_impl();
@@ -194,6 +196,13 @@ inline std::string gtensor_container<T, N>::typestr() const&
     << this->shape() << this->strides();
   return s.str();
 }
+
+template <typename T, size_type N>
+inline bool gtensor_container<T, N>::is_f_contiguous() const
+{
+  return true;
+}
+
 
 // ======================================================================
 // copies

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -833,7 +833,7 @@ struct has_data_and_size<E,
 template <typename SRC, typename DST>
 std::enable_if_t<gt::has_data_and_size<SRC>::value &&
                  gt::has_data_and_size<DST>::value>
-copy(const SRC& src, DST& dst)
+copy(const SRC& src, DST&& dst)
 {
   if (!dst.is_f_contiguous()) {
     auto dst_tmp = gt::empty_like(dst);
@@ -854,23 +854,35 @@ template <typename SRC, typename DST>
 std::enable_if_t<
   std::is_same<expr_space_type<SRC>, expr_space_type<DST>>::value &&
   !(gt::has_data_and_size<SRC>::value && gt::has_data_and_size<DST>::value)>
-copy(const SRC& src, DST& dst)
+copy(const SRC& src, DST&& dst)
 {
   dst = src;
 }
 
-// different spaces, destination is storage-like
+// different spaces, source not storage like, destination is storage-like
 template <typename SRC, typename DST>
 std::enable_if_t<
   !std::is_same<expr_space_type<SRC>, expr_space_type<DST>>::value &&
   (!gt::has_data_and_size<SRC>::value && gt::has_data_and_size<DST>::value)>
-copy(const SRC& src, DST& dst)
+copy(const SRC& src, DST&& dst)
 {
   if (dst.is_f_contiguous()) {
     gt::copy(gt::eval(src), dst);
   } else {
     assert(0);
   }
+}
+
+// different spaces, destination is not storage-like
+template <typename SRC, typename DST>
+std::enable_if_t<
+  !std::is_same<expr_space_type<SRC>, expr_space_type<DST>>::value &&
+  !gt::has_data_and_size<DST>::value>
+copy(const SRC& src, DST&& dst)
+{
+  auto dst_tmp = gt::empty_like(dst);
+  gt::copy(src, dst_tmp);
+  dst = dst_tmp;
 }
 
 // ======================================================================

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -204,42 +204,6 @@ inline bool gtensor_container<T, N>::is_f_contiguous() const
 }
 
 // ======================================================================
-
-template <typename E, typename Enable = void>
-struct has_data_and_size : std::false_type
-{};
-
-template <typename E>
-struct has_data_and_size<E,
-                         gt::meta::void_t<decltype(std::declval<E>().data()),
-                                          decltype(std::declval<E>().size())>>
-  : std::true_type
-{};
-
-// ======================================================================
-// copies
-//
-// FIXME, there should be only one, more general version,
-// and maybe this should be .assign or operator=
-
-template <typename SRC, typename DST>
-std::enable_if_t<gt::has_data_and_size<SRC>::value &&
-                 gt::has_data_and_size<DST>::value>
-copy(const SRC& src, DST& dst)
-{
-  if (src.is_f_contiguous()) {
-    if (dst.is_f_contiguous()) {
-      assert(src.size() == dst.size());
-      gt::copy_n(src.data(), src.size(), dst.data());
-    } else {
-      assert(0);
-    }
-  } else {
-    assert(0);
-  }
-}
-
-// ======================================================================
 // launch
 
 #if defined(GTENSOR_DEVICE_CUDA) || defined(GTENSOR_DEVICE_HIP)
@@ -847,6 +811,40 @@ inline std::enable_if_t<
 eval(E&& e)
 {
   return {std::forward<E>(e)};
+}
+
+// ======================================================================
+// has_data_and_size
+
+template <typename E, typename Enable = void>
+struct has_data_and_size : std::false_type
+{};
+
+template <typename E>
+struct has_data_and_size<E,
+                         gt::meta::void_t<decltype(std::declval<E>().data()),
+                                          decltype(std::declval<E>().size())>>
+  : std::true_type
+{};
+
+// ======================================================================
+// copies
+
+template <typename SRC, typename DST>
+std::enable_if_t<gt::has_data_and_size<SRC>::value &&
+                 gt::has_data_and_size<DST>::value>
+copy(const SRC& src, DST& dst)
+{
+  if (src.is_f_contiguous()) {
+    if (dst.is_f_contiguous()) {
+      assert(src.size() == dst.size());
+      gt::copy_n(src.data(), src.size(), dst.data());
+    } else {
+      assert(0);
+    }
+  } else {
+    assert(0);
+  }
 }
 
 // ======================================================================

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -835,22 +835,16 @@ std::enable_if_t<gt::has_data_and_size<SRC>::value &&
                  gt::has_data_and_size<DST>::value>
 copy(const SRC& src, DST& dst)
 {
-  if (src.is_f_contiguous()) {
-    if (dst.is_f_contiguous()) {
+  if (!dst.is_f_contiguous()) {
+    auto dst_tmp = gt::empty_like(dst);
+    gt::copy(src, dst_tmp);
+    dst = dst_tmp;
+  } else {
+    if (src.is_f_contiguous()) {
       assert(src.size() == dst.size());
       gt::copy_n(src.data(), src.size(), dst.data());
     } else {
-      auto dst_tmp = gt::empty_like(dst);
-      gt::copy(src, dst_tmp);
-      dst = dst_tmp;
-    }
-  } else {
-    if (dst.is_f_contiguous()) {
       gt::copy(gt::eval(src), dst);
-    } else {
-      auto dst_tmp = gt::empty_like(dst);
-      gt::copy(src, dst_tmp);
-      dst = dst_tmp;
     }
   }
 }

--- a/include/gtensor/gtensor_span.h
+++ b/include/gtensor/gtensor_span.h
@@ -220,30 +220,36 @@ inline std::string gtensor_span<T, N, S>::typestr() const&
 // ======================================================================
 // adapt
 
-template <size_type N, typename T>
-GT_INLINE gtensor_span<T, N> adapt(T* data, const shape_type<N>& shape)
+template <size_type N, typename S, typename T>
+GT_INLINE auto adapt(gt::space_pointer<T, S> data, const shape_type<N>& shape)
 {
-  return gtensor_span<T, N>(data, shape, calc_strides(shape));
+  return gtensor_span<T, N, S>(data, shape, calc_strides(shape));
+}
+
+// host
+template <size_type N, typename T>
+GT_INLINE auto adapt(T* data, const shape_type<N>& shape)
+{
+  return adapt<N, gt::space::host, T>(data, shape);
 }
 
 template <size_type N, typename T>
-gtensor_span<T, N> adapt(T* data, const int* shape_data)
+GT_INLINE auto adapt(T* data, const int* shape_data)
 {
-  return adapt<N, T>(data, {shape_data, N});
+  return adapt<N, gt::space::host, T>(data, {shape_data, N});
+}
+
+// device
+template <size_type N, typename T>
+GT_INLINE auto adapt_device(T* data, const shape_type<N>& shape)
+{
+  return adapt<N, gt::space::device>(gt::device_pointer_cast(data), shape);
 }
 
 template <size_type N, typename T>
-GT_INLINE gtensor_span<T, N, space::device> adapt_device(
-  T* data, const shape_type<N>& shape)
+GT_INLINE auto adapt_device(T* data, const int* shape_data)
 {
-  return gtensor_span<T, N, space::device>(gt::device_pointer_cast(data), shape,
-                                           calc_strides(shape));
-}
-
-template <size_type N, typename T>
-gtensor_span<T, N, space::device> adapt_device(T* data, const int* shape_data)
-{
-  return adapt_device<N, T>(data, {shape_data, N});
+  return adapt<N, gt::space::device, T>(data, {shape_data, N});
 }
 
 // ======================================================================

--- a/include/gtensor/gtensor_span.h
+++ b/include/gtensor/gtensor_span.h
@@ -112,6 +112,8 @@ public:
 
   inline std::string typestr() const&;
 
+  inline bool is_f_contiguous() const;
+
 private:
   storage_type storage_;
 
@@ -215,6 +217,12 @@ inline std::string gtensor_span<T, N, S>::typestr() const&
   s << "s" << N << "<" << get_type_name<T>() << ">" << this->shape()
     << this->strides();
   return s.str();
+}
+
+template <typename T, size_type N, typename S>
+inline bool gtensor_span<T, N, S>::is_f_contiguous() const
+{
+  return this->strides() == calc_strides(this->shape());
 }
 
 // ======================================================================

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -69,6 +69,12 @@ TEST(gtensor, indexing_2d)
   EXPECT_EQ(a(2, 1), adata[5]);
 }
 
+TEST(gtensor, is_f_contiguous)
+{
+  gt::gtensor<double, 2> a{{11., 21., 31.}, {12., 22., 32.}};
+  EXPECT_TRUE(a.is_f_contiguous());
+}
+
 TEST(gtensor, op_equal)
 {
   gt::gtensor<double, 2> a{{11., 12., 13.}, {21., 22., 23.}};
@@ -868,6 +874,18 @@ TYPED_TEST(gtensor_copy, span_span)
   EXPECT_EQ(s_a, s_b);
 }
 
+TYPED_TEST(gtensor_copy, expr_gtensor)
+{
+  using a_space_type = typename TypeParam::a_space_type;
+  using b_space_type = typename TypeParam::b_space_type;
+  auto a =
+    gt::gtensor<double, 2, a_space_type>{{11., 12., 13.}, {21., 22., 23.}};
+  auto b = gt::gtensor<double, 2, b_space_type>(a.shape(), 0.);
+
+  // gt::copy(a + a, b);
+  // EXPECT_EQ(b, a + a);
+}
+
 TYPED_TEST(gtensor_copy, non_contig_span)
 {
   using a_space_type = typename TypeParam::a_space_type;
@@ -882,7 +900,6 @@ TYPED_TEST(gtensor_copy, non_contig_span)
 
   EXPECT_EQ(s_a,
             (gt::gtensor<double, 2, a_space_type>{{12., 13.}, {22., 23.}}));
-  std::cout << s_a << "\n";
 
   // FIXME!!!
   //  gt::copy(s_a, b);

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -802,11 +802,80 @@ TYPED_TEST_SUITE(gtensor_space, gtensor_space_types);
 TYPED_TEST(gtensor_space, copy_gtensor_gtensor_hh)
 {
   auto a = gt::gtensor<double, 2>{{11., 12., 13.}, {21., 22., 23.}};
-  auto b = gt::empty_like(a);
+  auto b = gt::gtensor<double, 2>(a.shape(), 0.);
 
   EXPECT_NE(b, a);
   gt::copy(a, b);
   EXPECT_EQ(b, a);
+}
+
+TYPED_TEST(gtensor_space, copy_gtensor_gtensor_dh)
+{
+  using device = TypeParam;
+  auto a = gt::gtensor<double, 2, device>{{11., 12., 13.}, {21., 22., 23.}};
+  auto b = gt::gtensor<double, 2>(a.shape(), 0.);
+
+  EXPECT_NE(b, a);
+  gt::copy(a, b);
+  EXPECT_EQ(b, a);
+}
+
+TYPED_TEST(gtensor_space, copy_gtensor_gtensor_hd)
+{
+  using device = TypeParam;
+  auto a = gt::gtensor<double, 2>{{11., 12., 13.}, {21., 22., 23.}};
+  auto b = gt::gtensor<double, 2, device>(a.shape(), 0.);
+
+  EXPECT_NE(b, a);
+  gt::copy(a, b);
+  EXPECT_EQ(b, a);
+}
+
+TYPED_TEST(gtensor_space, copy_gtensor_gtensor_dd)
+{
+  using device = TypeParam;
+  auto a = gt::gtensor<double, 2, device>{{11., 12., 13.}, {21., 22., 23.}};
+  auto b = gt::gtensor<double, 2, device>(a.shape(), 0.);
+
+  EXPECT_NE(b, a);
+  gt::copy(a, b);
+  EXPECT_EQ(b, a);
+}
+
+TYPED_TEST(gtensor_space, copy_gtensor_span_hh)
+{
+  auto a = gt::gtensor<double, 2>{{11., 12., 13.}, {21., 22., 23.}};
+  auto b = gt::gtensor<double, 2>(a.shape(), 0.);
+  auto s_a = gt::adapt<2>(a.data(), a.shape());
+  auto s_b = gt::adapt<2>(b.data(), b.shape());
+
+  EXPECT_NE(s_b, a);
+  gt::copy(a, s_b);
+  EXPECT_EQ(s_b, a);
+}
+
+TYPED_TEST(gtensor_space, copy_span_gtensor_hh)
+{
+  auto a = gt::gtensor<double, 2>{{11., 12., 13.}, {21., 22., 23.}};
+  auto b = gt::gtensor<double, 2>(a.shape(), 0.);
+  auto s_a = gt::adapt<2>(a.data(), a.shape());
+  auto s_b = gt::adapt<2>(b.data(), b.shape());
+
+  EXPECT_NE(b, s_a);
+  gt::copy(s_a, b);
+  EXPECT_EQ(b, s_a);
+}
+
+TYPED_TEST(gtensor_space, copy_span_span_hh)
+{
+  auto a = gt::gtensor<double, 2>{{11., 12., 13.}, {21., 22., 23.}};
+  auto b = gt::gtensor<double, 2>(a.shape(), 0.);
+  auto s_a = gt::adapt<2>(a.data(), a.shape());
+  auto s_b = gt::adapt<2>(b.data(), b.shape());
+
+  EXPECT_NE(s_b, s_a);
+  gt::copy(s_a, s_b);
+  EXPECT_EQ(s_b, s_a);
 }
 
 // host_mirror should basically be a no-op when compiling host only (space_type

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -874,18 +874,6 @@ TYPED_TEST(gtensor_copy, span_span)
   EXPECT_EQ(s_a, s_b);
 }
 
-TYPED_TEST(gtensor_copy, expr_gtensor)
-{
-  using a_space_type = typename TypeParam::a_space_type;
-  using b_space_type = typename TypeParam::b_space_type;
-  auto a =
-    gt::gtensor<double, 2, a_space_type>{{11., 12., 13.}, {21., 22., 23.}};
-  auto b = gt::gtensor<double, 2, b_space_type>(a.shape(), 0.);
-
-  gt::copy(a + a, b);
-  EXPECT_EQ(b, a + a);
-}
-
 TYPED_TEST(gtensor_copy, from_non_contiguous_span)
 {
   using a_space_type = typename TypeParam::a_space_type;
@@ -940,6 +928,30 @@ TYPED_TEST(gtensor_copy, from_to_non_contiguous_span)
   gt::copy(s_a, s_b);
   EXPECT_EQ(
     b, (gt::gtensor<double, 2, b_space_type>{{0., 12., 13.}, {0., 22., 23.}}));
+}
+
+TYPED_TEST(gtensor_copy, from_expr)
+{
+  using a_space_type = typename TypeParam::a_space_type;
+  using b_space_type = typename TypeParam::b_space_type;
+  auto a =
+    gt::gtensor<double, 2, a_space_type>{{11., 12., 13.}, {21., 22., 23.}};
+  auto b = gt::gtensor<double, 2, b_space_type>(a.shape(), 0.);
+
+  gt::copy(a + a, b);
+  EXPECT_EQ(b, a + a);
+}
+
+TYPED_TEST(gtensor_copy, to_expr)
+{
+  using a_space_type = typename TypeParam::a_space_type;
+  using b_space_type = typename TypeParam::b_space_type;
+  auto a =
+    gt::gtensor<double, 2, a_space_type>{{11., 12., 13.}, {21., 22., 23.}};
+  auto b = gt::gtensor<double, 2, b_space_type>(a.shape(), 0.);
+
+  gt::copy(a, b.view());
+  EXPECT_EQ(b, a);
 }
 
 // ======================================================================

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -868,6 +868,28 @@ TYPED_TEST(gtensor_copy, span_span)
   EXPECT_EQ(s_a, s_b);
 }
 
+TYPED_TEST(gtensor_copy, non_contig_span)
+{
+  using a_space_type = typename TypeParam::a_space_type;
+  using b_space_type = typename TypeParam::b_space_type;
+  auto a =
+    gt::gtensor<double, 2, a_space_type>{{11., 12., 13.}, {21., 22., 23.}};
+  auto b = gt::gtensor<double, 2, b_space_type>(gt::shape(2, 2), 0.);
+
+  // make a noncontiguous subset gtensor_span
+  auto s_a = gt::gtensor_span<double, 2, a_space_type>(
+    a.data() + 1, gt::shape(2, 2), a.strides());
+
+  EXPECT_EQ(s_a,
+            (gt::gtensor<double, 2, a_space_type>{{12., 13.}, {22., 23.}}));
+  std::cout << s_a << "\n";
+
+  // FIXME!!!
+  //  gt::copy(s_a, b);
+  //  EXPECT_EQ(b, (gt::gtensor<double, 2, b_space_type>{{12., 13.},
+  //  {22., 23.}}));
+}
+
 // ======================================================================
 
 template <typename S>

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -901,10 +901,8 @@ TYPED_TEST(gtensor_copy, non_contig_span)
   EXPECT_EQ(s_a,
             (gt::gtensor<double, 2, a_space_type>{{12., 13.}, {22., 23.}}));
 
-  // FIXME!!!
-  //  gt::copy(s_a, b);
-  //  EXPECT_EQ(b, (gt::gtensor<double, 2, b_space_type>{{12., 13.},
-  //  {22., 23.}}));
+  gt::copy(s_a, b);
+  EXPECT_EQ(b, (gt::gtensor<double, 2, b_space_type>{{12., 13.}, {22., 23.}}));
 }
 
 // ======================================================================

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -799,6 +799,16 @@ using gtensor_space_types = ::testing::Types<
 
 TYPED_TEST_SUITE(gtensor_space, gtensor_space_types);
 
+TYPED_TEST(gtensor_space, copy_gtensor_gtensor_hh)
+{
+  auto a = gt::gtensor<double, 2>{{11., 12., 13.}, {21., 22., 23.}};
+  auto b = gt::empty_like(a);
+
+  EXPECT_NE(b, a);
+  gt::copy(a, b);
+  EXPECT_EQ(b, a);
+}
+
 // host_mirror should basically be a no-op when compiling host only (space_type
 // == host), but will handle the situation where something really lives on the
 // device but needs to be manipulated on the host

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -882,8 +882,8 @@ TYPED_TEST(gtensor_copy, expr_gtensor)
     gt::gtensor<double, 2, a_space_type>{{11., 12., 13.}, {21., 22., 23.}};
   auto b = gt::gtensor<double, 2, b_space_type>(a.shape(), 0.);
 
-  // gt::copy(a + a, b);
-  // EXPECT_EQ(b, a + a);
+  gt::copy(a + a, b);
+  EXPECT_EQ(b, a + a);
 }
 
 TYPED_TEST(gtensor_copy, non_contig_span)

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -923,6 +923,25 @@ TYPED_TEST(gtensor_copy, to_non_contiguous_span)
     b, (gt::gtensor<double, 2, b_space_type>{{0., 12., 13.}, {0., 22., 23.}}));
 }
 
+TYPED_TEST(gtensor_copy, from_to_non_contiguous_span)
+{
+  using a_space_type = typename TypeParam::a_space_type;
+  using b_space_type = typename TypeParam::b_space_type;
+  auto a =
+    gt::gtensor<double, 2, a_space_type>{{11., 12., 13.}, {21., 22., 23.}};
+  auto b = gt::gtensor<double, 2, b_space_type>(a.shape(), 0.);
+
+  // make a noncontiguous subset gtensor_spans
+  auto s_a = gt::gtensor_span<double, 2, a_space_type>(
+    a.data() + 1, gt::shape(2, 2), a.strides());
+  auto s_b = gt::gtensor_span<double, 2, b_space_type>(
+    b.data() + 1, gt::shape(2, 2), b.strides());
+
+  gt::copy(s_a, s_b);
+  EXPECT_EQ(
+    b, (gt::gtensor<double, 2, b_space_type>{{0., 12., 13.}, {0., 22., 23.}}));
+}
+
 // ======================================================================
 
 template <typename S>

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -886,7 +886,7 @@ TYPED_TEST(gtensor_copy, expr_gtensor)
   EXPECT_EQ(b, a + a);
 }
 
-TYPED_TEST(gtensor_copy, non_contig_span)
+TYPED_TEST(gtensor_copy, from_non_contiguous_span)
 {
   using a_space_type = typename TypeParam::a_space_type;
   using b_space_type = typename TypeParam::b_space_type;
@@ -903,6 +903,24 @@ TYPED_TEST(gtensor_copy, non_contig_span)
 
   gt::copy(s_a, b);
   EXPECT_EQ(b, (gt::gtensor<double, 2, b_space_type>{{12., 13.}, {22., 23.}}));
+}
+
+TYPED_TEST(gtensor_copy, to_non_contiguous_span)
+{
+  using a_space_type = typename TypeParam::a_space_type;
+  using b_space_type = typename TypeParam::b_space_type;
+  auto a = gt::gtensor<double, 2, a_space_type>{{12., 13.}, {22., 23.}};
+  auto b = gt::gtensor<double, 2, b_space_type>(gt::shape(3, 2), 0.);
+
+  // make a noncontiguous subset gtensor_span
+  auto s_b = gt::gtensor_span<double, 2, b_space_type>(
+    b.data() + 1, gt::shape(2, 2), b.strides());
+
+  gt::copy(a, s_b);
+  EXPECT_EQ(s_b,
+            (gt::gtensor<double, 2, b_space_type>{{12., 13.}, {22., 23.}}));
+  EXPECT_EQ(
+    b, (gt::gtensor<double, 2, b_space_type>{{0., 12., 13.}, {0., 22., 23.}}));
 }
 
 // ======================================================================

--- a/tests/test_gtensor.cxx
+++ b/tests/test_gtensor.cxx
@@ -954,6 +954,25 @@ TYPED_TEST(gtensor_copy, to_expr)
   EXPECT_EQ(b, a);
 }
 
+TYPED_TEST(gtensor_copy, expr_to_non_contiguous)
+{
+  using a_space_type = typename TypeParam::a_space_type;
+  using b_space_type = typename TypeParam::b_space_type;
+  auto a =
+    gt::gtensor<double, 2, a_space_type>{{11., 12., 13.}, {21., 22., 23.}};
+  auto b = gt::gtensor<double, 2, b_space_type>(a.shape(), 0.);
+
+  // use a view on the source side
+  auto v_a = a.view(gt::slice(1, 3), gt::slice(0, 2));
+  // make a noncontiguous subset gtensor_span for destination
+  auto s_b = gt::gtensor_span<double, 2, b_space_type>(
+    b.data() + 1, gt::shape(2, 2), b.strides());
+
+  gt::copy(v_a, s_b);
+  EXPECT_EQ(
+    b, (gt::gtensor<double, 2, b_space_type>{{0., 12., 13.}, {0., 22., 23.}}));
+}
+
 // ======================================================================
 
 template <typename S>

--- a/tests/test_gtensor_span.cxx
+++ b/tests/test_gtensor_span.cxx
@@ -14,6 +14,18 @@ TEST(gtensor_span, adapt_ctor_init_2d)
   EXPECT_EQ(b, (gt::gtensor<double, 2>({{11., 12.}, {13., 21.}, {22., 23.}})));
 }
 
+TEST(gtensor_span, adapt_ctor_init_2d_space_type)
+{
+  gt::gtensor<double, 2> a({{11., 12., 13.}, {21., 22., 23.}});
+  auto a_data = a.data();
+
+  auto b = gt::adapt<2, gt::space::host>(a_data, {2, 3});
+  static_assert(
+    std::is_same<gt::expr_space_type<decltype(b)>, gt::space::host>::value,
+    "space mismatch");
+  EXPECT_EQ(b, (gt::gtensor<double, 2>({{11., 12.}, {13., 21.}, {22., 23.}})));
+}
+
 // Note: the implicit conversion from gtensor won't work if this
 // is templates on the gtensor_span types.
 inline double first_element(const gt::gtensor_span<double, 2>& a)
@@ -141,3 +153,20 @@ TEST(gtensor_span, DISABLED_fill_from_strides_0)
   EXPECT_EQ(a_span, (gt::gtensor<double, 2>({{0., 0.}, {0., 0.}})));
   EXPECT_EQ(a, (gt::gtensor<double, 2>({{0., 0., 13.}, {0., 0., 23.}})));
 }
+
+#ifdef GTENSOR_HAVE_DEVICE
+
+TEST(gtensor_span, adapt_ctor_init_2d_space_type_device)
+{
+  gt::gtensor_device<double, 2> a({{11., 12., 13.}, {21., 22., 23.}});
+  auto a_data = a.data();
+
+  auto b = gt::adapt<2, gt::space::device>(a_data, {2, 3});
+  static_assert(
+    std::is_same<gt::expr_space_type<decltype(b)>, gt::space::device>::value,
+    "space mismatch");
+  EXPECT_EQ(
+    b, (gt::gtensor_device<double, 2>({{11., 12.}, {13., 21.}, {22., 23.}})));
+}
+
+#endif

--- a/tests/test_gtensor_span.cxx
+++ b/tests/test_gtensor_span.cxx
@@ -124,6 +124,19 @@ TEST(gtensor_span, index_by_shape)
   EXPECT_EQ(aspan[gt::shape(2, 1)], 32.);
 }
 
+TEST(gtensor_span, is_f_contiguous)
+{
+  gt::gtensor<double, 2> a({{11., 12., 13.}, {21., 22., 23.}});
+
+  auto b = gt::adapt<2>(a.data(), a.shape());
+  EXPECT_TRUE(b.is_f_contiguous());
+
+  auto c =
+    gt::gtensor_span<double, 2>(a.data() + 1, gt::shape(2, 2), a.strides());
+  EXPECT_EQ(c, (gt::gtensor<double, 2>{{12., 13.}, {22., 23.}}));
+  EXPECT_FALSE(c.is_f_contiguous());
+}
+
 TEST(gtensor_span, fill_full)
 {
   gt::gtensor<double, 2> a({{11., 12., 13.}, {21., 22., 23.}});


### PR DESCRIPTION
This at least attempts to handle all kinds of different cases how gt::copy may be used. It fixes at least one existing bug
(copies involving non-contiguous gtensor_spans), but now also handles having expressions (rather than just gtensor/gtensor_span) as source and/or destination.

There might still be some cases that I missed, hopefully the kind that will lead to compile time errors, but the cases I handle are all covered by tests, so should be okay.