### PR TITLE
add FFT support on host (via fftw)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 include(cmake/CPM.cmake)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/")
 
 option(USE_GTEST_DISCOVER_TESTS "use gtest_discover_tests()" ON)
 set(GTENSOR_DEVICE "cuda" CACHE STRING "Device type 'host', 'cuda', or 'hip'")
@@ -493,6 +494,10 @@ if (GTENSOR_ENABLE_FFT)
     else()
       target_link_libraries(gtfft INTERFACE oneapi_mkl_sycl)
     endif()
+  elseif (${GTENSOR_DEVICE} STREQUAL "host")
+    find_package(FFTW REQUIRED)
+
+    target_link_libraries(gtfft INTERFACE FFTW::Double FFTW::Float)
   endif()
 
   list(APPEND GTENSOR_TARGETS gtfft)

--- a/cmake/FindFFTW.cmake
+++ b/cmake/FindFFTW.cmake
@@ -1,0 +1,351 @@
+# - Find the FFTW library
+#
+# Original version of this file:
+#   Copyright (c) 2015, Wenzel Jakob
+#   https://github.com/wjakob/layerlab/blob/master/cmake/FindFFTW.cmake, commit 4d58bfdc28891b4f9373dfe46239dda5a0b561c6
+# Modifications:
+#   Copyright (c) 2017, Patrick Bos
+#
+# Usage:
+#   find_package(FFTW [REQUIRED] [QUIET] [COMPONENTS component1 ... componentX] )
+#
+# It sets the following variables:
+#   FFTW_FOUND                  ... true if fftw is found on the system
+#   FFTW_[component]_LIB_FOUND  ... true if the component is found on the system (see components below)
+#   FFTW_LIBRARIES              ... full paths to all found fftw libraries
+#   FFTW_[component]_LIB        ... full path to one of the components (see below)
+#   FFTW_INCLUDE_DIRS           ... fftw include directory paths
+#
+# The following variables will be checked by the function
+#   FFTW_USE_STATIC_LIBS        ... if true, only static libraries are found, otherwise both static and shared.
+#   FFTW_ROOT                   ... if set, the libraries are exclusively searched
+#                                   under this path
+#
+# This package supports the following components:
+#   FLOAT_LIB
+#   DOUBLE_LIB
+#   LONGDOUBLE_LIB
+#   FLOAT_THREADS_LIB
+#   DOUBLE_THREADS_LIB
+#   LONGDOUBLE_THREADS_LIB
+#   FLOAT_OPENMP_LIB
+#   DOUBLE_OPENMP_LIB
+#   LONGDOUBLE_OPENMP_LIB
+#
+
+# TODO (maybe): extend with ExternalProject download + build option
+# TODO: put on conda-forge
+
+
+if( NOT FFTW_ROOT AND DEFINED ENV{FFTWDIR} )
+  set( FFTW_ROOT $ENV{FFTWDIR} )
+endif()
+
+# Check if we can use PkgConfig
+find_package(PkgConfig)
+
+#Determine from PKG
+if( PKG_CONFIG_FOUND AND NOT FFTW_ROOT )
+  pkg_check_modules( PKG_FFTW QUIET "fftw3" )
+endif()
+
+#Check whether to search static or dynamic libs
+set( CMAKE_FIND_LIBRARY_SUFFIXES_SAV ${CMAKE_FIND_LIBRARY_SUFFIXES} )
+
+if( ${FFTW_USE_STATIC_LIBS} )
+  set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX} )
+else()
+  set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_SAV} )
+endif()
+
+if( FFTW_ROOT )
+  # find libs
+
+  find_library(
+    FFTW_DOUBLE_LIB
+    NAMES "fftw3" libfftw3-3
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH
+  )
+
+  find_library(
+    FFTW_DOUBLE_THREADS_LIB
+    NAMES "fftw3_threads"
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH
+  )
+
+  find_library(
+          FFTW_DOUBLE_OPENMP_LIB
+          NAMES "fftw3_omp"
+          PATHS ${FFTW_ROOT}
+          PATH_SUFFIXES "lib" "lib64"
+          NO_DEFAULT_PATH
+  )
+
+  find_library(
+    FFTW_FLOAT_LIB
+    NAMES "fftw3f" libfftw3f-3
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH
+  )
+
+  find_library(
+    FFTW_FLOAT_THREADS_LIB
+    NAMES "fftw3f_threads"
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH
+  )
+
+  find_library(
+          FFTW_FLOAT_OPENMP_LIB
+          NAMES "fftw3f_omp"
+          PATHS ${FFTW_ROOT}
+          PATH_SUFFIXES "lib" "lib64"
+          NO_DEFAULT_PATH
+  )
+
+  find_library(
+    FFTW_LONGDOUBLE_LIB
+    NAMES "fftw3l" libfftw3l-3
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH
+  )
+
+  find_library(
+    FFTW_LONGDOUBLE_THREADS_LIB
+    NAMES "fftw3l_threads"
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "lib" "lib64"
+    NO_DEFAULT_PATH
+  )
+
+  find_library(
+          FFTW_LONGDOUBLE_OPENMP_LIB
+          NAMES "fftw3l_omp"
+          PATHS ${FFTW_ROOT}
+          PATH_SUFFIXES "lib" "lib64"
+          NO_DEFAULT_PATH
+  )
+
+  #find includes
+  find_path(FFTW_INCLUDE_DIRS
+    NAMES "fftw3.h"
+    PATHS ${FFTW_ROOT}
+    PATH_SUFFIXES "include"
+    NO_DEFAULT_PATH
+  )
+
+else()
+
+  find_library(
+    FFTW_DOUBLE_LIB
+    NAMES "fftw3"
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+  )
+
+  find_library(
+    FFTW_DOUBLE_THREADS_LIB
+    NAMES "fftw3_threads"
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+  )
+
+  find_library(
+          FFTW_DOUBLE_OPENMP_LIB
+          NAMES "fftw3_omp"
+          PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+  )
+
+  find_library(
+    FFTW_FLOAT_LIB
+    NAMES "fftw3f"
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+  )
+
+  find_library(
+    FFTW_FLOAT_THREADS_LIB
+    NAMES "fftw3f_threads"
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+  )
+
+  find_library(
+          FFTW_FLOAT_OPENMP_LIB
+          NAMES "fftw3f_omp"
+          PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+  )
+
+  find_library(
+    FFTW_LONGDOUBLE_LIB
+    NAMES "fftw3l"
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+  )
+
+  find_library(
+    FFTW_LONGDOUBLE_THREADS_LIB
+    NAMES "fftw3l_threads"
+    PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+  )
+
+  find_library(FFTW_LONGDOUBLE_OPENMP_LIB
+          NAMES "fftw3l_omp"
+          PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+  )
+
+  find_path(FFTW_INCLUDE_DIRS
+    NAMES "fftw3.h"
+    PATHS ${PKG_FFTW_INCLUDE_DIRS} ${INCLUDE_INSTALL_DIR}
+  )
+
+endif( FFTW_ROOT )
+
+#--------------------------------------- components
+
+if (FFTW_DOUBLE_LIB)
+  set(FFTW_DOUBLE_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_DOUBLE_LIB})
+  if (NOT TARGET FFTW::Double)
+    add_library(FFTW::Double INTERFACE IMPORTED)
+    set_target_properties(FFTW::Double
+      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+                 INTERFACE_LINK_LIBRARIES "${FFTW_DOUBLE_LIB}"
+    )
+  endif()
+else()
+  set(FFTW_DOUBLE_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_FLOAT_LIB)
+  set(FFTW_FLOAT_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_FLOAT_LIB})
+  if (NOT TARGET FFTW::Float)
+    add_library(FFTW::Float INTERFACE IMPORTED)
+    set_target_properties(FFTW::Float
+      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+                 INTERFACE_LINK_LIBRARIES "${FFTW_FLOAT_LIB}"
+    )
+  endif()
+else()
+  set(FFTW_FLOAT_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_LONGDOUBLE_LIB)
+  set(FFTW_LONGDOUBLE_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_LONGDOUBLE_LIB})
+  if (NOT TARGET FFTW::LongDouble)
+    add_library(FFTW::LongDouble INTERFACE IMPORTED)
+    set_target_properties(FFTW::LongDouble
+      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+                 INTERFACE_LINK_LIBRARIES "${FFTW_LONGDOUBLE_LIB}"
+    )
+  endif()
+else()
+  set(FFTW_LONGDOUBLE_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_DOUBLE_THREADS_LIB)
+  set(FFTW_DOUBLE_THREADS_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_DOUBLE_THREADS_LIB})
+  if (NOT TARGET FFTW::DoubleThreads)
+    add_library(FFTW::DoubleThreads INTERFACE IMPORTED)
+    set_target_properties(FFTW::DoubleThreads
+      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+                 INTERFACE_LINK_LIBRARIES "${FFTW_DOUBLETHREADS_LIB}"
+    )
+  endif()
+else()
+  set(FFTW_DOUBLE_THREADS_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_FLOAT_THREADS_LIB)
+  set(FFTW_FLOAT_THREADS_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_FLOAT_THREADS_LIB})
+  if (NOT TARGET FFTW::FloatThreads)
+    add_library(FFTW::FloatThreads INTERFACE IMPORTED)
+    set_target_properties(FFTW::FloatThreads
+      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+                 INTERFACE_LINK_LIBRARIES "${FFTW_FLOAT_THREADS_LIB}"
+    )
+  endif()
+else()
+  set(FFTW_FLOAT_THREADS_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_LONGDOUBLE_THREADS_LIB)
+  set(FFTW_LONGDOUBLE_THREADS_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_LONGDOUBLE_THREADS_LIB})
+  if (NOT TARGET FFTW::LongDoubleThreads)
+    add_library(FFTW::LongDoubleThreads INTERFACE IMPORTED)
+    set_target_properties(FFTW::LongDoubleThreads
+      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+                 INTERFACE_LINK_LIBRARIES "${FFTW_LONGDOUBLE_THREADS_LIB}"
+    )
+  endif()
+else()
+  set(FFTW_LONGDOUBLE_THREADS_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_DOUBLE_OPENMP_LIB)
+  set(FFTW_DOUBLE_OPENMP_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_DOUBLE_OPENMP_LIB})
+  add_library(FFTW::DoubleOpenMP INTERFACE IMPORTED)
+  set_target_properties(FFTW::DoubleOpenMP
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+               INTERFACE_LINK_LIBRARIES "${FFTW_DOUBLE_OPENMP_LIB}"
+  )
+else()
+  set(FFTW_DOUBLE_OPENMP_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_FLOAT_OPENMP_LIB)
+  set(FFTW_FLOAT_OPENMP_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_FLOAT_OPENMP_LIB})
+  add_library(FFTW::FloatOpenMP INTERFACE IMPORTED)
+  set_target_properties(FFTW::FloatOpenMP
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+               INTERFACE_LINK_LIBRARIES "${FFTW_FLOAT_OPENMP_LIB}"
+  )
+else()
+  set(FFTW_FLOAT_OPENMP_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_LONGDOUBLE_OPENMP_LIB)
+  set(FFTW_LONGDOUBLE_OPENMP_LIB_FOUND TRUE)
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_LONGDOUBLE_OPENMP_LIB})
+  add_library(FFTW::LongDoubleOpenMP INTERFACE IMPORTED)
+  set_target_properties(FFTW::LongDoubleOpenMP
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+               INTERFACE_LINK_LIBRARIES "${FFTW_LONGDOUBLE_OPENMP_LIB}"
+  )
+else()
+  set(FFTW_LONGDOUBLE_OPENMP_LIB_FOUND FALSE)
+endif()
+
+#--------------------------------------- end components
+
+set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_SAV} )
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(FFTW
+        REQUIRED_VARS FFTW_INCLUDE_DIRS
+        HANDLE_COMPONENTS
+        )
+
+mark_as_advanced(
+        FFTW_INCLUDE_DIRS
+        FFTW_LIBRARIES
+        FFTW_FLOAT_LIB
+        FFTW_DOUBLE_LIB
+        FFTW_LONGDOUBLE_LIB
+        FFTW_FLOAT_THREADS_LIB
+        FFTW_DOUBLE_THREADS_LIB
+        FFTW_LONGDOUBLE_THREADS_LIB
+        FFTW_FLOAT_OPENMP_LIB
+        FFTW_DOUBLE_OPENMP_LIB
+        FFTW_LONGDOUBLE_OPENMP_LIB
+        )

