### PR TITLE
view: add view_strided, strided reshape etc overloads

### DIFF
--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -799,21 +799,26 @@ inline auto zeros_like(const expression<E>& _e)
 // eval
 
 template <typename E>
-inline std::enable_if_t<is_gcontainer<E>::value, E> eval(E&& e)
+inline std::enable_if_t<
+  is_gcontainer<E>::value && !std::is_const<expr_value_type<E>>::value, E>
+eval(E&& e)
 {
   return std::forward<E>(e);
 }
 
 template <typename E>
-inline std::enable_if_t<is_gcontainer<E>::value, E&> eval(E& e)
+inline std::enable_if_t<
+  is_gcontainer<E>::value && !std::is_const<expr_value_type<E>>::value, E&>
+eval(E& e)
 {
   return e;
 }
 
 template <typename E>
-inline std::enable_if_t<
-  !is_gcontainer<E>::value,
-  gtensor<expr_value_type<E>, expr_dimension<E>(), expr_space_type<E>>>
+inline std::enable_if_t<!is_gcontainer<E>::value ||
+                          std::is_const<expr_value_type<E>>::value,
+                        gtensor<std::remove_cv_t<expr_value_type<E>>,
+                                expr_dimension<E>(), expr_space_type<E>>>
 eval(E&& e)
 {
   return {std::forward<E>(e)};

--- a/include/gtensor/gtensor.h
+++ b/include/gtensor/gtensor.h
@@ -805,6 +805,12 @@ inline std::enable_if_t<is_gcontainer<E>::value, E> eval(E&& e)
 }
 
 template <typename E>
+inline std::enable_if_t<is_gcontainer<E>::value, E&> eval(E& e)
+{
+  return e;
+}
+
+template <typename E>
 inline std::enable_if_t<
   !is_gcontainer<E>::value,
   gtensor<expr_value_type<E>, expr_dimension<E>(), expr_space_type<E>>>

--- a/include/gtensor/gtensor_span.h
+++ b/include/gtensor/gtensor_span.h
@@ -27,7 +27,10 @@ struct gtensor_inner_types<gtensor_span<T, N, S>>
   constexpr static size_type dimension = N;
 
   using storage_type = typename gt::span<T, gt::space_pointer<T, S>>;
-  using value_type = typename storage_type::value_type;
+  // NB: gt::span, following std::span, strips const for value_type, and keeps
+  // original template param in element_type. We want the original param for
+  // the value type of gtensor_span, to have container-like behavior.
+  using value_type = typename storage_type::element_type;
   using pointer = typename storage_type::pointer;
   using const_pointer = typename storage_type::const_pointer;
   using reference = typename storage_type::reference;
@@ -43,11 +46,11 @@ public:
   using inner_types = gtensor_inner_types<self_type>;
   using storage_type = typename inner_types::storage_type;
 
-  using value_type = typename storage_type::value_type;
-  using pointer = typename storage_type::pointer;
-  using const_pointer = typename storage_type::const_pointer;
-  using reference = typename storage_type::reference;
-  using const_reference = typename storage_type::const_reference;
+  using value_type = typename inner_types::value_type;
+  using pointer = typename inner_types::pointer;
+  using const_pointer = typename inner_types::const_pointer;
+  using reference = typename inner_types::reference;
+  using const_reference = typename inner_types::const_reference;
 
   using base_type::dimension;
   using typename base_type::shape_type;

--- a/include/gtensor/gview.h
+++ b/include/gtensor/gview.h
@@ -233,11 +233,7 @@ public:
   GT_INLINE decltype(auto) data_access(size_type i) const;
   GT_INLINE decltype(auto) data_access(size_type i);
 
-  inline pointer data() const;
-
   inline std::string typestr() const&;
-
-  inline bool is_f_contiguous() const;
 
 private:
   EC e_;
@@ -319,32 +315,12 @@ GT_INLINE decltype(auto) gview<EC, N>::data_access(size_t i)
 }
 
 template <typename EC, size_type N>
