### PR TITLE
gt-fft: add get_work_buffer_bytes plan method

### DIFF
--- a/benchmarks/bench_fft.cxx
+++ b/benchmarks/bench_fft.cxx
@@ -48,6 +48,8 @@ static void BM_fft_r2c_1d(benchmark::State& state)
   gt::copy(h_A, d_A);
 
   gt::fft::FFTPlanMany<gt::fft::Domain::REAL, E> plan({Nx}, batch_size);
+  std::size_t work_bytes = plan.get_work_buffer_bytes();
+  std::cout << "plan work bytes: " << work_bytes << std::endl;
 
   auto fn = [&]() {
     plan(d_A, d_B);
@@ -86,6 +88,80 @@ BENCHMARK(BM_fft_r2c_1d<double, 32, 500, gt::space::managed>)
 BENCHMARK(BM_fft_r2c_1d<float, 64, 500, gt::space::managed>)
   ->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_fft_r2c_1d<double, 64, 500, gt::space::managed>)
+  ->Unit(benchmark::kMillisecond);
+
+template <typename E, int Nx, int batch_k, typename S = gt::space::device>
+static void BM_fft_c2r_1d(benchmark::State& state)
+{
+  int batch_size = 1024 * batch_k;
+  using T = gt::complex<E>;
+
+  auto h_A = gt::zeros<E>({Nx, batch_size});
+  gt::bm::gtensor2<E, 2, S> d_A(h_A.shape());
+
+  auto h_A2 = gt::zeros<E>(h_A.shape());
+  gt::bm::gtensor2<E, 2, S> d_A2(h_A.shape());
+
+  auto h_B = gt::empty<T>({Nx / 2 + 1, batch_size});
+  auto h_B_expected = gt::empty<T>(h_B.shape());
+  gt::bm::gtensor2<T, 2, S> d_B(h_B.shape());
+
+  // Set up periodic domain with frequency 4
+  // m = [sin(2*pi*x) for x in -2:1/16:2-1/16]
+  double x, fx;
+  for (int i = 0; i < Nx; i++) {
+    x = -2.0 + i / 16.0;
+    fx = sin(2 * PI * x);
+    for (int j = 0; j < batch_size; j++) {
+      h_A(i, j) = fx;
+    }
+  }
+
+  gt::copy(h_A, d_A);
+
+  gt::fft::FFTPlanMany<gt::fft::Domain::REAL, E> plan({Nx}, batch_size);
+  std::size_t work_bytes = plan.get_work_buffer_bytes();
+  std::cout << "plan work bytes: " << work_bytes << std::endl;
+
+  plan(d_A, d_B);
+
+  auto fn = [&]() {
+    plan.inverse(d_B, d_A);
+    gt::synchronize();
+  };
+
+  // warm up, device compile
+  fn();
+
+  for (auto _ : state) {
+    fn();
+  }
+}
+
+BENCHMARK(BM_fft_c2r_1d<float, 32, 200>)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_fft_c2r_1d<double, 32, 200>)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_fft_c2r_1d<float, 64, 200>)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_fft_c2r_1d<double, 64, 200>)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_fft_c2r_1d<float, 32, 500>)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_fft_c2r_1d<double, 32, 500>)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_fft_c2r_1d<float, 64, 500>)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_fft_c2r_1d<double, 64, 500>)->Unit(benchmark::kMillisecond);
+
+BENCHMARK(BM_fft_c2r_1d<float, 32, 200, gt::space::managed>)
+  ->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_fft_c2r_1d<double, 32, 200, gt::space::managed>)
+  ->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_fft_c2r_1d<float, 64, 200, gt::space::managed>)
+  ->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_fft_c2r_1d<double, 64, 200, gt::space::managed>)
+  ->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_fft_c2r_1d<float, 32, 500, gt::space::managed>)
+  ->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_fft_c2r_1d<double, 32, 500, gt::space::managed>)
+  ->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_fft_c2r_1d<float, 64, 500, gt::space::managed>)
+  ->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_fft_c2r_1d<double, 64, 500, gt::space::managed>)
   ->Unit(benchmark::kMillisecond);
 
 BENCHMARK_MAIN();

