### PR TITLE
Add native hip support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,9 +179,9 @@ if ("hip" IN_LIST GTENSOR_BUILD_DEVICES)
   enable_language(HIP)
   add_gtensor_library(hip)
 
-  if(NOT (CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR CMAKE_CXX_COMPILER MATCHES ".*/hipcc$"))
-    message(FATAL_ERROR "For GTENSOR_BUILD_DEVICES=hip, 'hcc' or 'hipcc' must be used as C++ compiler.")
-  endif()
+  #if(NOT (CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR CMAKE_CXX_COMPILER MATCHES ".*/hipcc$"))
+  #  message(FATAL_ERROR "For GTENSOR_BUILD_DEVICES=hip, 'hcc' or 'hipcc' must be used as C++ compiler.")
+  #endif()
 
   # The official ROCm/HIP cmake support causes problems on mixed language
   # executables, where hipcc specific flags leak into the other language

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(gtensor
         VERSION 0.01
         LANGUAGES CXX
@@ -79,7 +79,7 @@ set(HIP_PATH "${ROCM_PATH}/hip" CACHE STRING "path to HIP installation")
 if(GTENSOR_GPU_ARCHITECTURES STREQUAL "default")
   set(CMAKE_HIP_ARCHITECTURES "gfx90a")
 else()
-  set(CMAKE_HIP_ARCHITECTURES ${GTENSOR_GPU_ARCHITECTURES})
+  set(CMAKE_HIP_ARCHITECTURES "${GTENSOR_GPU_ARCHITECTURES}")
 endif()
 
 # SYCL specific configuration
@@ -176,6 +176,7 @@ endif()
 
 if ("hip" IN_LIST GTENSOR_BUILD_DEVICES)
   message(STATUS "${PROJECT_NAME}: adding gtensor_hip target")
+  enable_language(HIP)
   add_gtensor_library(hip)
 
   if(NOT (CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR CMAKE_CXX_COMPILER MATCHES ".*/hipcc$"))

--- a/cmake/target-gtensor-sources-macro.cmake
+++ b/cmake/target-gtensor-sources-macro.cmake
@@ -8,6 +8,10 @@ function(target_gtensor_sources TARGET)
     set_source_files_properties(${target_gtensor_sources_PRIVATE}
                                 TARGET_DIRECTORY ${TARGET}
                                 PROPERTIES LANGUAGE CUDA)
+  elseif("${GTENSOR_DEVICE}" STREQUAL "hip")
+    set_source_files_properties(${target_gtensor_sources_PRIVATE}
+      TARGET_DIRECTORY ${TARGET}
+      PROPERTIES LANGUAGE HIP)
   else()
     set_source_files_properties(${target_gtensor_sources_PRIVATE}
                                 TARGET_DIRECTORY ${TARGET}


### PR DESCRIPTION
Now with minimal changes to enable HIP support from CMake.
I also changed the check for the CXX compiler to be hipcc or hcc. In the amd/rocm case, amdclang++ is also a valid CXX compiler. In general the CMAKE_HIP_COMPILER can be different from the CMAKE_CXX_COMPILER.