--- a/include/gt-fft/backend/fftw_inc.h
+++ b/include/gt-fft/backend/fftw_inc.h
@@ -64,19 +64,25 @@ public:
 
   void execute_dft(complex_type* in, complex_type* out) const
   {
-    assert(plan_);
+    if (!plan_) {
+      throw std::runtime_error("can't use a moved-from plan");
+    }
     return ::FFTW_(execute_dft)(plan_, in, out);
   }
 
   void execute_dft_r2c(real_type* in, complex_type* out) const
   {
-    assert(plan_);
+    if (!plan_) {
+      throw std::runtime_error("can't use a moved-from plan");
+    }
     return ::FFTW_(execute_dft_r2c)(plan_, in, out);
   }
 
   void execute_dft_c2r(complex_type* in, real_type* out) const
   {
-    assert(plan_);
+    if (!plan_) {
+      throw std::runtime_error("can't use a moved-from plan");
+    }
     return ::FFTW_(execute_dft_c2r)(plan_, in, out);
   }
 

--- a/include/gt-fft/backend/fftw_inc.h
+++ b/include/gt-fft/backend/fftw_inc.h
@@ -4,6 +4,7 @@ class fftw<R>
 public:
   using plan_type = ::FFTW_(plan);
   using complex_type = ::FFTW_(complex);
