### PR TITLE
format: single line all functions, dual version ci

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,8 +11,9 @@ AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: true
-AllowShortFunctionsOnASingleLine: Inline
+AllowShortFunctionsOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: false
+AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -13,11 +13,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.5
+    - uses: DoozyX/clang-format-lint-action@v0.14
       with:
         source: '.'
         extensions: 'h,cxx'
         clangFormatVersion: 9
+    - uses: DoozyX/clang-format-lint-action@v0.14
+      with:
+        source: '.'
+        extensions: 'h,cxx'
+        clangFormatVersion: 14
 
   tests-cpu:
     runs-on: ubuntu-18.04

--- a/include/gtensor/device_backend.h
+++ b/include/gtensor/device_backend.h
@@ -83,10 +83,7 @@ inline void copy_n(InputPtr in, gt::size_type count, OutputPtr out)
 // ======================================================================
 // synchronize
 
-void inline synchronize()
-{
-  gt::backend::clib::device_synchronize();
-}
+void inline synchronize() { gt::backend::clib::device_synchronize(); }
 
 } // namespace gt
 

--- a/include/gtensor/macros.h
+++ b/include/gtensor/macros.h
@@ -78,10 +78,7 @@ inline void doCudaCheck(cudaError_t code, const char* file, int line)
   }
 }
 
-inline auto gpuGetLastError()
-{
-  return cudaGetLastError();
-}
+inline auto gpuGetLastError() { return cudaGetLastError(); }
 
 #elif defined(GTENSOR_DEVICE_HIP)
 
@@ -116,10 +113,7 @@ inline void doHipCheck(hipError_t code, const char* file, int line)
   }
 }
 
-inline auto gpuGetLastError()
-{
-  return hipGetLastError();
-}
+inline auto gpuGetLastError() { return hipGetLastError(); }
 
 #elif defined(GTENSOR_DEVICE_SYCL)
 

--- a/src/cgtblas.cxx
+++ b/src/cgtblas.cxx
@@ -134,10 +134,7 @@ void gtblas_destroy()
   }
 }
 
-void gtblas_set_stream(gt::stream_view stream)
-{
-  g_handle->set_stream(stream);
-}
+void gtblas_set_stream(gt::stream_view stream) { g_handle->set_stream(stream); }
 
 void gtblas_get_stream(gt::stream_view* stream_id)
 {

--- a/src/cgtensor.cxx
+++ b/src/cgtensor.cxx
@@ -3,10 +3,7 @@
 #include <gtensor/capi.h>
 #include <gtensor/gtensor.h>
 
-void gt_synchronize()
-{
-  gt::synchronize();
-}
+void gt_synchronize() { gt::synchronize(); }
 
 int gt_backend_device_get_count()
 {
@@ -18,10 +15,7 @@ void gt_backend_device_set(int device_id)
   return gt::backend::clib::device_set(device_id);
 }
 
-int gt_backend_device_get()
-{
-  return gt::backend::clib::device_get();
-}
+int gt_backend_device_get() { return gt::backend::clib::device_get(); }
 
 uint32_t gt_backend_device_get_vendor_id(int device_id)
 {

--- a/tests/test_bandsolver.cxx
+++ b/tests/test_bandsolver.cxx
@@ -208,15 +208,9 @@ void test_getrs_batch_real()
   EXPECT_EQ(h_B(2, 1, 0), 31.0);
 }
 
-TEST(bandsolve, sgetrs_batch)
-{
-  test_getrs_batch_real<float>();
-}
+TEST(bandsolve, sgetrs_batch) { test_getrs_batch_real<float>(); }
 
-TEST(bandsolve, dgetrs_batch)
-{
-  test_getrs_batch_real<double>();
-}
+TEST(bandsolve, dgetrs_batch) { test_getrs_batch_real<double>(); }
 
 namespace test
 {
@@ -323,15 +317,9 @@ void test_getrs_batch_complex()
   expect_complex_near(h_B(2, 1, 1), 31.0);
 }
 
-TEST(bandsolve, cgetrs_batch)
-{
-  test_getrs_batch_complex<float>();
-}
+TEST(bandsolve, cgetrs_batch) { test_getrs_batch_complex<float>(); }
 
-TEST(bandsolve, zgetrs_batch)
-{
-  test_getrs_batch_complex<double>();
-}
+TEST(bandsolve, zgetrs_batch) { test_getrs_batch_complex<double>(); }
 
 TEST(bandsolve, cgetrs_batch_managed)
 {
@@ -386,15 +374,9 @@ void test_get_max_bandwidth()
   EXPECT_EQ(bw.upper, 1);
 }
 
-TEST(bandsolve, sget_max_bandwidth)
-{
-  test_get_max_bandwidth<double>();
-}
+TEST(bandsolve, sget_max_bandwidth) { test_get_max_bandwidth<double>(); }
 
-TEST(bandsolve, dget_max_bandwidth)
-{
-  test_get_max_bandwidth<double>();
-}
+TEST(bandsolve, dget_max_bandwidth) { test_get_max_bandwidth<double>(); }
 
 TEST(bandsolve, cget_max_bandwidth)
 {
@@ -499,15 +481,9 @@ void test_invert_batch_complex()
   GT_EXPECT_NEAR_ARRAY(h_Ainv.view(gt::all, gt::all, 1), h_Ainv_expected);
 }
 
-TEST(bandsolve, cinvert_batch)
-{
-  test_invert_batch_complex<float>();
-}
+TEST(bandsolve, cinvert_batch) { test_invert_batch_complex<float>(); }
 
-TEST(bandsolve, zinvert_batch)
-{
-  test_invert_batch_complex<double>();
-}
+TEST(bandsolve, zinvert_batch) { test_invert_batch_complex<double>(); }
 
 template <typename R, typename S = gt::space::device>
 void test_solve_inverted_batch_complex()
@@ -804,15 +780,9 @@ void test_full_solve_real(gt::stream_view stream = gt::stream_view{})
   GT_EXPECT_NEAR_ARRAY(h_C.view(gt::all, 1, 0), h_C_expected);
 }
 
