### PR TITLE
Return device_count=0 in error case

### DIFF
--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -180,7 +180,21 @@ public:
   static int device_get_count()
   {
     int device_count;
-    gtGpuCheck(cudaGetDeviceCount(&device_count));
+    cudaError_t code = cudaGetDeviceCount(&device_count);
+    switch (code) {
+      case cudaErrorNoDevice:
+        fprintf(stderr, "Error in cudaGetDeviceCount: %d (%s)\n", code,
+                cudaGetErrorString(code));
+        device_count = 0;
+        break;
+      case cudaErrorInsufficientDriver:
+        fprintf(stderr, "Error in cudaGetDeviceCount: %d (%s)\n", code,
+                cudaGetErrorString(code));
+        fprintf(stderr, "Did you start the job on a CPU partition?\n");
+        device_count = 0;
+        break;
+      case cudaSuccess: break;
+    }
     return device_count;
   }
 

--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -181,20 +181,17 @@ public:
   {
     int device_count;
     cudaError_t code = cudaGetDeviceCount(&device_count);
-    switch (code) {
-      case cudaErrorNoDevice:
-        fprintf(stderr, "Error in cudaGetDeviceCount: %d (%s)\n", code,
-                cudaGetErrorString(code));
-        device_count = 0;
-        break;
-      case cudaErrorInsufficientDriver:
-        fprintf(stderr, "Error in cudaGetDeviceCount: %d (%s)\n", code,
-                cudaGetErrorString(code));
-        fprintf(stderr, "Did you start the job on a CPU partition?\n");
-        device_count = 0;
-        break;
-      case cudaSuccess: break;
-      case default: gtGpuCheck(code); break;
+    if (code == cudaErrorNoDevice) {
+      fprintf(stderr, "Error in cudaGetDeviceCount: %d (%s)\n", code,
+              cudaGetErrorString(code));
+      device_count = 0;
+    } else if (code == cudaErrorInsufficientDriver) {
+      fprintf(stderr, "Error in cudaGetDeviceCount: %d (%s)\n", code,
+              cudaGetErrorString(code));
+      fprintf(stderr, "Did you start the job on a CPU partition?\n");
+      device_count = 0;
+    } else if (code != cudaSuccess) {
+      gtGpuCheck(code);
     }
     return device_count;
   }

--- a/include/gtensor/backend_cuda.h
+++ b/include/gtensor/backend_cuda.h
@@ -194,6 +194,7 @@ public:
         device_count = 0;
         break;
       case cudaSuccess: break;
+      case default: gtGpuCheck(code); break;
     }
     return device_count;
   }

--- a/include/gtensor/backend_hip.h
+++ b/include/gtensor/backend_hip.h
@@ -217,13 +217,12 @@ public:
   {
     int device_count;
     hipError_t code = hipGetDeviceCount(&device_count);
-    switch (code) {
-      case hipErrorNoDevice:
-        /* Set silently the return value to 0 */
-        device_count = 0;
-        break;
-      case hipSuccess: break;
-      case default: gtGpuCheck(code); break;
+    if (code == hipErrorNoDevice) {
+      fprintf(stderr, "Error in hipGetDeviceCount: %d (%s)\n", code,
+              hipGetErrorString(code));
+      device_count = 0;
+    } else if (code != hipSuccess) {
+      gtGpuCheck(code);
     }
     return device_count;
   }

--- a/include/gtensor/backend_hip.h
+++ b/include/gtensor/backend_hip.h
@@ -216,7 +216,14 @@ public:
   static int device_get_count()
   {
     int device_count;
-    gtGpuCheck(hipGetDeviceCount(&device_count));
+    hipError_t code = hipGetDeviceCount(&device_count);
+    switch (code) {
+      case hipErrorNoDevice:
+        /* Set silently the return value to 0 */
+        device_count = 0;
+        break;
+      case hipSuccess: break;
+    }
     return device_count;
   }
 

--- a/include/gtensor/backend_hip.h
+++ b/include/gtensor/backend_hip.h
@@ -223,6 +223,7 @@ public:
         device_count = 0;
         break;
       case hipSuccess: break;
+      case default: gtGpuCheck(code); break;
     }
     return device_count;
   }


### PR DESCRIPTION
For me it seems to be more natural if the get_device_count function returns just 0 in the case of cudaErrorNoDevice and cudaErrorInsufficientDriver. The handling of this case should happen on the applications level, but at the moment the gtensor code aborts.