-inline typename gview<EC, N>::pointer gview<EC, N>::data() const
-{
-  if (!is_f_contiguous()) {
-#ifdef GTENSOR_DEVICE_ONLY
-    printf("cannot get data pointer for non-contiguous view");
-    assert(0);
-#else
-    throw std::runtime_error("cannot get data pointer for non-contiguous view");
-#endif
-  }
-  return pointer(&(data_access(0)));
-}
-
-template <typename EC, size_type N>
 inline std::string gview<EC, N>::typestr() const&
 {
   std::stringstream s;
   s << "v" << N << "(" << e_.typestr() << ")" << this->shape()
     << this->strides();
   return s.str();
-}
-
-template <typename EC, size_type N>
-inline bool gview<EC, N>::is_f_contiguous() const
-{
-  return this->strides() == calc_strides(this->shape());
 }
 
 template <typename EC, size_type N>

--- a/include/gtensor/gview.h
+++ b/include/gtensor/gview.h
@@ -168,7 +168,8 @@ public:
   using const_reference = typename inner_types::const_reference;
   using reference = typename inner_types::reference;
   using value_type = typename inner_types::value_type;
-  using pointer = typename std::add_pointer<value_type>::type;
+  using space_type = gt::expr_space_type<EC>;
+  using pointer = gt::space_pointer<value_type, space_type>;
 
   using typename base_type::shape_type;
   using typename base_type::strides_type;
@@ -216,7 +217,7 @@ public:
   GT_INLINE decltype(auto) data_access(size_type i) const;
   GT_INLINE decltype(auto) data_access(size_type i);
 
-  inline decltype(auto) data() const;
+  inline pointer data() const;
 
   inline std::string typestr() const&;
 
@@ -302,7 +303,7 @@ GT_INLINE decltype(auto) gview<EC, N>::data_access(size_t i)
 }
 
 template <typename EC, size_type N>
-inline decltype(auto) gview<EC, N>::data() const
+inline typename gview<EC, N>::pointer gview<EC, N>::data() const
 {
   if (!is_f_contiguous()) {
 #ifdef GTENSOR_DEVICE_ONLY
@@ -312,7 +313,7 @@ inline decltype(auto) gview<EC, N>::data() const
     throw std::runtime_error("cannot get data pointer for non-contiguous view");
 #endif
   }
-  return &(data_access(0));
+  return pointer(&(data_access(0)));
 }
 
 template <typename EC, size_type N>

--- a/include/gtensor/gview.h
+++ b/include/gtensor/gview.h
@@ -545,8 +545,7 @@ template <size_type N, typename E,
 inline auto reshape(E& e, gt::shape_type<N> shape)
 {
   detail::calc_reshape(e.shape(), shape);
-  return gtensor_span<expr_value_type<E>, N, expr_space_type<E>>(
-    e.data(), shape, calc_strides(shape));
+  return adapt<N, expr_space_type<E>>(e.data(), shape);
 }
 
 // ======================================================================

--- a/tests/test_gtensor_span.cxx
+++ b/tests/test_gtensor_span.cxx
@@ -56,6 +56,33 @@ TEST(gtensor_span, gtensor_implicit_conversion_ctor)
   EXPECT_EQ(first, a(0, 0));
 }
 