-TEST(bandsolve, sfull_invert_solve)
-{
-  test_full_solve_real<float>();
-}
+TEST(bandsolve, sfull_invert_solve) { test_full_solve_real<float>(); }
 
-TEST(bandsolve, dfull_invert_solve)
-{
-  test_full_solve_real<double>();
-}
+TEST(bandsolve, dfull_invert_solve) { test_full_solve_real<double>(); }
 
 TEST(bandsolve, cfull_invert_solve)
 {

--- a/tests/test_blas.cxx
+++ b/tests/test_blas.cxx
@@ -37,15 +37,9 @@ void test_axpy_real()
   }
 }
 
-TEST(blas, saxpy)
-{
-  test_axpy_real<float>();
-}
+TEST(blas, saxpy) { test_axpy_real<float>(); }
 
-TEST(blas, daxpy)
-{
-  test_axpy_real<double>();
-}
+TEST(blas, daxpy) { test_axpy_real<double>(); }
 
 template <typename R>
 void test_axpy_complex()
@@ -78,15 +72,9 @@ void test_axpy_complex()
   }
 }
 
-TEST(blas, caxpy)
-{
-  test_axpy_complex<float>();
-}
+TEST(blas, caxpy) { test_axpy_complex<float>(); }
 
-TEST(blas, zaxpy)
-{
-  test_axpy_complex<double>();
-}
+TEST(blas, zaxpy) { test_axpy_complex<double>(); }
 
 template <typename R>
 void test_scal_complex()
@@ -122,15 +110,9 @@ void test_scal_complex()
   }
 }
 
-TEST(blas, cscal)
-{
-  test_scal_complex<float>();
-}
+TEST(blas, cscal) { test_scal_complex<float>(); }
 
-TEST(blas, zscal)
-{
-  test_scal_complex<double>();
-}
+TEST(blas, zscal) { test_scal_complex<double>(); }
 
 template <typename T>
 void test_scal_real()
@@ -158,15 +140,9 @@ void test_scal_real()
   }
 }
 
-TEST(blas, sscal)
-{
-  test_scal_real<float>();
-}
+TEST(blas, sscal) { test_scal_real<float>(); }
 
-TEST(blas, dscal)
-{
-  test_scal_real<double>();
-}
+TEST(blas, dscal) { test_scal_real<double>(); }
 
 template <typename R>
 void test_copy_complex()
