### PR TITLE
workaround mem_info compile error on MacOS

### DIFF
--- a/include/gtensor/backend_host.h
+++ b/include/gtensor/backend_host.h
@@ -7,7 +7,9 @@
 #include <algorithm>
 #include <cstdint>
 
+#ifdef __linux__
 #include <sys/sysinfo.h>
+#endif
 
 // ======================================================================
 // gt::backend::host
@@ -69,10 +71,15 @@ public:
 
   static void mem_info(size_t* free, size_t* total)
   {
+#ifdef __linux__
     struct sysinfo info;
     sysinfo(&info);
     *total = info.totalram;
     *free = info.freeram;
+#else
+    *total = 0;
+    *free = 0;
+#endif
   }
 };
 


### PR DESCRIPTION
This doesn't make mem_info work correctly, but at least it fixes the build. Not sure it's worth it to fix this properly, though it could be done.