### PR TITLE
gt-blas: add gtblas_get_handle to clib

### DIFF
--- a/include/gt-blas/cblas.h
+++ b/include/gt-blas/cblas.h
@@ -12,6 +12,8 @@ extern "C" {
 void gtblas_create();
 void gtblas_destroy();
 
+void* gtblas_get_handle();
+
 void gtblas_set_stream(gt::stream_view stream_id);
 void gtblas_get_stream(gt::stream_view* stream_id);
 

--- a/src/cgtblas.cxx
+++ b/src/cgtblas.cxx
@@ -134,6 +134,12 @@ void gtblas_destroy()
   }
 }
 
+void* gtblas_get_handle()
+{
+  gtblas_create();
+  return g_handle;
+}
+
 void gtblas_set_stream(gt::stream_view stream) { g_handle->set_stream(stream); }
 
 void gtblas_get_stream(gt::stream_view* stream_id)

--- a/tests/test_cblas.cxx
+++ b/tests/test_cblas.cxx
@@ -267,3 +267,25 @@ void test_gemv_complex(F&& f)
 TEST(cblas, cgemv) { test_gemv_complex<float>(&gtblas_cgemv); }
 
 TEST(cblas, zgemv) { test_gemv_complex<double>(&gtblas_zgemv); }
+
+TEST(cblas, get_handle)
+{
+  void *h1, *h2, *h3;
+
+  gtblas_create();
+
+  h1 = gtblas_get_handle();
+
+  gtblas_create();
+
+  h2 = gtblas_get_handle();
+
+  EXPECT_EQ(h1, h2);
+
+  gtblas_destroy();
+
+  // calls create internally
+  h3 = gtblas_get_handle();
+
+  EXPECT_NE(h2, h3);
+}


### PR DESCRIPTION
Useful for Fortran applications using both gtblas and gtsolver, should use same handle for all operations on same gpu / stream.