+TEST(gtensor_span, value_type)
+{
+  gt::gtensor<double, 2> a({{11., 12., 13.}, {21., 22., 23.}});
+  gt::gtensor_span<double, 2> aspan = a;
+  gt::gtensor_span<const double, 2> aspan_const = a;
+
+  GT_DEBUG_TYPE(aspan);
+  GT_DEBUG_TYPE_NAME(decltype(aspan)::value_type);
+  GT_DEBUG_TYPE_NAME(decltype(aspan)::pointer);
+  GT_DEBUG_TYPE_NAME(decltype(aspan)::const_pointer);
+  GT_DEBUG_TYPE_NAME(decltype(aspan)::reference);
+  GT_DEBUG_TYPE_NAME(decltype(aspan)::const_reference);
+
+  GT_DEBUG_TYPE(aspan_const);
+  GT_DEBUG_TYPE_NAME(decltype(aspan_const)::value_type);
+  GT_DEBUG_TYPE_NAME(decltype(aspan_const)::pointer);
+  GT_DEBUG_TYPE_NAME(decltype(aspan_const)::const_pointer);
+  GT_DEBUG_TYPE_NAME(decltype(aspan_const)::reference);
+  GT_DEBUG_TYPE_NAME(decltype(aspan_const)::const_reference);
+
+  static_assert(std::is_same<decltype(aspan)::value_type, double>::value,
+                "wrong value_type");
+  static_assert(
+    std::is_same<decltype(aspan_const)::value_type, const double>::value,
+    "wrong value_type (const)");
+}
+
 TEST(gtensor_span, adapt_vector)
 {
   std::vector<double> v = {2., 3.};

--- a/tests/test_helper.cxx
+++ b/tests/test_helper.cxx
@@ -241,8 +241,8 @@ TEST(helper, has_data_method)
   EXPECT_TRUE(gt::has_data_method_v<decltype(aspan)>);
   EXPECT_TRUE(gt::has_data_method<decltype(aspan)>::value);
 
-  EXPECT_FALSE(gt::has_data_method_v<decltype(aview)>);
-  EXPECT_FALSE(gt::has_data_method<decltype(aview)>::value);
+  EXPECT_TRUE(gt::has_data_method_v<decltype(aview)>);
+  EXPECT_TRUE(gt::has_data_method<decltype(aview)>::value);
 }
 
 TEST(helper, has_size_method)
@@ -273,8 +273,8 @@ TEST(helper, has_container_methods)
   EXPECT_TRUE(gt::has_container_methods_v<decltype(aspan)>);
   EXPECT_TRUE(gt::has_container_methods<decltype(aspan)>::value);
 
-  EXPECT_FALSE(gt::has_container_methods_v<decltype(aview)>);
-  EXPECT_FALSE(gt::has_container_methods<decltype(aview)>::value);
+  EXPECT_TRUE(gt::has_container_methods_v<decltype(aview)>);
+  EXPECT_TRUE(gt::has_container_methods<decltype(aview)>::value);
 }
 
 TEST(helper, is_allowed_element_type_conversion)

--- a/tests/test_helper.cxx
+++ b/tests/test_helper.cxx
@@ -234,6 +234,7 @@ TEST(helper, has_data_method)
   gt::gtensor<double, 1> a(gt::shape(10));
   auto aspan = a.to_kernel();
   auto aview = a.view(gt::slice(3, 6));
+  auto avstrided = gt::view_strided(a, gt::slice(3, 6));
 
   EXPECT_TRUE(gt::has_data_method_v<decltype(a)>);
   EXPECT_TRUE(gt::has_data_method<decltype(a)>::value);
@@ -241,8 +242,11 @@ TEST(helper, has_data_method)
   EXPECT_TRUE(gt::has_data_method_v<decltype(aspan)>);
   EXPECT_TRUE(gt::has_data_method<decltype(aspan)>::value);
 
-  EXPECT_TRUE(gt::has_data_method_v<decltype(aview)>);
-  EXPECT_TRUE(gt::has_data_method<decltype(aview)>::value);
+  EXPECT_FALSE(gt::has_data_method_v<decltype(aview)>);
+  EXPECT_FALSE(gt::has_data_method<decltype(aview)>::value);
+
+  EXPECT_TRUE(gt::has_data_method_v<decltype(avstrided)>);
+  EXPECT_TRUE(gt::has_data_method<decltype(avstrided)>::value);
 }
 
 TEST(helper, has_size_method)