@@ -197,15 +173,9 @@ void test_copy_complex()
   }
 }
 
-TEST(blas, ccopy)
-{
-  test_copy_complex<float>();
-}
+TEST(blas, ccopy) { test_copy_complex<float>(); }
 
-TEST(blas, zcopy)
-{
-  test_copy_complex<double>();
-}
+TEST(blas, zcopy) { test_copy_complex<double>(); }
 
 template <typename T>
 void test_dot_real()
@@ -232,15 +202,9 @@ void test_dot_real()
   EXPECT_EQ(result, (N - 1) * N);
 }
 
-TEST(blas, sdot)
-{
-  test_dot_real<float>();
-}
+TEST(blas, sdot) { test_dot_real<float>(); }
 
-TEST(blas, ddot)
-{
-  test_dot_real<double>();
-}
+TEST(blas, ddot) { test_dot_real<double>(); }
 
 template <typename R>
 void test_dot_complex()
@@ -272,15 +236,9 @@ void test_dot_complex()
   EXPECT_EQ(resultc, T(sum, sum));
 }
 
-TEST(blas, cdot)
-{
-  test_dot_complex<float>();
-}
+TEST(blas, cdot) { test_dot_complex<float>(); }
 
-TEST(blas, zdot)
-{
-  test_dot_complex<double>();
-}
+TEST(blas, zdot) { test_dot_complex<double>(); }
 
 template <typename T>
 void test_gemv_real()
@@ -350,15 +308,9 @@ void test_gemv_real()
   }
 }
 
-TEST(blas, sgemv)
-{
-  test_gemv_real<float>();
-}
+TEST(blas, sgemv) { test_gemv_real<float>(); }
 
-TEST(blas, dgemv)
-{
-  test_gemv_real<double>();
-}
+TEST(blas, dgemv) { test_gemv_real<double>(); }
 
 template <typename R>
 void test_gemv_complex()
@@ -403,15 +355,9 @@ void test_gemv_complex()
   }
 }
 
-TEST(blas, cgemv)
-{
-  test_gemv_complex<float>();
-}
+TEST(blas, cgemv) { test_gemv_complex<float>(); }
 
-TEST(blas, zgemv)
-{
-  test_gemv_complex<double>();
-}
+TEST(blas, zgemv) { test_gemv_complex<double>(); }
 
 template <typename R>
 void test_gemm_batched_real()
@@ -473,15 +419,9 @@ void test_gemm_batched_real()
   }
 }
 
-TEST(blas, sgemm_batched)
-{
-  test_gemm_batched_real<float>();
-}
+TEST(blas, sgemm_batched) { test_gemm_batched_real<float>(); }
 
-TEST(blas, dgemm_batched)
-{
-  test_gemm_batched_real<double>();
-}
+TEST(blas, dgemm_batched) { test_gemm_batched_real<double>(); }
 
 template <typename R>
 void test_gemm_batched_complex()
@@ -560,15 +500,9 @@ void test_gemm_batched_complex()
   }
 }
 
-TEST(blas, cgemm_batched)
-{
-  test_gemm_batched_complex<float>();
-}
+TEST(blas, cgemm_batched) { test_gemm_batched_complex<float>(); }
 
-TEST(blas, zgemm_batched)
-{
-  test_gemm_batched_complex<double>();
-}
+TEST(blas, zgemm_batched) { test_gemm_batched_complex<double>(); }
 
 template <typename R>
 void test_gemm_batched_b0_complex()
@@ -647,12 +581,6 @@ void test_gemm_batched_b0_complex()
   }
 }
 
-TEST(blas, cgemm_batched_b0)
-{
-  test_gemm_batched_b0_complex<float>();
-}
+TEST(blas, cgemm_batched_b0) { test_gemm_batched_b0_complex<float>(); }
 
-TEST(blas, zgemm_batched_b0)
-{
-  test_gemm_batched_b0_complex<double>();
-}
+TEST(blas, zgemm_batched_b0) { test_gemm_batched_b0_complex<double>(); }

--- a/tests/test_cblas.cxx
+++ b/tests/test_cblas.cxx
@@ -36,15 +36,9 @@ void test_real_axpy(F&& f)
   }
 }
 
