### PR TITLE
Pr/gt solver nobuff

### DIFF
--- a/include/gt-solver/backend/cuda-bsrsm2.h
+++ b/include/gt-solver/backend/cuda-bsrsm2.h
@@ -135,6 +135,7 @@ class csr_matrix_lu_cuda_bsrsm2
 public:
   using value_type = T;
   using space_type = gt::space::device;
+  static constexpr bool inplace = false;
 
   csr_matrix_lu_cuda_bsrsm2(gt::sparse::csr_matrix<T, space_type>& csr_mat,
                             const T alpha, int nrhs,

--- a/include/gt-solver/backend/cuda-csrsm2.h
+++ b/include/gt-solver/backend/cuda-csrsm2.h
@@ -148,6 +148,7 @@ class csr_matrix_lu_cuda_csrsm2
 public:
   using value_type = T;
   using space_type = gt::space::device;
+  static constexpr bool inplace = true;
 
   csr_matrix_lu_cuda_csrsm2(gt::sparse::csr_matrix<T, space_type>& csr_mat,
                             const T alpha, int nrhs,

--- a/include/gt-solver/backend/cuda-generic.h
+++ b/include/gt-solver/backend/cuda-generic.h
@@ -127,6 +127,12 @@ class csr_matrix_lu_cuda_generic
 public:
   using value_type = T;
   using space_type = gt::space::device;
+  // has it's own internal buffer and does not need wrapping, because of
+  // dense vector descriptors.
+  // TODO: is it expensive to change the descriptors on each call to solve? If
+  // not, we can remove the buffers here to be more like the other backends,
+  // which don't buffer at all by default and rely on wrapper class when needed.
+  static constexpr bool inplace = true;
 
   csr_matrix_lu_cuda_generic(gt::sparse::csr_matrix<T, space_type>& csr_mat,
                              const T alpha, int nrhs,

--- a/include/gt-solver/backend/hip.h
+++ b/include/gt-solver/backend/hip.h
@@ -134,6 +134,7 @@ class csr_matrix_lu_hip
 public:
   using value_type = T;
   using space_type = gt::space::device;
+  static constexpr bool inplace = true;
 
   csr_matrix_lu_hip(gt::sparse::csr_matrix<T, space_type>& csr_mat,
                     const T alpha, int nrhs,

--- a/include/gt-solver/backend/sycl.h
+++ b/include/gt-solver/backend/sycl.h
@@ -41,6 +41,7 @@ class csr_matrix_lu_sycl
 public:
   using value_type = T;
   using space_type = gt::space::device;
+  static constexpr bool inplace = false;
 
   csr_matrix_lu_sycl(gt::sparse::csr_matrix<T, space_type>& csr_mat,
                      const T alpha, int nrhs,

--- a/include/gt-solver/solver.h
+++ b/include/gt-solver/solver.h
@@ -53,6 +53,7 @@ class staging_solver : solver<typename Solver::value_type>
 {
 public:
   using value_type = typename Solver::value_type;
+  static constexpr bool inplace = Solver::inplace;
 
   staging_solver(gt::blas::handle_t& h, int n, int nbatches, int nrhs,
                  value_type* const* matrix_batches);
@@ -66,8 +67,8 @@ private:
   int nrhs_;
   Solver solver_;
   gt::gtensor_device<value_type, 3> rhs_stage_;
-  gt::gtensor_device<value_type, 3> result_stage_;
   value_type* rhs_stage_p_;
+  gt::gtensor_device<value_type, 3> result_stage_;
   value_type* result_stage_p_;
 };
 
@@ -82,6 +83,7 @@ class solver_dense : public solver<T>
 public:
   using base_type = solver<T>;
   using typename base_type::value_type;
+  static constexpr bool inplace = true;
 
   solver_dense(gt::blas::handle_t& h, int n, int nbatches, int nrhs,
                T* const* matrix_batches);
@@ -108,6 +110,7 @@ class solver_dense : public solver<T>
 public:
   using base_type = solver<T>;
   using typename base_type::value_type;
+  static constexpr bool inplace = true;
 
   solver_dense(gt::blas::handle_t& h, int n, int nbatches, int nrhs,
                T* const* matrix_batches);
@@ -136,6 +139,7 @@ class solver_invert : solver<T>
 public:
   using base_type = solver<T>;
   using typename base_type::value_type;
+  static constexpr bool inplace = false;
 
   solver_invert(gt::blas::handle_t& h, int n, int nbatches, int nrhs,
                 T* const* matrix_batches);
@@ -164,6 +168,8 @@ class solver_sparse : public solver<T>
 public:
   using base_type = solver<T>;
   using typename base_type::value_type;
+  using csr_matrix_type = gt::sparse::csr_matrix<T, gt::space::device>;
+  static constexpr bool inplace = csr_matrix_lu<T>::inplace;
 
   solver_sparse(gt::blas::handle_t& blas_h, int n, int nbatches, int nrhs,
                 T* const* matrix_batches);
@@ -175,7 +181,7 @@ protected:
   int n_;
   int nbatches_;
   int nrhs_;
-  gt::sparse::csr_matrix<T, gt::space::device> csr_mat_;
+  csr_matrix_type csr_mat_;
   csr_matrix_lu<T> csr_mat_lu_;
 
 private:
@@ -189,6 +195,7 @@ class solver_band : public solver<T>
 public:
   using base_type = solver<T>;
   using typename base_type::value_type;
+  static constexpr bool inplace = true;
 
   solver_band(gt::blas::handle_t& h, int n, int nbatches, int nrhs,
               T* const* matrix_batches);

--- a/include/gt-solver/solver.h
+++ b/include/gt-solver/solver.h
@@ -48,6 +48,29 @@ public:
   virtual std::size_t get_device_memory_usage() = 0;
 };
 
+template <typename Solver>
+class staging_solver : solver<typename Solver::value_type>
+{
+public:
+  using value_type = typename Solver::value_type;
+
+  staging_solver(gt::blas::handle_t& h, int n, int nbatches, int nrhs,
+                 value_type* const* matrix_batches);
+
+  virtual void solve(value_type* rhs, value_type* result);
+  virtual std::size_t get_device_memory_usage();
+
+private:
+  int n_;
+  int nbatches_;
+  int nrhs_;
+  Solver solver_;
+  gt::gtensor_device<value_type, 3> rhs_stage_;
+  gt::gtensor_device<value_type, 3> result_stage_;
+  value_type* rhs_stage_p_;
+  value_type* result_stage_p_;
+};
+
 #ifdef GTENSOR_DEVICE_SYCL
 
 // use contiguous strided dense API for SYCL, it has been better

--- a/include/gt-solver/solver.h
+++ b/include/gt-solver/solver.h
@@ -73,7 +73,6 @@ protected:
   int nrhs_;
   gt::gtensor_device<T, 3> matrix_data_;
   gt::gtensor_device<gt::blas::index_t, 2> pivot_data_;
-  gt::gtensor_device<T, 3> rhs_data_;
   gt::blas::index_t scratch_count_;
   gt::space::device_vector<T> scratch_;
 };
@@ -102,8 +101,8 @@ protected:
   gt::gtensor_device<T*, 1> matrix_pointers_;
   gt::gtensor_device<gt::blas::index_t, 2> pivot_data_;
   gt::gtensor_device<int, 1> info_;
-  gt::gtensor_device<T, 3> rhs_data_;
   gt::gtensor_device<T*, 1> rhs_pointers_;
+  gt::gtensor<T*, 1> h_rhs_pointers_;
 };
 
 #endif
@@ -130,10 +129,10 @@ protected:
   gt::gtensor_device<T*, 1> matrix_pointers_;
   gt::gtensor_device<gt::blas::index_t, 2> pivot_data_;
   gt::gtensor_device<int, 1> info_;
-  gt::gtensor_device<T, 3> rhs_data_;
   gt::gtensor_device<T*, 1> rhs_pointers_;
-  gt::gtensor_device<T, 3> rhs_input_data_;
-  gt::gtensor_device<T*, 1> rhs_input_pointers_;
+  gt::gtensor<T*, 1> h_rhs_pointers_;
+  gt::gtensor_device<T*, 1> result_pointers_;
+  gt::gtensor<T*, 1> h_result_pointers_;
 };
 
 template <typename T>
@@ -185,8 +184,8 @@ protected:
   gt::gtensor_device<T*, 1> matrix_pointers_;
   gt::gtensor_device<gt::blas::index_t, 2> pivot_data_;
   gt::gtensor_device<int, 1> info_;
-  gt::gtensor_device<T, 3> rhs_data_;
   gt::gtensor_device<T*, 1> rhs_pointers_;
+  gt::gtensor<T*, 1> h_rhs_pointers_;
 };
 
 } // namespace solver