@@ -250,6 +254,7 @@ TEST(helper, has_size_method)
   gt::gtensor<double, 1> a(gt::shape(10));
   auto aspan = a.to_kernel();
   auto aview = a.view(gt::slice(3, 6));
+  auto avstrided = gt::view_strided(a, gt::slice(3, 6));
 
   EXPECT_TRUE(gt::has_size_method_v<decltype(a)>);
   EXPECT_TRUE(gt::has_size_method<decltype(a)>::value);
@@ -259,6 +264,9 @@ TEST(helper, has_size_method)
 
   EXPECT_TRUE(gt::has_size_method_v<decltype(aview)>);
   EXPECT_TRUE(gt::has_size_method<decltype(aview)>::value);
+
+  EXPECT_TRUE(gt::has_size_method_v<decltype(avstrided)>);
+  EXPECT_TRUE(gt::has_size_method<decltype(avstrided)>::value);
 }
 
 TEST(helper, has_container_methods)
@@ -266,6 +274,7 @@ TEST(helper, has_container_methods)
   gt::gtensor<double, 1> a(gt::shape(10));
   auto aspan = a.to_kernel();
   auto aview = a.view(gt::slice(3, 6));
+  auto avstrided = gt::view_strided(a, gt::slice(3, 6));
 
   EXPECT_TRUE(gt::has_container_methods_v<decltype(a)>);
   EXPECT_TRUE(gt::has_container_methods<decltype(a)>::value);
@@ -273,8 +282,11 @@ TEST(helper, has_container_methods)
   EXPECT_TRUE(gt::has_container_methods_v<decltype(aspan)>);
   EXPECT_TRUE(gt::has_container_methods<decltype(aspan)>::value);
 
-  EXPECT_TRUE(gt::has_container_methods_v<decltype(aview)>);
-  EXPECT_TRUE(gt::has_container_methods<decltype(aview)>::value);
+  EXPECT_FALSE(gt::has_container_methods_v<decltype(aview)>);
+  EXPECT_FALSE(gt::has_container_methods<decltype(aview)>::value);
+
+  EXPECT_TRUE(gt::has_container_methods_v<decltype(avstrided)>);
+  EXPECT_TRUE(gt::has_container_methods<decltype(avstrided)>::value);
 }
 
 TEST(helper, is_allowed_element_type_conversion)

--- a/tests/test_span.cxx
+++ b/tests/test_span.cxx
@@ -52,6 +52,29 @@ TEST(span, type_aliases)
     (std::is_same<decltype(h1)::const_pointer, const double*>::value));
 }
 
+TEST(span, type_aliases_const)
+{
+  constexpr int N = 1024;
+  double a[N];
+  gt::span<const double> h1(&a[0], N);
+
+  GT_DEBUG_TYPE_NAME(decltype(h1)::element_type);
+  GT_DEBUG_TYPE_NAME(decltype(h1)::value_type);
+  GT_DEBUG_TYPE_NAME(decltype(h1)::reference);
+  GT_DEBUG_TYPE_NAME(decltype(h1)::const_reference);
+  GT_DEBUG_TYPE_NAME(decltype(h1)::pointer);
+  GT_DEBUG_TYPE_NAME(decltype(h1)::const_pointer);
+
+  EXPECT_TRUE((std::is_same<decltype(h1)::element_type, const double>::value));
+  EXPECT_TRUE((std::is_same<decltype(h1)::value_type, double>::value));
+  EXPECT_TRUE((std::is_same<decltype(h1)::reference, const double&>::value));
+  EXPECT_TRUE(
+    (std::is_same<decltype(h1)::const_reference, const double&>::value));
+  EXPECT_TRUE((std::is_same<decltype(h1)::pointer, const double*>::value));
+  EXPECT_TRUE(
+    (std::is_same<decltype(h1)::const_pointer, const double*>::value));
+}
+
 #ifdef GTENSOR_HAVE_DEVICE
 
 namespace gt