+  using real_type = R;
 
   fftw() = default;
   fftw(plan_type plan) : plan_{plan} {}
@@ -39,10 +40,44 @@ public:
                                        sign, flags)};
   }
 
+  static fftw plan_many_dft_r2c(int rank, const int* n, int howmany,
+                                real_type* in, const int* inembed, int istride,
+                                int idist, complex_type* out,
+                                const int* onembed, int ostride, int odist,
+                                unsigned flags)
+  {
+    return fftw{::FFTW_(plan_many_dft_r2c)(rank, n, howmany, in, inembed,
+                                           istride, idist, out, onembed,
+                                           ostride, odist, flags)};
+  }
+
+  static fftw plan_many_dft_c2r(int rank, const int* n, int howmany,
+                                complex_type* in, const int* inembed,
+                                int istride, int idist, real_type* out,
+                                const int* onembed, int ostride, int odist,
+                                unsigned flags)
+  {
+    return fftw{::FFTW_(plan_many_dft_c2r)(rank, n, howmany, in, inembed,
+                                           istride, idist, out, onembed,
+                                           ostride, odist, flags)};
+  }
+
   void execute_dft(complex_type* in, complex_type* out) const
   {
     assert(plan_);
     return ::FFTW_(execute_dft)(plan_, in, out);
+  }
+
+  void execute_dft_r2c(real_type* in, complex_type* out) const
+  {
+    assert(plan_);
+    return ::FFTW_(execute_dft_r2c)(plan_, in, out);
+  }
+
+  void execute_dft_c2r(complex_type* in, real_type* out) const
+  {
+    assert(plan_);
+    return ::FFTW_(execute_dft_c2r)(plan_, in, out);
   }
 
 private:

--- a/include/gt-fft/backend/fftw_inc.h
+++ b/include/gt-fft/backend/fftw_inc.h
@@ -6,14 +6,11 @@ public:
   using complex_type = ::FFTW_(complex);
 
   fftw() = default;
-  fftw(plan_type plan) : plan_{plan}, is_valid_{true} {}
+  fftw(plan_type plan) : plan_{plan} {}
 
   // move only
   fftw(const fftw& other) = delete;
-  fftw(fftw&& other) : plan_{other.plan_}, is_valid_{other.is_valid_}
-  {
-    other.is_valid_ = false;
-  }
+  fftw(fftw&& other) : plan_{other.plan_} { other.plan_ = {}; }
 
   fftw& operator=(const fftw& other) = delete;
   fftw& operator=(fftw&& other)
@@ -21,14 +18,13 @@ public:
     if (&other != this) {
       using std::swap;
       swap(plan_, other.plan_);
-      swap(is_valid_, other.is_valid_);
     }
     return *this;
   }
 
   ~fftw()
   {
-    if (is_valid_) {
+    if (plan_) {
       FFTW_(destroy_plan)(plan_);
     }
   }
@@ -45,11 +41,10 @@ public:
 
   void execute_dft(complex_type* in, complex_type* out) const
   {
-    assert(is_valid_);
+    assert(plan_);
     return ::FFTW_(execute_dft)(plan_, in, out);
   }
 
 private:
-  plan_type plan_;
-  bool is_valid_ = false;
+  plan_type plan_ = {};
 };

