### PR TITLE
Add first-class HIP support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ if ("cuda" IN_LIST GTENSOR_BUILD_DEVICES)
     CPMAddPackage(
       NAME rmm
       GITHUB_REPOSITORY rapidsai/rmm
-      VERSION 23.02.00
+      VERSION 26.02.00
     )
     target_compile_definitions(gtensor_cuda INTERFACE
       GTENSOR_USE_MEMORY_POOL GTENSOR_USE_RMM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,7 +375,7 @@ if ((BUILD_TESTING AND IS_MAIN_PROJECT) OR GTENSOR_BUILD_BENCHMARKS)
     # There is no release yet, but we want post 1.10.0 with
     # cmake_minimum_required updated
     GIT_TAG 32f4f52d95dc99c35f51deed552a6ba700567f94
-    VERSION 1.17.0
+    VERSION 1.12.1
     OPTIONS
       "INSTALL_GTEST OFF"
       "gtest_force_shared_crt ON"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(gtensor
         VERSION 0.01
         LANGUAGES CXX
@@ -79,7 +79,7 @@ set(HIP_PATH "${ROCM_PATH}/hip" CACHE STRING "path to HIP installation")
 if(GTENSOR_GPU_ARCHITECTURES STREQUAL "default")
   set(CMAKE_HIP_ARCHITECTURES "gfx90a")
 else()
-  set(CMAKE_HIP_ARCHITECTURES ${GTENSOR_GPU_ARCHITECTURES})
+  set(CMAKE_HIP_ARCHITECTURES "${GTENSOR_GPU_ARCHITECTURES}")
 endif()
 
 # SYCL specific configuration
@@ -176,6 +176,7 @@ endif()
 
 if ("hip" IN_LIST GTENSOR_BUILD_DEVICES)
   message(STATUS "${PROJECT_NAME}: adding gtensor_hip target")
+  enable_language(HIP)
   add_gtensor_library(hip)
 
   if(NOT (CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR CMAKE_CXX_COMPILER MATCHES ".*/hipcc$"))
@@ -374,7 +375,7 @@ if ((BUILD_TESTING AND IS_MAIN_PROJECT) OR GTENSOR_BUILD_BENCHMARKS)
     # There is no release yet, but we want post 1.10.0 with
     # cmake_minimum_required updated
     GIT_TAG 32f4f52d95dc99c35f51deed552a6ba700567f94
-    VERSION 1.10.0
+    VERSION 1.17.0
     OPTIONS
       "INSTALL_GTEST OFF"
       "gtest_force_shared_crt ON"

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,4 +1,4 @@
-set(CPM_DOWNLOAD_VERSION 0.32.1)
+set(CPM_DOWNLOAD_VERSION 0.42.1)
 
 if(CPM_SOURCE_CACHE)
   # Expand relative path. This is important if the provided path contains a tilde (~)

--- a/cmake/target-gtensor-sources-macro.cmake
+++ b/cmake/target-gtensor-sources-macro.cmake
@@ -8,6 +8,10 @@ function(target_gtensor_sources TARGET)
     set_source_files_properties(${target_gtensor_sources_PRIVATE}
                                 TARGET_DIRECTORY ${TARGET}
                                 PROPERTIES LANGUAGE CUDA)
+  elseif("${GTENSOR_DEVICE}" STREQUAL "hip")
+    set_source_files_properties(${target_gtensor_sources_PRIVATE}
+      TARGET_DIRECTORY ${TARGET}
+      PROPERTIES LANGUAGE HIP)
   else()
     set_source_files_properties(${target_gtensor_sources_PRIVATE}
                                 TARGET_DIRECTORY ${TARGET}


### PR DESCRIPTION
Since CMake 3.21, the HIP language is supported. This PR enables the hip language in the hip case.
Also updated CPM and GTest to more recent versions.