-TEST(cblas, saxpy)
-{
-  test_real_axpy<float>(&gtblas_saxpy);
-}
+TEST(cblas, saxpy) { test_real_axpy<float>(&gtblas_saxpy); }
 
-TEST(cblas, daxpy)
-{
-  test_real_axpy<double>(&gtblas_daxpy);
-}
+TEST(cblas, daxpy) { test_real_axpy<double>(&gtblas_daxpy); }
 
 template <typename R, typename F>
 void test_complex_axpy(F&& f)
@@ -79,15 +73,9 @@ void test_complex_axpy(F&& f)
   }
 }
 
-TEST(cblas, caxpy)
-{
-  test_complex_axpy<float>(&gtblas_caxpy);
-}
+TEST(cblas, caxpy) { test_complex_axpy<float>(&gtblas_caxpy); }
 
-TEST(cblas, zaxpy)
-{
-  test_complex_axpy<double>(&gtblas_zaxpy);
-}
+TEST(cblas, zaxpy) { test_complex_axpy<double>(&gtblas_zaxpy); }
 
 template <typename T, typename F>
 void test_real_scal(F&& f)
@@ -116,15 +104,9 @@ void test_real_scal(F&& f)
   }
 }
 
-TEST(cblas, sscal)
-{
-  test_real_scal<float>(&gtblas_sscal);
-}
+TEST(cblas, sscal) { test_real_scal<float>(&gtblas_sscal); }
 
-TEST(cblas, dscal)
-{
-  test_real_scal<double>(&gtblas_dscal);
-}
+TEST(cblas, dscal) { test_real_scal<double>(&gtblas_dscal); }
 
 template <typename R, typename F, typename F2>
 void test_complex_scal(F&& f, F2&& f2)
@@ -161,15 +143,9 @@ void test_complex_scal(F&& f, F2&& f2)
   }
 }
 
-TEST(cblas, cscal)
-{
-  test_complex_scal<float>(&gtblas_cscal, &gtblas_csscal);
-}
+TEST(cblas, cscal) { test_complex_scal<float>(&gtblas_cscal, &gtblas_csscal); }
 
-TEST(cblas, zscal)
-{
-  test_complex_scal<double>(&gtblas_zscal, &gtblas_zdscal);
-}
+TEST(cblas, zscal) { test_complex_scal<double>(&gtblas_zscal, &gtblas_zdscal); }
 
 template <typename T, typename F>
 void test_gemv_real(F&& f)
@@ -240,15 +216,9 @@ void test_gemv_real(F&& f)
   }
 }
 
-TEST(cblas, sgemv)
-{
-  test_gemv_real<float>(&gtblas_sgemv);
-}
+TEST(cblas, sgemv) { test_gemv_real<float>(&gtblas_sgemv); }
 
-TEST(cblas, dgemv)
-{
-  test_gemv_real<double>(&gtblas_dgemv);
-}
+TEST(cblas, dgemv) { test_gemv_real<double>(&gtblas_dgemv); }
 
 template <typename R, typename F>
 void test_gemv_complex(F&& f)
@@ -294,12 +264,6 @@ void test_gemv_complex(F&& f)
   }
 }
 
-TEST(cblas, cgemv)
-{
-  test_gemv_complex<float>(&gtblas_cgemv);
-}
+TEST(cblas, cgemv) { test_gemv_complex<float>(&gtblas_cgemv); }
 
-TEST(cblas, zgemv)
-{
-  test_gemv_complex<double>(&gtblas_zgemv);
-}
+TEST(cblas, zgemv) { test_gemv_complex<double>(&gtblas_zgemv); }

--- a/tests/test_fft.cxx
+++ b/tests/test_fft.cxx
@@ -95,15 +95,9 @@ void fft_r2c_1d()
   GT_EXPECT_NEAR(h_B(2, 1), T(38, 0));
 }
 
-TEST(fft, d2z_1d)
-{
-  fft_r2c_1d<double>();
-}
+TEST(fft, d2z_1d) { fft_r2c_1d<double>(); }
 
-TEST(fft, r2c_1d)
-{
-  fft_r2c_1d<float>();
-}
+TEST(fft, r2c_1d) { fft_r2c_1d<float>(); }
 
 template <typename E>
 void fft_r2c_1d_strided()