--- a/include/gt-fft/backend/fftw_inc.h
+++ b/include/gt-fft/backend/fftw_inc.h
@@ -1,0 +1,30 @@
+template <>
+class fftw<R>
+{
+public:
+  using plan_type = ::FFTW_(plan);
+  using complex_type = ::FFTW_(complex);
+
+  fftw() = default;
+  fftw(plan_type plan) : plan_{plan}, is_valid_{true} {}
+
+  static fftw plan_many_dft(int rank, const int* n, int howmany,
+                            complex_type* in, const int* inembed, int istride,
+                            int idist, complex_type* out, const int* onembed,
+                            int ostride, int odist, int sign, unsigned flags)
+  {
+    return fftw{::FFTW_(plan_many_dft)(rank, n, howmany, in, inembed, istride,
+                                       idist, out, onembed, ostride, odist,
+                                       sign, flags)};
+  }
+
+  void execute_dft(complex_type* in, complex_type* out) const
+  {
+    assert(is_valid_);
+    return ::FFTW_(execute_dft)(plan_, in, out);
+  }
+
+private:
+  plan_type plan_;
+  bool is_valid_ = false;
+};

--- a/include/gt-fft/backend/fftw_inc.h
+++ b/include/gt-fft/backend/fftw_inc.h
@@ -8,6 +8,31 @@ public:
   fftw() = default;
   fftw(plan_type plan) : plan_{plan}, is_valid_{true} {}
 
