### PR TITLE
add GTENSOR_DISABLE_PREFETCH option, mtype check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,9 @@ option(GTENSOR_ENABLE_SOLVER "Enable high level solver library" OFF)
 option(GTENSOR_PER_DIM_KERNELS
        "Enable per dim kernels (may break for large arrays)" OFF)
 
+option(GTENSOR_DISABLE_PREFETCH
+       "Make prefetch operations a no-op. Improves performance in some cases." OFF)
+
 option(GTENSOR_ALLOCATOR_CACHING "Enable naive caching allocators" ON)
 
 option(GTENSOR_BOUNDS_CHECK "Enable per access bounds checking" OFF)
@@ -328,6 +331,14 @@ if (GTENSOR_PER_DIM_KERNELS)
                              INTERFACE GTENSOR_PER_DIM_KERNELS)
 else()
   message(STATUS "${PROJECT_NAME}: using N-d -> 1d assign/launch kernels")
+endif()
+
+if (GTENSOR_DISABLE_PREFETCH)
+  message(STATUS "${PROJECT_NAME}: prefetch is DISABLED")
+  target_compile_definitions(gtensor_${GTENSOR_DEVICE}
+                             INTERFACE GTENSOR_DISABLE_PREFETCH)
+else()
+  message(STATUS "${PROJECT_NAME}: prefetch is ENABLED")
 endif()
 
 if (GTENSOR_ALLOCATOR_CACHING AND NOT GTENSOR_USE_RMM AND NOT GTENSOR_USE_UMPIRE)

--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -247,16 +247,26 @@ public:
   template <typename T>
   static void prefetch_device(T* p, size_type n)
   {
-    int device_id;
-    gtGpuCheck(cudaGetDevice(&device_id));
-    gtGpuCheck(cudaMemPrefetchAsync(p, n * sizeof(T), device_id, nullptr));
+#ifndef GTENSOR_DISABLE_PREFETCH
+    auto mtype = gt::backend::get_managed_memory_type();
+    if (mtype != gt::backend::managed_memory_type::device) {
+      int device_id;
+      gtGpuCheck(cudaGetDevice(&device_id));
+      gtGpuCheck(cudaMemPrefetchAsync(p, n * sizeof(T), device_id, nullptr));
+    }
+#endif
   }
 
   template <typename T>
   static void prefetch_host(T* p, size_type n)
   {
-    gtGpuCheck(
-      cudaMemPrefetchAsync(p, n * sizeof(T), cudaCpuDeviceId, nullptr));
+#ifndef GTENSOR_DISABLE_PREFETCH
+    auto mtype = gt::backend::get_managed_memory_type();
+    if (mtype != gt::backend::managed_memory_type::device) {
+      gtGpuCheck(
+        cudaMemPrefetchAsync(p, n * sizeof(T), cudaCpuDeviceId, nullptr));
+    }
+#endif
   }
 
   template <typename T>

--- a/include/gtensor/backend_hip.h
+++ b/include/gtensor/backend_hip.h
@@ -281,15 +281,26 @@ public:
   template <typename T>
   static void prefetch_device(T* p, size_type n)
   {
-    int device_id;
-    gtGpuCheck(hipGetDevice(&device_id));
-    gtGpuCheck(hipMemPrefetchAsync(p, n * sizeof(T), device_id, nullptr));
+#ifndef GTENSOR_DISABLE_PREFETCH
+    auto mtype = gt::backend::get_managed_memory_type();
+    if (mtype != gt::backend::managed_memory_type::device) {
+      int device_id;
+      gtGpuCheck(hipGetDevice(&device_id));
+      gtGpuCheck(hipMemPrefetchAsync(p, n * sizeof(T), device_id, nullptr));
+    }
+#endif
   }
 
   template <typename T>
   static void prefetch_host(T* p, size_type n)
   {
-    gtGpuCheck(hipMemPrefetchAsync(p, n * sizeof(T), hipCpuDeviceId, nullptr));
+#ifndef GTENSOR_DISABLE_PREFETCH
+    auto mtype = gt::backend::get_managed_memory_type();
+    if (mtype != gt::backend::managed_memory_type::device) {
+      gtGpuCheck(
+        hipMemPrefetchAsync(p, n * sizeof(T), hipCpuDeviceId, nullptr));
+    }
+#endif
   }
 
   template <typename T>

--- a/include/gtensor/backend_sycl.h
+++ b/include/gtensor/backend_sycl.h
@@ -276,8 +276,13 @@ public:
   template <typename T>
   static void prefetch_device(T* p, size_type n)
   {
-    auto& q = gt::backend::sycl::get_queue();
-    q.prefetch(p, n);
+#ifndef GTENSOR_DISABLE_PREFETCH
+    auto mtype = gt::backend::get_managed_memory_type();
+    if (mtype != gt::backend::managed_memory_type::device) {
+      auto& q = gt::backend::sycl::get_queue();
+      q.prefetch(p, n);
+    }
+#endif
   }
 
   // Not available in SYCL 2020, make it a no-op


### PR DESCRIPTION
- making prefetch a no-op can improve performance, in particular on AMD platforms
- using prefetch when the default managed memory type is device is pointless, so also make it a no-op in that case even when prefetch is enabled
- prefetch is still enabled by default for other cases