### PR TITLE
Clearer error message and HIP architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,9 +77,9 @@ else()
 endif()
 set(HIP_PATH "${ROCM_PATH}/hip" CACHE STRING "path to HIP installation")
 if(GTENSOR_GPU_ARCHITECTURES STREQUAL "default")
-  set(HIP_GPU_ARCHITECTURE "gfx90a")
+  set(CMAKE_HIP_ARCHITECTURES "gfx90a")
 else()
-  set(CMAKE_CUDA_ARCHITECTURES ${GTENSOR_GPU_ARCHITECTURES})
+  set(CMAKE_HIP_ARCHITECTURES ${GTENSOR_GPU_ARCHITECTURES})
 endif()
 
 # SYCL specific configuration
@@ -201,8 +201,8 @@ if ("hip" IN_LIST GTENSOR_BUILD_DEVICES)
   target_compile_definitions(gtensor_hip INTERFACE GTENSOR_HAVE_DEVICE)
   target_compile_definitions(gtensor_hip INTERFACE GTENSOR_DEVICE_HIP)
 
-  set(GPU_TARGETS "${HIP_GPU_ARCHITECTURES}"
-      CACHE STRING "GPU targets to compile for")
+  #set(GPU_TARGETS "${HIP_GPU_ARCHITECTURES}"
+  #    CACHE STRING "GPU targets to compile for")
   find_package(hip REQUIRED)
   find_package(rocthrust REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,8 +201,6 @@ if ("hip" IN_LIST GTENSOR_BUILD_DEVICES)
   target_compile_definitions(gtensor_hip INTERFACE GTENSOR_HAVE_DEVICE)
   target_compile_definitions(gtensor_hip INTERFACE GTENSOR_DEVICE_HIP)
 
-  #set(GPU_TARGETS "${HIP_GPU_ARCHITECTURES}"
-  #    CACHE STRING "GPU targets to compile for")
   find_package(hip REQUIRED)
   find_package(rocthrust REQUIRED)
 

--- a/include/gtensor/macros.h
+++ b/include/gtensor/macros.h
@@ -92,7 +92,8 @@ inline void gtLaunchCheck(dim3 numblocks, dim3 numthreads, const char* file,
 {
   hipError_t last_error = hipGetLastError();
   if (last_error != hipSuccess) {
-    fprintf(stderr, "launch failed %s %d, error_code: %d\n", file, line,last_error);
+    fprintf(stderr, "launch failed %s %d, error_code: %d\n", file, line,
+            last_error);
     fprintf(stderr, "(%s)\n", hipGetErrorString(last_error));
     fprintf(stderr, "blocks was [%d, %d, %d]\n", numblocks.x, numblocks.y,
             numblocks.z);

--- a/include/gtensor/macros.h
+++ b/include/gtensor/macros.h
@@ -90,8 +90,10 @@ inline auto gpuGetLastError() { return cudaGetLastError(); }
 inline void gtLaunchCheck(dim3 numblocks, dim3 numthreads, const char* file,
                           int line)
 {
-  if (hipGetLastError() != hipSuccess) {
-    fprintf(stderr, "launch failed %s %d\n", file, line);
+  hipError_t last_error = hipGetLastError();
+  if (last_error != hipSuccess) {
+    fprintf(stderr, "launch failed %s %d, error_code: %d\n", file, line,last_error);
+    fprintf(stderr, "(%s)\n", hipGetErrorString(last_error));
     fprintf(stderr, "blocks was [%d, %d, %d]\n", numblocks.x, numblocks.y,
             numblocks.z);
     fprintf(stderr, "threads was [%d, %d, %d]\n", numthreads.x, numthreads.y,


### PR DESCRIPTION
- In the `macros.h` file, the error message is added to the error code.
- We use the `CMAKE_HIP_ARCHITECTURES` variable to set the hip architecture for AMD GPUs.