+  // move only
+  fftw(const fftw& other) = delete;
+  fftw(fftw&& other) : plan_{other.plan_}, is_valid_{other.is_valid_}
+  {
+    other.is_valid_ = false;
+  }
+
+  fftw& operator=(const fftw& other) = delete;
+  fftw& operator=(fftw&& other)
+  {
+    if (&other != this) {
+      using std::swap;
+      swap(plan_, other.plan_);
+      swap(is_valid_, other.is_valid_);
+    }
+    return *this;
+  }
+
+  ~fftw()
+  {
+    if (is_valid_) {
+      FFTW_(destroy_plan)(plan_);
+    }
+  }
+
   static fftw plan_many_dft(int rank, const int* n, int howmany,
                             complex_type* in, const int* inembed, int istride,
                             int idist, complex_type* out, const int* onembed,

--- a/include/gt-fft/backend/host.h
+++ b/include/gt-fft/backend/host.h
@@ -139,23 +139,23 @@ private:
   {
     int rank = lengths.size();
     int* n = lengths.data();
-    Bin* in = nullptr;
-    Bout* out = nullptr;
+    Bin dummy_in;
+    Bout dummy_out;
 
     if constexpr (D == gt::fft::Domain::COMPLEX) {
-      fftw_forward_ =
-        fftw::plan_many_dft(rank, n, batch_size, in, NULL, istride, idist, out,
-                            NULL, ostride, odist, -1, FFTW_ESTIMATE);
-      fftw_inverse_ =
-        fftw::plan_many_dft(rank, n, batch_size, out, NULL, ostride, odist, in,
-                            NULL, istride, idist, 1, FFTW_ESTIMATE);
+      fftw_forward_ = fftw::plan_many_dft(rank, n, batch_size, &dummy_in, NULL,
+                                          istride, idist, &dummy_out, NULL,
+                                          ostride, odist, -1, FFTW_ESTIMATE);
+      fftw_inverse_ = fftw::plan_many_dft(rank, n, batch_size, &dummy_out, NULL,
+                                          ostride, odist, &dummy_in, NULL,
+                                          istride, idist, 1, FFTW_ESTIMATE);
     } else {
-      fftw_forward_ =
-        fftw::plan_many_dft_r2c(rank, n, batch_size, in, NULL, istride, idist,
-                                out, NULL, ostride, odist, FFTW_ESTIMATE);
-      fftw_inverse_ =
-        fftw::plan_many_dft_c2r(rank, n, batch_size, out, NULL, ostride, odist,
-                                in, NULL, istride, idist, FFTW_ESTIMATE);
+      fftw_forward_ = fftw::plan_many_dft_r2c(
+        rank, n, batch_size, &dummy_in, NULL, istride, idist, &dummy_out, NULL,
+        ostride, odist, FFTW_ESTIMATE);
+      fftw_inverse_ = fftw::plan_many_dft_c2r(
+        rank, n, batch_size, &dummy_out, NULL, ostride, odist, &dummy_in, NULL,
+        istride, idist, FFTW_ESTIMATE);
     }
   }
 

--- a/include/gt-fft/backend/host.h
+++ b/include/gt-fft/backend/host.h
@@ -1,0 +1,216 @@
+#ifndef GTENSOR_FFT_BACKEND_HOST_H
+#define GTENSOR_FFT_BACKEND_HOST_H
+
+#include <numeric>
+#include <stdexcept>
+#include <vector>
+
+#include <fftw3.h>
+
+namespace gt
+{
+
+namespace fft
+{
+
+namespace detail
+{
+
+template <gt::fft::Domain D, typename R>
+struct fft_config;
+
+template <>
+struct fft_config<gt::fft::Domain::COMPLEX, double>
+{
+  using Tin = gt::complex<double>;
+  using Tout = gt::complex<double>;
+  using Bin = fftw_complex;
+  using Bout = fftw_complex;
+  using plan_type = fftw_plan;
+
+  static plan_type fftw_plan_many_dft(int rank, const int* n, int howmany,
+                                      Bin* in, const int* inembed, int istride,
+                                      int idist, Bout* out, const int* onembed,
+                                      int ostride, int odist, int sign,
+                                      unsigned flags)
+  {
+    return ::fftw_plan_many_dft(rank, n, howmany, in, inembed, istride, idist,
+                                out, onembed, ostride, odist, sign, flags);
+  }
+
+  static void fftw_execute_dft(plan_type plan, Bin* in, Bout* out)
+  {
+    return ::fftw_execute_dft(plan, in, out);
+  }
+};
+
+template <>
+struct fft_config<gt::fft::Domain::COMPLEX, float>
+{
+  using Tin = gt::complex<float>;
+  using Tout = gt::complex<float>;
+  using Bin = fftwf_complex;
+  using Bout = fftwf_complex;
+  using plan_type = fftwf_plan;
+
+  static plan_type fftw_plan_many_dft(int rank, const int* n, int howmany,
+                                      Bin* in, const int* inembed, int istride,
+                                      int idist, Bout* out, const int* onembed,
+                                      int ostride, int odist, int sign,
+                                      unsigned flags)
+  {
+    return ::fftwf_plan_many_dft(rank, n, howmany, in, inembed, istride, idist,
+                                 out, onembed, ostride, odist, sign, flags);
+  }
+
+  static void fftw_execute_dft(plan_type plan, Bin* in, Bout* out)
+  {
+    return ::fftwf_execute_dft(plan, in, out);
+  }
+};
+
+template <>
+struct fft_config<gt::fft::Domain::REAL, double>
+{
+  using Tin = double;
+  using Tout = gt::complex<double>;
+  using Bin = double;
+  using Bout = fftw_complex;
+  using plan_type = fftw_plan;
+};
+
+template <>
+struct fft_config<gt::fft::Domain::REAL, float>
+{
+  using Tin = float;
+  using Tout = gt::complex<float>;
+  using Bin = float;
+  using Bout = fftwf_complex;
+  using plan_type = fftwf_plan;
+};
+
+} // namespace detail
+
+template <gt::fft::Domain D, typename R>
+class FFTPlanManyHost
+{
+  using Bin = typename detail::fft_config<D, R>::Bin;
+  using Bout = typename detail::fft_config<D, R>::Bout;
+  using plan_type = typename detail::fft_config<D, R>::plan_type;
+
+public:
+  FFTPlanManyHost(std::vector<int> lengths, int batch_size = 1,
+                  gt::stream_view stream = gt::stream_view{})
+    : is_valid_(true)
+  {
+    int rank = lengths.size();
+    int idist, odist;
+    idist = std::accumulate(lengths.begin(), lengths.end(), 1,
+                            std::multiplies<int>());
+    if (D == gt::fft::Domain::REAL) {
+      odist = idist / lengths[rank - 1] * (lengths[rank - 1] / 2 + 1);
+    } else {
+      odist = idist;
+    }
+    init(lengths, 1, idist, 1, odist, batch_size);
+  }
+
+  FFTPlanManyHost(std::vector<int> lengths, int istride, int idist, int ostride,
+                  int odist, int batch_size = 1,
+                  gt::stream_view stream = gt::stream_view{})
+    : is_valid_(true)
+  {
+    init(lengths, istride, idist, ostride, odist, batch_size);
+  }
+
+  // move only
+  // delete copy ctor/assign
+  FFTPlanManyHost(const FFTPlanManyHost& other) = delete;
+  FFTPlanManyHost& operator=(const FFTPlanManyHost& other) = delete;
+
+  // custom move to avoid double destroy in moved-from object
+  FFTPlanManyHost(FFTPlanManyHost&& other) : is_valid_(true)
+  {
+    plan_forward_ = other.plan_forward_;
+    plan_inverse_ = other.plan_inverse_;
+    other.is_valid_ = false;
+  }
+
+  FFTPlanManyHost& operator=(FFTPlanManyHost&& other)
+  {
+    plan_forward_ = other.plan_forward_;
+    plan_inverse_ = other.plan_inverse_;
+    other.is_valid_ = false;
+    return *this;
+  }
+
+  virtual ~FFTPlanManyHost()
+  {
+    if (is_valid_) {
+      // fftw_destroy_plan(plan_forward_);
+      // fftw_destroy_plan(plan_inverse_);
+    }
+  }
+
+  void operator()(typename detail::fft_config<D, R>::Tin* indata,
+                  typename detail::fft_config<D, R>::Tout* outdata) const
+  {
+    if (!is_valid_) {
+      throw std::runtime_error("can't use a moved-from plan");
+    }
+    auto bin = reinterpret_cast<Bin*>(indata);
+    auto bout = reinterpret_cast<Bout*>(outdata);
+    if constexpr (D == gt::fft::Domain::COMPLEX) {
+      detail::fft_config<D, R>::fftw_execute_dft(plan_forward_, bin, bout);
+    }
+  }
+
+  void inverse(typename detail::fft_config<D, R>::Tout* indata,
+               typename detail::fft_config<D, R>::Tin* outdata) const
+  {
+    if (!is_valid_) {
+      throw std::runtime_error("can't use a moved-from plan");
+    }
+    auto bin = reinterpret_cast<Bout*>(indata);
+    auto bout = reinterpret_cast<Bin*>(outdata);
+    if constexpr (D == gt::fft::Domain::COMPLEX) {
+      detail::fft_config<D, R>::fftw_execute_dft(plan_inverse_, bin, bout);
+    }
+  }
+
+  std::size_t get_work_buffer_bytes() { return 0; }
+
+private:
+  void init(std::vector<int> lengths, int istride, int idist, int ostride,
+            int odist, int batch_size)
+  {
+    int rank = lengths.size();
+    int* n = lengths.data();
+
+    if constexpr (D == gt::fft::Domain::COMPLEX) {
+      using Bin = typename detail::fft_config<D, R>::Bin;
+      using Bout = typename detail::fft_config<D, R>::Bout;
+      Bin* in = nullptr;
+      Bout* out = nullptr;
+      plan_forward_ = detail::fft_config<D, R>::fftw_plan_many_dft(
+        rank, n, batch_size, in, NULL, istride, idist, out, NULL, ostride,
+        odist, -1, FFTW_ESTIMATE);
+      plan_inverse_ = detail::fft_config<D, R>::fftw_plan_many_dft(
+        rank, n, batch_size, out, NULL, ostride, odist, in, NULL, istride,
+        idist, 1, FFTW_ESTIMATE);
+    }
+  }
+
+  plan_type plan_inverse_;
+  plan_type plan_forward_;
+  bool is_valid_;
+};
+
+template <gt::fft::Domain D, typename R>
+using FFTPlanManyBackend = FFTPlanManyHost<D, R>;
+
+} // namespace fft
+
+} // namespace gt
+
+#endif // GTENSOR_FFT_CUDA_H

--- a/include/gt-fft/backend/host.h
+++ b/include/gt-fft/backend/host.h
@@ -114,6 +114,8 @@ public:
     auto bout = reinterpret_cast<Bout*>(outdata);
     if constexpr (D == gt::fft::Domain::COMPLEX) {
       fftw_forward_.execute_dft(bin, bout);
+    } else {
+      fftw_forward_.execute_dft_r2c(bin, bout);
     }
   }
 
