### PR TITLE
ci: use clang-15 for cxx20 host test

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        cxx: [ 'g++-12', 'clang++-14' ]
+        cxx: [ 'g++-12', 'clang++-15' ]
     name: tests-cpu-cxx20-${{ matrix.cxx }}
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 8


### PR DESCRIPTION
fixes spurious CI failure on clang cxx20 test. Not sure why this started happening out of the blue, it used to work, and now fails on main branch.