--- a/tests/test_solver.cxx
+++ b/tests/test_solver.cxx
@@ -155,3 +155,27 @@ TEST(solver, zfull_band_solve)
 {
   test_full_solve<gt::solver::solver_band<gt::complex<double>>>();
 }
+
+TEST(solver, sfull_staging_dense_solve)
+{
+  test_full_solve<
+    gt::solver::staging_solver<gt::solver::solver_dense<float>>>();
+}
+
+TEST(solver, dfull_staging_dense_solve)
+{
+  test_full_solve<
+    gt::solver::staging_solver<gt::solver::solver_dense<double>>>();
+}
+
+TEST(solver, cfull_staging_dense_solve)
+{
+  test_full_solve<
+    gt::solver::staging_solver<gt::solver::solver_dense<gt::complex<float>>>>();
+}
+
+TEST(solver, zfull_staging_dense_solve)
+{
+  test_full_solve<gt::solver::staging_solver<
+    gt::solver::solver_dense<gt::complex<double>>>>();
+}

--- a/tests/test_solver.cxx
+++ b/tests/test_solver.cxx
@@ -179,3 +179,54 @@ TEST(solver, zfull_staging_dense_solve)
   test_full_solve<gt::solver::staging_solver<
     gt::solver::solver_dense<gt::complex<double>>>>();
 }