@@ -169,15 +163,9 @@ void fft_r2c_1d_strided()
   GT_EXPECT_EQ(h_A, h_A2 / N);
 }
 
-TEST(fft, d2z_1d_strided)
-{
-  fft_r2c_1d_strided<double>();
-}
+TEST(fft, d2z_1d_strided) { fft_r2c_1d_strided<double>(); }
 
-TEST(fft, r2c_1d_strided)
-{
-  fft_r2c_1d_strided<float>();
-}
+TEST(fft, r2c_1d_strided) { fft_r2c_1d_strided<float>(); }
 
 template <typename E>
 void fft_c2r_1d()
@@ -222,15 +210,9 @@ void fft_c2r_1d()
   EXPECT_EQ(h_A(3, 1) / N, 1);
 }
 
-TEST(fft, z2d_1d)
-{
-  fft_c2r_1d<double>();
-}
+TEST(fft, z2d_1d) { fft_c2r_1d<double>(); }
 
-TEST(fft, c2r_1d)
-{
-  fft_c2r_1d<float>();
-}
+TEST(fft, c2r_1d) { fft_c2r_1d<float>(); }
 
 template <typename E>
 void fft_c2c_1d_forward()
@@ -292,15 +274,9 @@ void fft_c2c_1d_forward()
   }
 }
 
-TEST(fft, z2z_1d_forward)
-{
-  fft_c2c_1d_forward<double>();
-}
+TEST(fft, z2z_1d_forward) { fft_c2c_1d_forward<double>(); }
 
-TEST(fft, c2c_1d_forward)
-{
-  fft_c2c_1d_forward<float>();
-}
+TEST(fft, c2c_1d_forward) { fft_c2c_1d_forward<float>(); }
 
 template <typename E>
 void fft_c2c_1d_forward_strided()
@@ -365,15 +341,9 @@ void fft_c2c_1d_forward_strided()
   GT_EXPECT_NEAR(h_A, h_A2 / T(N, 0));
 }
 
-TEST(fft, z2z_1d_forward_strided)
-{
-  fft_c2c_1d_forward_strided<double>();
-}
+TEST(fft, z2z_1d_forward_strided) { fft_c2c_1d_forward_strided<double>(); }
 
-TEST(fft, c2c_1d_forward_strided)
-{
-  fft_c2c_1d_forward_strided<float>();
-}
+TEST(fft, c2c_1d_forward_strided) { fft_c2c_1d_forward_strided<float>(); }
 
 template <typename E>
 void fft_c2c_1d_inverse()
@@ -422,15 +392,9 @@ void fft_c2c_1d_inverse()
   GT_EXPECT_NEAR(h_B(3, 1), dN * T(1, 0));
 }
 
-TEST(fft, z2z_1d_inverse)
-{
-  fft_c2c_1d_inverse<double>();
-}
+TEST(fft, z2z_1d_inverse) { fft_c2c_1d_inverse<double>(); }
 
-TEST(fft, c2c_1d_inverse)
-{
-  fft_c2c_1d_inverse<float>();
-}
+TEST(fft, c2c_1d_inverse) { fft_c2c_1d_inverse<float>(); }
 
 TEST(fft, move_only)
 {
@@ -539,15 +503,9 @@ void fft_r2c_2d()
   GT_EXPECT_NEAR(h_A, h_A2 / (Nx * Ny));
 }
 
-TEST(fft, r2c_2d)
-{
-  fft_r2c_2d<float>();
-}
+TEST(fft, r2c_2d) { fft_r2c_2d<float>(); }
 
-TEST(fft, d2z_2d)
-{
-  fft_r2c_2d<double>();
-}
+TEST(fft, d2z_2d) { fft_r2c_2d<double>(); }
 
 template <typename E>
 void fft_c2c_2d()
@@ -592,15 +550,9 @@ void fft_c2c_2d()
   }
 }
 
-TEST(fft, c2c_2d)
-{
-  fft_c2c_2d<float>();
-}
+TEST(fft, c2c_2d) { fft_c2c_2d<float>(); }
 
