### PR TITLE
Enable gt half precision types for HIP

### DIFF
--- a/include/gtensor/bfloat16_t.h
+++ b/include/gtensor/bfloat16_t.h
@@ -47,56 +47,56 @@ class bfloat16_t
 
 public:
   bfloat16_t() = default;
-  GT_INLINE bfloat16_t(float x) : x(x){};
-  GT_INLINE bfloat16_t(storage_type x) : x(x){};
+  GT_INLINE bfloat16_t(float x) : x_(x){};
+  GT_INLINE bfloat16_t(storage_type x) : x_(x){};
 
   GT_INLINE const bfloat16_t& operator=(const float f)
   {
-    x = f;
+    x_ = f;
     return *this;
   }
-  GT_INLINE compute_type Get() const { return static_cast<compute_type>(x); }
+  GT_INLINE compute_type Get() const { return static_cast<compute_type>(x_); }
 
   // update operators [+=, -=, *=, /=]
   GT_INLINE bfloat16_t operator+=(const bfloat16_t& y)
   {
 #if defined(BFLOAT16T_ON_DEVICE)
-    x += y.Get();
+    x_ += y.Get();
 #else
-    x = this->Get() + y.Get();
+    x_ = this->Get() + y.Get();
 #endif
     return *this;
   }
   GT_INLINE bfloat16_t operator-=(const bfloat16_t& y)
   {
 #if defined(BFLOAT16T_ON_DEVICE)
-    x -= y.Get();
+    x_ -= y.Get();
 #else
-    x = this->Get() - y.Get();
+    x_ = this->Get() - y.Get();
 #endif
     return *this;
   }
   GT_INLINE bfloat16_t operator*=(const bfloat16_t& y)
   {
 #if defined(BFLOAT16T_ON_DEVICE)
-    x *= y.Get();
+    x_ *= y.Get();
 #else
-    x = this->Get() * y.Get();
+    x_ = this->Get() * y.Get();
 #endif
     return *this;
   }
   GT_INLINE bfloat16_t operator/=(const bfloat16_t& y)
   {
 #if defined(BFLOAT16T_ON_DEVICE)
-    x /= y.Get();
+    x_ /= y.Get();
 #else
-    x = this->Get() / y.Get();
+    x_ = this->Get() / y.Get();
 #endif
     return *this;
   }
 
 private:
-  storage_type x;
+  storage_type x_;
 };
 
 // op is unary [+, -]

--- a/include/gtensor/float16_t.h
+++ b/include/gtensor/float16_t.h
@@ -47,56 +47,56 @@ class float16_t
 
 public:
   float16_t() = default;
-  GT_INLINE float16_t(float x) : x(x){};
-  GT_INLINE float16_t(storage_type x) : x(x){};
+  GT_INLINE float16_t(float x) : x_(x){};
+  GT_INLINE float16_t(storage_type x) : x_(x){};
 
   GT_INLINE const float16_t& operator=(const float f)
   {
-    x = f;
+    x_ = f;
     return *this;
   }
-  GT_INLINE compute_type Get() const { return static_cast<compute_type>(x); }
+  GT_INLINE compute_type Get() const { return static_cast<compute_type>(x_); }
 
   // update operators [+=, -=, *=, /=]
   GT_INLINE float16_t operator+=(const float16_t& y)
   {
 #if defined(FLOAT16T_ON_DEVICE)
-    x += y.Get();
+    x_ += y.Get();
 #else
-    x = this->Get() + y.Get();
+    x_ = this->Get() + y.Get();
 #endif
     return *this;
   }
   GT_INLINE float16_t operator-=(const float16_t& y)
   {
 #if defined(FLOAT16T_ON_DEVICE)
-    x -= y.Get();
+    x_ -= y.Get();
 #else
-    x = this->Get() - y.Get();
+    x_ = this->Get() - y.Get();
 #endif
     return *this;
   }
   GT_INLINE float16_t operator*=(const float16_t& y)
   {
 #if defined(FLOAT16T_ON_DEVICE)
-    x *= y.Get();
+    x_ *= y.Get();
 #else
-    x = this->Get() * y.Get();
+    x_ = this->Get() * y.Get();
 #endif
     return *this;
   }
   GT_INLINE float16_t operator/=(const float16_t& y)
   {
 #if defined(FLOAT16T_ON_DEVICE)
-    x /= y.Get();
+    x_ /= y.Get();
 #else
-    x = this->Get() / y.Get();
+    x_ = this->Get() / y.Get();
 #endif
     return *this;
   }
 
 private:
-  storage_type x;
+  storage_type x_;
 };
 
 // op is unary [+, -]

--- a/include/gtensor/float16_t.h
+++ b/include/gtensor/float16_t.h
@@ -37,10 +37,10 @@ class float16_t
 #if defined(GTENSOR_FP16_CUDA_HEADER) && defined(__CUDA_ARCH__) &&             \
   (__CUDA_ARCH__ >= 530)
   using compute_type = __half;
-#define FLOAT16T_ON_CUDA_DEVICE
+#define FLOAT16T_ON_DEVICE
 #elif defined(GTENSOR_FP16_HIP_HEADER) && defined(__HIP_DEVICE_COMPILE__)
   using compute_type = __half;
-#define FLOAT16T_ON_HIP_DEVICE
+#define FLOAT16T_ON_DEVICE
 #else
   using compute_type = float;
 #endif
@@ -60,7 +60,7 @@ public:
   // update operators [+=, -=, *=, /=]
   GT_INLINE float16_t operator+=(const float16_t& y)
   {
-#if defined(FLOAT16T_ON_CUDA_DEVICE) || defined(FLOAT16T_ON_HIP_DEVICE)
+#if defined(FLOAT16T_ON_DEVICE)
     x += y.Get();
 #else
     x = this->Get() + y.Get();
@@ -69,7 +69,7 @@ public:
   }
   GT_INLINE float16_t operator-=(const float16_t& y)
   {
-#if defined(FLOAT16T_ON_CUDA_DEVICE) || defined(FLOAT16T_ON_HIP_DEVICE)
+#if defined(FLOAT16T_ON_DEVICE)
     x -= y.Get();
 #else
     x = this->Get() - y.Get();
@@ -78,7 +78,7 @@ public:
   }
   GT_INLINE float16_t operator*=(const float16_t& y)
   {
-#if defined(FLOAT16T_ON_CUDA_DEVICE) || defined(FLOAT16T_ON_HIP_DEVICE)
+#if defined(FLOAT16T_ON_DEVICE)
     x *= y.Get();
 #else
     x = this->Get() * y.Get();
@@ -87,7 +87,7 @@ public:
   }
   GT_INLINE float16_t operator/=(const float16_t& y)
   {
-#if defined(FLOAT16T_ON_CUDA_DEVICE) || defined(FLOAT16T_ON_HIP_DEVICE)
+#if defined(FLOAT16T_ON_DEVICE)
     x /= y.Get();
 #else
     x = this->Get() / y.Get();
@@ -207,7 +207,7 @@ PROVIDE_MIXED_INTEGRAL_FLOAT16T_COMPARISON_OPERATOR(!=, int);
 // function is sqrt
 GT_INLINE float16_t sqrt(const float16_t& x)
 {
-#if defined(FLOAT16T_ON_CUDA_DEVICE) || defined(FLOAT16T_ON_HIP_DEVICE)
+#if defined(FLOAT16T_ON_DEVICE)
   return hsqrt(x.Get());
 #else
   return std::sqrt(x.Get());
@@ -224,8 +224,7 @@ std::ostream& operator<<(std::ostream& s, const float16_t& h)
 
 #undef GTENSOR_FP16_CUDA_HEADER
 #undef GTENSOR_FP16_HIP_HEADER
-#undef FLOAT16T_ON_CUDA_DEVICE
-#undef FLOAT16T_ON_HIP_DEVICE
+#undef FLOAT16T_ON_DEVICE
 #undef PROVIDE_FLOAT16T_UNARY_ARITHMETIC_OPERATOR
 #undef PROVIDE_FLOAT16T_BINARY_ARITHMETIC_OPERATOR
 #undef PROVIDE_MIXED_FLOAT16T_BINARY_ARITHMETIC_OPERATOR


### PR DESCRIPTION
Uses 16 bit FP types from HIP headers (`<hip/hip_fp16.h>`, `<hip/hip_bf16.h>`) when CUDA headers not available.

BF16 tests pass on AMD MI300A when built with module `rocm/6.3` loaded via
```
cmake -S . -B build-hip -DCMAKE_INSTALL_PREFIX=build-hip -DGTENSOR_DEVICE=hip -DBUILD_TESTING=ON -DGTENSOR_ENABLE_BF16=ON -DCMAKE_CXX_COMPILER=$(which hipcc)
cmake --build build-hip --target install
```
(FP16 tests pass analogously, when built with `-DGTENSOR_ENABLE_FP16=ON`)