--- a/include/gt-fft/backend/hip.h
+++ b/include/gt-fft/backend/hip.h
@@ -137,7 +137,7 @@ public:
     info_forward_ = other.info_forward_;
     info_inverse_ = other.info_inverse_;
     work_buffer_ = other.work_buffer_;
-    work_buffer_size_ = other.work_buffer_size_;
+    work_buffer_bytes_ = other.work_buffer_bytes_;
     is_valid_ = true;
     other.is_valid_ = false;
   }
@@ -149,7 +149,7 @@ public:
     info_forward_ = other.info_forward_;
     info_inverse_ = other.info_inverse_;
     work_buffer_ = other.work_buffer_;
-    work_buffer_size_ = other.work_buffer_size_;
+    work_buffer_bytes_ = other.work_buffer_bytes_;
     is_valid_ = true;
     other.is_valid_ = false;
     return *this;
@@ -189,6 +189,8 @@ public:
     void* out[1] = {(void*)outdata};
     gtFFTCheck(rocfft_execute(plan_inverse_, in, out, info_inverse_));
   }
+
+  std::size_t get_work_buffer_bytes() { return work_buffer_bytes_; }
 
 private:
   void init(std::vector<int> lengths_int, int istride, int idist, int ostride,
@@ -270,11 +272,11 @@ private:
     gtFFTCheck(
       rocfft_plan_get_work_buffer_size(plan_inverse_, &work_size_inverse));
 
-    work_buffer_size_ = std::max(work_size_forward, work_size_inverse);
+    work_buffer_bytes_ = std::max(work_size_forward, work_size_inverse);
 
-    if (work_buffer_size_ > 0) {
+    if (work_buffer_bytes_ > 0) {
       // use same work buffer for forward and inverse plans
-      hipError_t malloc_result = hipMalloc(&work_buffer_, work_buffer_size_);
+      hipError_t malloc_result = hipMalloc(&work_buffer_, work_buffer_bytes_);
       if (malloc_result != hipSuccess) {
         fprintf(stderr, "gpuCheck: %d (%s) %s %d\n", malloc_result,
                 hipGetErrorString(malloc_result), __FILE__, __LINE__);
@@ -300,7 +302,7 @@ private:
   rocfft_execution_info info_forward_;
   rocfft_execution_info info_inverse_;
   void* work_buffer_;
-  size_t work_buffer_size_;
+  size_t work_buffer_bytes_;
 
   bool is_valid_;
 };

--- a/tests/test_fft.cxx
+++ b/tests/test_fft.cxx
@@ -51,6 +51,8 @@ void fft_r2c_1d()
   // but with fftw convention for real transforms, the last term is
   // conjugate of second and set to 0 to save storage / computation
   gt::fft::FFTPlanMany<gt::fft::Domain::REAL, E> plan({N}, batch_size);
+  std::cout << "plan work bytes: " << plan.get_work_buffer_bytes() << std::endl;
+
   // plan.exec_forward(gt::raw_pointer_cast(d_A.data()),
   //                  gt::raw_pointer_cast(d_B.data()));
   plan(d_A, d_B);
@@ -150,6 +152,8 @@ void fft_r2c_1d_strided()
   // conjugate of second and set to 0 to save storage / computation
   gt::fft::FFTPlanMany<gt::fft::Domain::REAL, E> plan(
     {N}, rstride, rdist, cstride, cdist, batch_size);
+  std::cout << "plan work bytes: " << plan.get_work_buffer_bytes() << std::endl;
+
   // plan.exec_forward(gt::raw_pointer_cast(d_A.data()),
   //                  gt::raw_pointer_cast(d_B.data()));
   plan(d_A, d_B);
@@ -216,6 +220,8 @@ void fft_r2c_1d_strided_dist()
   // conjugate of second and set to 0 to save storage / computation
   gt::fft::FFTPlanMany<gt::fft::Domain::REAL, E> plan(
     {N}, rstride, rdist, cstride, cdist, batch_size);
+  std::cout << "plan work bytes: " << plan.get_work_buffer_bytes() << std::endl;
+
   // plan.exec_forward(gt::raw_pointer_cast(d_A.data()),
   //                  gt::raw_pointer_cast(d_B.data()));
   plan(d_A, d_B);
@@ -259,6 +265,8 @@ void fft_c2r_1d()
 
   // ifft(x) -> [8+0i 3+1i -6+0i 3-1i]
   gt::fft::FFTPlanMany<gt::fft::Domain::REAL, E> plan({N}, batch_size);
+  std::cout << "plan work bytes: " << plan.get_work_buffer_bytes() << std::endl;
+
   // plan.exec_inverse(gt::raw_pointer_cast(d_B.data()),
   //                  gt::raw_pointer_cast(d_A.data()));
   plan.inverse(d_B, d_A);
@@ -311,6 +319,7 @@ void fft_c2c_1d_forward()
   gt::copy(h_A, d_A);
 
   gt::fft::FFTPlanMany<gt::fft::Domain::COMPLEX, E> plan({N}, batch_size);
+  std::cout << "plan work bytes: " << plan.get_work_buffer_bytes() << std::endl;
 
   // ifft(x) -> [8+0i 3+1i -6+0i 3-1i]
   // plan.exec_forward(gt::raw_pointer_cast(d_A.data()),
@@ -391,6 +400,7 @@ void fft_c2c_1d_forward_strided()
 
   gt::fft::FFTPlanMany<gt::fft::Domain::COMPLEX, E> plan(
     {N}, istride, idist, ostride, odist, batch_size);
+  std::cout << "plan work bytes: " << plan.get_work_buffer_bytes() << std::endl;
 
   // ifft(x) -> [8+0i 3+1i -6+0i 3-1i]
   // plan.exec_forward(gt::raw_pointer_cast(d_A.data()),
@@ -458,6 +468,7 @@ void fft_c2c_1d_forward_strided_dist()
 
   gt::fft::FFTPlanMany<gt::fft::Domain::COMPLEX, E> plan(
     {N}, istride, idist, ostride, odist, batch_size);
+  std::cout << "plan work bytes: " << plan.get_work_buffer_bytes() << std::endl;
 
   // ifft(x) -> [8+0i 3+1i -6+0i 3-1i]
   // plan.exec_forward(gt::raw_pointer_cast(d_A.data()),
@@ -510,6 +521,7 @@ void fft_c2c_1d_inverse()
   gt::copy(h_A, d_A);
 
   gt::fft::FFTPlanMany<gt::fft::Domain::COMPLEX, E> plan({N}, batch_size);
+  std::cout << "plan work bytes: " << plan.get_work_buffer_bytes() << std::endl;
 
   // ifft(x) -> [8+0i 3+1i -6+0i 3-1i]
   // plan.exec_inverse(gt::raw_pointer_cast(d_A.data()),
@@ -617,6 +629,8 @@ void fft_r2c_2d()
   gt::copy(h_A, d_A);
 
   gt::fft::FFTPlanMany<gt::fft::Domain::REAL, E> plan({Ny, Nx}, batch_size);
+  std::cout << "plan work bytes: " << plan.get_work_buffer_bytes() << std::endl;
+
   plan(d_A, d_B);
   gt::copy(d_B, h_B);
 
@@ -669,6 +683,8 @@ void fft_c2c_2d()
   gt::copy(h_A, d_A);
 
   gt::fft::FFTPlanMany<gt::fft::Domain::COMPLEX, E> plan({Ny, Nx}, batch_size);
+  std::cout << "plan work bytes: " << plan.get_work_buffer_bytes() << std::endl;
+
   plan(d_A, d_B);
   gt::copy(d_B, h_B);
 
@@ -717,6 +733,8 @@ void fft_r2c_3d()
   gt::copy(h_A, d_A);
 
   gt::fft::FFTPlanMany<gt::fft::Domain::REAL, E> plan({Nz, Ny, Nx}, batch_size);
+  std::cout << "plan work bytes: " << plan.get_work_buffer_bytes() << std::endl;
+
   plan(d_A, d_B);
   gt::copy(d_B, h_B);
 


### PR DESCRIPTION
Useful to see if re-using the same buffer between plans and inverse/forward could help with total space used, when concurrency among plans is not needed.