-TEST(fft, z2z_2d)
-{
-  fft_c2c_2d<double>();
-}
+TEST(fft, z2z_2d) { fft_c2c_2d<double>(); }
 
 template <typename E>
 void fft_r2c_3d()
@@ -638,12 +590,6 @@ void fft_r2c_3d()
   GT_EXPECT_NEAR(h_A, h_A2 / (Nx * Ny * Nz));
 }
 
-TEST(fft, r2c_3d)
-{
-  fft_r2c_3d<float>();
-}
+TEST(fft, r2c_3d) { fft_r2c_3d<float>(); }
 
-TEST(fft, d2z_3d)
-{
-  fft_r2c_3d<double>();
-}
+TEST(fft, d2z_3d) { fft_r2c_3d<double>(); }

--- a/tests/test_lapack.cxx
+++ b/tests/test_lapack.cxx
@@ -204,15 +204,9 @@ void test_getrf_batch_real()
   }
 }
 
-TEST(lapack, sgetrf_batch)
-{
-  test_getrf_batch_real<float>();
-}
+TEST(lapack, sgetrf_batch) { test_getrf_batch_real<float>(); }
 
-TEST(lapack, dgetrf_batch)
-{
-  test_getrf_batch_real<double>();
-}
+TEST(lapack, dgetrf_batch) { test_getrf_batch_real<double>(); }
 
 template <typename T>
 void test_getrs_batch_real()
@@ -274,15 +268,9 @@ void test_getrs_batch_real()
   EXPECT_EQ(h_B(2, 1, 0), 31.0);
 }
 
-TEST(lapack, sgetrs_batch)
-{
-  test_getrs_batch_real<float>();
-}
+TEST(lapack, sgetrs_batch) { test_getrs_batch_real<float>(); }
 
-TEST(lapack, dgetrs_batch)
-{
-  test_getrs_batch_real<double>();
-}
+TEST(lapack, dgetrs_batch) { test_getrs_batch_real<double>(); }
 
 template <typename R>
 void test_getrf_batch_complex()
@@ -371,15 +359,9 @@ void test_getrf_batch_complex()
   }
 }
 
-TEST(lapack, cgetrf_batch)
-{
-  test_getrf_batch_complex<float>();
-}
+TEST(lapack, cgetrf_batch) { test_getrf_batch_complex<float>(); }
 
-TEST(lapack, zgetrf_batch)
-{
-  test_getrf_batch_complex<double>();
-}
+TEST(lapack, zgetrf_batch) { test_getrf_batch_complex<double>(); }
 
 #ifdef GTENSOR_HAVE_DEVICE
 template <typename R>
@@ -451,15 +433,9 @@ void test_getrf_npvt_batch_complex()
   }
 }
 
-TEST(lapack, cgetrf_npvt_batch)
-{
-  test_getrf_npvt_batch_complex<float>();
-}
+TEST(lapack, cgetrf_npvt_batch) { test_getrf_npvt_batch_complex<float>(); }
 
-TEST(lapack, zgetrf_npvt_batch)
-{
-  test_getrf_npvt_batch_complex<double>();
-}
+TEST(lapack, zgetrf_npvt_batch) { test_getrf_npvt_batch_complex<double>(); }
 #endif
 
 namespace test
@@ -566,15 +542,9 @@ void test_getrs_batch_complex()
   expect_complex_near(h_B(2, 1, 1), 31.0);
 }
 
-TEST(lapack, cgetrs_batch)
-{
-  test_getrs_batch_complex<float>();
-}
+TEST(lapack, cgetrs_batch) { test_getrs_batch_complex<float>(); }
 
-TEST(lapack, zgetrs_batch)
-{
-  test_getrs_batch_complex<double>();
-}
+TEST(lapack, zgetrs_batch) { test_getrs_batch_complex<double>(); }
 
 TEST(lapack, cgetrs_batch_managed)
 {
@@ -663,15 +633,9 @@ void test_getri_batch_complex()
   expect_complex_near(h_C(2, 2, 1), T(0.036, 0.052));
 }
 
-TEST(lapack, cgetri_batch)
-{
-  test_getri_batch_complex<float>();
-}
+TEST(lapack, cgetri_batch) { test_getri_batch_complex<float>(); }
 