+
+TEST(solver, sfull_staging_invert_solve)
+{
+  test_full_solve<
+    gt::solver::staging_solver<gt::solver::solver_invert<float>>>();
+}
+
+TEST(solver, dfull_staging_invert_solve)
+{
+  test_full_solve<
+    gt::solver::staging_solver<gt::solver::solver_invert<double>>>();
+}
+
+TEST(solver, cfull_staging_invert_solve)
+{
+  test_full_solve<gt::solver::staging_solver<
+    gt::solver::solver_invert<gt::complex<float>>>>();
+}
+
+TEST(solver, zfull_staging_invert_solve)
+{
+  test_full_solve<gt::solver::staging_solver<
+    gt::solver::solver_invert<gt::complex<double>>>>();
+}
+
+TEST(solver, sfull_staging_sparse_solve)
+{
+  test_full_solve<
+    gt::solver::staging_solver<gt::solver::solver_sparse<float>>>();
+}
+
+TEST(solver, dfull_staging_sparse_solve)
+{
+  test_full_solve<
+    gt::solver::staging_solver<gt::solver::solver_sparse<double>>>();
+}
+
+// Note: oneMKL sparse API does not support complex yet
+#if defined(GTENSOR_DEVICE_CUDA) || defined(GTENSOR_DEVICE_HIP)
+TEST(solver, cfull_staging_sparse_solve)
+{
+  test_full_solve<gt::solver::staging_solver<
+    gt::solver::solver_sparse<gt::complex<float>>>>();
+}
+
+TEST(solver, zfull_staging_sparse_solve)
+{
+  test_full_solve<gt::solver::staging_solver<
+    gt::solver::solver_sparse<gt::complex<double>>>>();
+}
+#endif


### PR DESCRIPTION
This removes the device memory staging buffers for the solve routines. The purpose of the buffers was to optimize the case of managed memory on AMD systems, where staging in to device memory is a significant performance win. This is a narrow case however, and on AMD systems we can also run out of device memory and rely on transparent host access to device memory so it still can handle certain managed memory cases.

This PR also still supports staging via a wrapper class, `gt::solver::staging_solver`. This is not quite as efficient as the original implementations, because for in-place solves only one buffer is needed, not two. This could be handled by specialization on wrapped Solver type if necessary.