--- a/tests/test_view.cxx
+++ b/tests/test_view.cxx
@@ -935,7 +935,7 @@ TEST(gview, device_is_contiguous)
   EXPECT_EQ(outer_last - outer_first + 1, outer_slice.size());
   EXPECT_EQ(outer_slice.strides(), calc_strides(outer_slice.shape()));
   EXPECT_TRUE(outer_slice.is_f_contiguous());
-  EXPECT_EQ(outer_slice.data(), &(a(0, 1)));
+  EXPECT_EQ(outer_slice.data().get(), &(a(0, 1)));
 
   auto a_trans = gt::transpose(a, gt::shape(1, 0));
   EXPECT_EQ(a_trans, (gt::gtensor<double, 2>{

--- a/tests/test_view.cxx
+++ b/tests/test_view.cxx
@@ -935,7 +935,7 @@ TEST(gview, device_is_contiguous)
   EXPECT_EQ(outer_last - outer_first + 1, outer_slice.size());
   EXPECT_EQ(outer_slice.strides(), calc_strides(outer_slice.shape()));
   EXPECT_TRUE(outer_slice.is_f_contiguous());
-  EXPECT_EQ(outer_slice.data().get(), &(a(0, 1)));
+  EXPECT_EQ(outer_slice.data().get(), gt::raw_pointer_cast(&(a(0, 1))));
 
   auto a_trans = gt::transpose(a, gt::shape(1, 0));
   EXPECT_EQ(a_trans, (gt::gtensor<double, 2>{

--- a/tests/test_view.cxx
+++ b/tests/test_view.cxx
@@ -977,37 +977,7 @@ TEST(gview, device_is_contiguous)
   EXPECT_FALSE(a_trans.is_f_contiguous());
 }
 
-TEST(gview, sum_ne_strides_contiguous)
-{
-  gt::gtensor_device<double, 2> a{
-    {11., 21., 31.}, {12., 22., 32.}, {13., 23., 33.}, {14., 24., 34.}};
-  gt::gtensor_device<double, 2> b{{11., 21.}, {31., 12.}, {22., 32.},
-                                  {13., 23.}, {33., 14.}, {24., 34.}};
-
-  auto aplusb = a + gt::reshape(b, a.shape());
-
-  GT_DEBUG_VAR(a.shape());
-  GT_DEBUG_VAR(b.shape());
-  GT_DEBUG_VAR(aplusb.shape());
-
-  GT_DEBUG_VAR(a.strides());
-  GT_DEBUG_VAR(b.strides());
-
-  GT_DEBUG_TYPE(aplusb);
-
-  auto inner_slice = aplusb.view(_s(1, 3), _all);
-  GT_DEBUG_TYPE(inner_slice);
-  GT_DEBUG_VAR(inner_slice.shape());
-  GT_DEBUG_VAR(inner_slice.strides());
-
-  EXPECT_EQ(inner_slice,
-            (2 * gt::gtensor<double, 2>{
-                   {21., 31.}, {22., 32.}, {23., 33.}, {24., 34.}}));
-
-  EXPECT_FALSE(inner_slice.is_f_contiguous());
-}
-
-TEST(gview, fn_view_contiguous)
+TEST(gview, device_fn_view_nodata)
 {
   gt::gtensor_device<double, 2> a{
     {11., 21., 31.}, {12., 22., 32.}, {13., 23., 33.}, {14., 24., 34.}};
@@ -1030,7 +1000,7 @@ TEST(gview, fn_view_contiguous)
             (2 * gt::gtensor<double, 2>{
                    {21., 31.}, {22., 32.}, {23., 33.}, {24., 34.}}));
 
-  EXPECT_FALSE(inner_slice.is_f_contiguous());
+  EXPECT_FALSE(gt::has_data_method_v<decltype(inner_slice)>);
 }
 
 #endif


### PR DESCRIPTION
The data method raises an exception or assert(0) in device code if called on a non-forward-contiguous view.