@@ -124,6 +126,8 @@ public:
     auto bout = reinterpret_cast<Bin*>(outdata);
     if constexpr (D == gt::fft::Domain::COMPLEX) {
       fftw_inverse_.execute_dft(bin, bout);
+    } else {
+      fftw_inverse_.execute_dft_c2r(bin, bout);
     }
   }
 
@@ -135,18 +139,23 @@ private:
   {
     int rank = lengths.size();
     int* n = lengths.data();
+    Bin* in = nullptr;
+    Bout* out = nullptr;
 
     if constexpr (D == gt::fft::Domain::COMPLEX) {
-      using Bin = typename detail::fft_config<D, R>::Bin;
-      using Bout = typename detail::fft_config<D, R>::Bout;
-      Bin* in = nullptr;
-      Bout* out = nullptr;
       fftw_forward_ =
         fftw::plan_many_dft(rank, n, batch_size, in, NULL, istride, idist, out,
                             NULL, ostride, odist, -1, FFTW_ESTIMATE);
       fftw_inverse_ =
         fftw::plan_many_dft(rank, n, batch_size, out, NULL, ostride, odist, in,
                             NULL, istride, idist, 1, FFTW_ESTIMATE);
+    } else {
+      fftw_forward_ =
+        fftw::plan_many_dft_r2c(rank, n, batch_size, in, NULL, istride, idist,
+                                out, NULL, ostride, odist, FFTW_ESTIMATE);
+      fftw_inverse_ =
+        fftw::plan_many_dft_c2r(rank, n, batch_size, out, NULL, ostride, odist,
+                                in, NULL, istride, idist, FFTW_ESTIMATE);
     }
   }
 