-TEST(lapack, zgetri_batch)
-{
-  test_getri_batch_complex<double>();
-}
+TEST(lapack, zgetri_batch) { test_getri_batch_complex<double>(); }
 
 TEST(lapack, cgetri_batch_managed)
 {

--- a/tests/test_reductions.cxx
+++ b/tests/test_reductions.cxx
@@ -187,20 +187,11 @@ void test_min(int n)
   EXPECT_EQ(amin, 1);
 }
 
-TEST(reductions, sum_1d)
-{
-  test_sum<gt::space::host>(2048);
-}
+TEST(reductions, sum_1d) { test_sum<gt::space::host>(2048); }
 
-TEST(reductions, max_1d)
-{
-  test_max<gt::space::host>(2048);
-}
+TEST(reductions, max_1d) { test_max<gt::space::host>(2048); }
 
-TEST(reductions, min_1d)
-{
-  test_min<gt::space::host>(2048);
-}
+TEST(reductions, min_1d) { test_min<gt::space::host>(2048); }
 
 TEST(reductions, norm)
 {
@@ -216,20 +207,11 @@ TEST(reductions, norm_expr)
 
 #ifdef GTENSOR_HAVE_DEVICE
 
-TEST(reductions, device_sum_1d)
-{
-  test_sum<gt::space::device>(2048);
-}
+TEST(reductions, device_sum_1d) { test_sum<gt::space::device>(2048); }
 
-TEST(reductions, device_max_1d)
-{
-  test_max<gt::space::device>(2048);
-}
+TEST(reductions, device_max_1d) { test_max<gt::space::device>(2048); }
 
-TEST(reductions, device_min_1d)
-{
-  test_min<gt::space::device>(2048);
-}
+TEST(reductions, device_min_1d) { test_min<gt::space::device>(2048); }
 
 #endif // GTENSOR_HAVE_DEVICE
 

--- a/tests/test_sarray.cxx
+++ b/tests/test_sarray.cxx
@@ -126,20 +126,11 @@ TEST(sarray, remove)
   EXPECT_EQ(a3[2], 3);
 }
 
-TEST(sarray, host_launch_insert)
-{
-  test_launch_insert<gt::space::host>();
-}
+TEST(sarray, host_launch_insert) { test_launch_insert<gt::space::host>(); }
 
-TEST(sarray, host_launch_remove)
-{
-  test_launch_remove<gt::space::host>();
-}
+TEST(sarray, host_launch_remove) { test_launch_remove<gt::space::host>(); }
 
-TEST(sarray, host_launch_assign)
-{
-  test_launch_assign<gt::space::host>();
-}
+TEST(sarray, host_launch_assign) { test_launch_assign<gt::space::host>(); }
 
 TEST(sarray, zero_dim)
 {
@@ -156,19 +147,10 @@ TEST(sarray, zero_dim)
 
 #ifdef GTENSOR_HAVE_DEVICE
 
-TEST(sarray, device_launch_insert)
-{
-  test_launch_insert<gt::space::device>();
-}
+TEST(sarray, device_launch_insert) { test_launch_insert<gt::space::device>(); }
 
-TEST(sarray, device_launch_remove)
-{
-  test_launch_remove<gt::space::device>();
-}
+TEST(sarray, device_launch_remove) { test_launch_remove<gt::space::device>(); }
 
-TEST(sarray, device_launch_assign)
-{
-  test_launch_assign<gt::space::device>();
-}
+TEST(sarray, device_launch_assign) { test_launch_assign<gt::space::device>(); }
 
 #endif

--- a/tests/test_sparse.cxx
+++ b/tests/test_sparse.cxx
@@ -152,10 +152,7 @@ void test_csr_matrix()
   EXPECT_EQ(h_err(0), 0);
 }
 
-TEST(sparse, csr_matrix_host_s)
-{
-  test_csr_matrix<float, gt::space::host>();
-}
+TEST(sparse, csr_matrix_host_s) { test_csr_matrix<float, gt::space::host>(); }
 
 TEST(sparse, csr_matrix_host_c)
 {


### PR DESCRIPTION
Starting in v14, short GT_LAMBDA is broken into multiple lines, which creates an inconsistency depending on version used. This change makes it consistent and adds ci checks for both 9 and 14.