--- a/include/gt-fft/backend/host.h
+++ b/include/gt-fft/backend/host.h
@@ -15,69 +15,17 @@ namespace fftw
 template <typename R>
 class fftw;
 
-template <>
-class fftw<double>
-{
-  using fftw_plan = ::fftw_plan;
+#define R double
+#define FFTW_(SFX) fftw_##SFX
+#include "fftw_inc.h"
+#undef R
+#undef FFTW_
 
-public:
-  using complex = fftw_complex;
-
-  fftw() = default;
-  fftw(fftw_plan plan) : plan_{plan}, is_valid_{true} {}
-
-  static fftw plan_many_dft(int rank, const int* n, int howmany, complex* in,
-                            const int* inembed, int istride, int idist,
-                            complex* out, const int* onembed, int ostride,
-                            int odist, int sign, unsigned flags)
-  {
-    return fftw{::fftw_plan_many_dft(rank, n, howmany, in, inembed, istride,
-                                     idist, out, onembed, ostride, odist, sign,
-                                     flags)};
-  }
-
-  void execute_dft(complex* in, complex* out) const
-  {
-    assert(is_valid_);
-    return ::fftw_execute_dft(plan_, in, out);
-  }
-
-public:
-  fftw_plan plan_;
-  bool is_valid_ = false;
-};
-
-template <>
-class fftw<float>
-{
-  using fftw_plan = ::fftwf_plan;
-
-public:
-  using complex = fftwf_complex;
-
-  fftw() = default;
-  fftw(fftw_plan plan) : plan_{plan}, is_valid_{true} {}
-
-  static fftw plan_many_dft(int rank, const int* n, int howmany, complex* in,
-                            const int* inembed, int istride, int idist,
-                            complex* out, const int* onembed, int ostride,
-                            int odist, int sign, unsigned flags)
-  {
-    return fftw{::fftwf_plan_many_dft(rank, n, howmany, in, inembed, istride,
-                                      idist, out, onembed, ostride, odist, sign,
-                                      flags)};
-  }
-
-  void execute_dft(complex* in, complex* out) const
-  {
-    assert(is_valid_);
-    return ::fftwf_execute_dft(plan_, in, out);
-  }
-
-private:
-  fftwf_plan plan_;
-  bool is_valid_ = false;
-};
+#define R float
+#define FFTW_(SFX) fftwf_##SFX
+#include "fftw_inc.h"
+#undef R
+#undef FFTW_
 
 } // namespace fftw
 

--- a/include/gt-fft/fft.h
+++ b/include/gt-fft/fft.h
@@ -33,6 +33,8 @@ enum class Domain
 #else
 #include "backend/sycl.h"
 #endif // GTENSOR_DEVICE_SYCL_BBFFT
+#elif defined(GTENSOR_DEVICE_HOST)
+#include "backend/host.h"
 #endif
 
 namespace gt


### PR DESCRIPTION
This PR makes it possible to use `gt::fft` even if actual GPU support is disabled. It's a prerequisite for building GENE with gtensor support on host-only. The goal isn't production-level support of host-only C++/gtensor GENE, but rather to simplify development of GENE on a local machine does not have GPUs -- because in regular host-only mode,  a lot of parts of GENE aren't even compiled, and obviously not tested. It might be useful for debugging, too.